### PR TITLE
Patch 1.0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ pol
 poltool
 uoconvert
 uotool
+nul

--- a/config/nlootgroup.cfg
+++ b/config/nlootgroup.cfg
@@ -2312,6 +2312,7 @@ Group Junk
 	Item	PickAxe
 	Item	ButcherKnife
 	Item	Cleaver
+	Item	lifecrystal
 	Item	SkinningKnife
 	Item	Club
 	Item	SmithyHammer
@@ -2350,6 +2351,7 @@ Group Junk
 	Item	Bascinet
 	Item	NoseHelm
 	Item	PlateHelm
+	Item	lifecrystal
 	Item	BronzeShield
 	Item	Buckler
 	Item	KiteShield
@@ -2385,6 +2387,7 @@ Group Junk
 	Item	JestersSuit
 	Item	Tunic
 	Item	Surcoat
+	Item	lifecrystal
 	Item	Shirt
 	Item	Cloak
 	Item	elvencloak
@@ -2438,6 +2441,7 @@ Group Junk
 	Item	cheese
 	Item	wine
 	Item	pie
+	Item	lifecrystal
 	Item	cake
 	Item	bread
 	Item	muffin

--- a/patchnotes/developer-changelog-v1.0.6.md
+++ b/patchnotes/developer-changelog-v1.0.6.md
@@ -1,0 +1,195 @@
+# Developer Changelog - v1.0.6
+**Range:** `9b695eb` (origin/Patch-1.0.5) -> `1d47820` (HEAD)  
+**Branch:** Patch-1.0.6  
+**Date:** 2026-06-03 -> 2026-06-25  
+**Commits in range:** 3 (excluding merge commits)  
+**Files changed:** 16 | +407 / -29
+
+---
+
+## Table of Contents
+
+1. [Talisman Compile Fix](#1-talisman-compile-fix)
+2. [Tamed Following Fix - Multi Overhang Cleanup](#2-tamed-following-fix---multi-overhang-cleanup)
+3. [Artifact System - Champion Relics and Expiry Sweeper](#3-artifact-system---champion-relics-and-expiry-sweeper)
+4. [Bank Resource Usage Fix - Cartography, Camping, Blacksmithy](#4-bank-resource-usage-fix---cartography-camping-blacksmithy)
+5. [Player Merchant - Hidden/Concealed Announce Guard](#5-player-merchant---hiddenconcealed-announce-guard)
+6. [Commit Timeline](#6-commit-timeline)
+
+---
+
+## 1. Talisman Compile Fix
+
+### Files Changed
+| File | Change |
+|------|--------|
+| `pkg/opt/talisman/include/talismanid.inc` | Moved `var result` declaration out of inner conditional scope to fix compile error |
+
+### Overview
+
+The batch-ID container path in `TalismanID(...)` declared `var result` inside an inner `else` block, which caused a compile error due to the variable being referenced prior to declaration in the outer scope. This was a direct follow-up to the 1.0.5 talisman logic rewrite.
+
+### Notable Functional Changes
+
+- `var result` is now declared at the start of the container-ID branch, before the itemlist size check.
+- `result :=` is used for the actual assignment inside `IDCore_IdentifyContainerItems(...)`.
+- No behavioral change; compile-only fix.
+
+### Expected Impact
+
+- Talisman batch-ID compiles and runs correctly.
+
+---
+
+## 2. Tamed Following Fix - Multi Overhang Cleanup
+
+### Files Changed
+| File | Change |
+|------|--------|
+| `scripts/ai/tamed.src` | Removed `following := 0` assignments from all multi-mismatch early-return branches |
+
+### Overview
+
+The `Follow()` function had a pattern where every early-return branch (multi mismatch, line-of-sight fail) both zeroed `following` and returned. Since `following` is a local variable and the function returns immediately after, zeroing it had no observable effect — but more critically it was causing the pet to stall in overhang/tower situations by invalidating the follow target before returning, which could interact with outer loop state. Removing the redundant assignments fixes following behavior beneath multi overhangs.
+
+### Notable Functional Changes
+
+- Removed `following := 0;` from all 21 early-return branches across three multi-owner check blocks.
+- `return;` remains in each branch — behavior is otherwise unchanged for non-overhang cases.
+- Pets now follow correctly through tower/multi overhang geometry.
+
+### Expected Impact
+
+- Pets no longer stall or lose follow state when the path crosses tower overhangs.
+- No change to multi-boundary enforcement logic.
+
+---
+
+## 3. Artifact System - Champion Relics and Expiry Sweeper
+
+### Files Changed
+| File | Change |
+|------|--------|
+| `pkg/opt/ArtifactSystem/artifact.inc` | Added `ARTIFACT_EXPIRE_PROP` const, null-safe `getItemArtifactBox`, recycle prop cleanup, `SweepExpiredArtifacts` and `SweepExpiredArtifactsInContainer` functions |
+| `pkg/opt/ArtifactSystem/artifactbox.src` | Added Champion Relic objtype consts, decay timer assignment on pull, null guard |
+| `pkg/opt/ArtifactSystem/championrelic.src` | New script — use handler for Champion Relics; spawns a champion boss and destroys relic |
+| `pkg/opt/ArtifactSystem/itemdesc.cfg` | Added item entries for Champion Relic Tier 1 (`0x7991`) and Tier 2 (`0x7992`) |
+| `pkg/opt/ArtifactSystem/artifact_daily_sweeper.src` | New script — daily daemon that calls `SweepExpiredArtifacts` |
+| `pkg/opt/ArtifactSystem/artifact_startup_sweeper.src` | New script — one-shot startup sweep to catch any expired artifacts from before the feature existed |
+| `pkg/packethooks/megacliloc/itemdata.src` | Added artifact expiry countdown display and `FormatDuration()` helper |
+| `scripts/start.src` | Registered artifact sweeper daemons at startup |
+| `.gitignore` | Minor update |
+| `pkg/opt/ArtifactSystem/artifact-system-summary.txt` | Internal system documentation |
+
+### Overview
+
+Two new artifact items have been added to the Artifact System: Champion Relics (Tier 1 and Tier 2). These are obtained from the artifact box and allow players to summon a champion-level boss when activated. Relics have a 14-day decay timer and are destroyed on use. A sweep system was also added to automatically remove expired relics from all storage areas.
+
+### Notable Functional Changes
+
+**Champion Relic Items:**
+- `0x7991` — Champion Relic (Tier 1): `MagicItemLevel i10`, activates barracoon or erebuschaosgod.
+- `0x7992` — Champion Relic (Tier 2): `MagicItemLevel i11`, activates rikktor or nyxseductress.
+- Both use graphic `0x3CC1` and are tagged with `Artifact i1` CProp.
+
+**Artifact Box Distribution:**
+- When a Champion Relic is pulled from the artifact box, it receives:
+  - `decayat` set to `ReadGameClock() + 1209600` (14 days).
+  - `#ArtifactExpireAt` property (same value) for sweeper reference.
+  - `RelicUID` set to a random integer for uniqueness tracking.
+- When a relic is recycled back into the artifact box, all expiry/uid props are erased so it restarts fresh on next pull.
+- Added null guard: if artifact box is empty, `getItemArtifactBox()` returns `0` (no crash).
+
+**Champion Relic Use Script (`championrelic.src`):**
+- Blocks activation in safe areas, guarded areas, and NOPK areas.
+- Spawns a randomly chosen boss from the tier's template list near the activating player.
+- Plays visual effect (`0x3728`) and sound (`0x01FE`) on boss spawn location.
+- Destroys the relic on successful boss spawn.
+- Returns graceful failure message if `CreateNpcFromTemplate` fails.
+
+**Expiry Sweeper:**
+- `SweepExpiredArtifacts(scope)` iterates all storage areas and recursively checks containers for expired artifact items (where `expire_at <= now`). Destroys expired items and logs a summary.
+- `artifact_daily_sweeper.src` runs this sweep on a daily loop.
+- `artifact_startup_sweeper.src` runs a one-shot sweep on shard startup.
+- Both sweepers registered in `scripts/start.src`.
+
+**MegaCliloc Expiry Display:**
+- Artifact items tagged with `#ArtifactExpireAt` now show a human-readable countdown in item tooltips.
+- Display: `"Artifact expires in Xd Xh Xm Xs"` (or `"Artifact expired, pending sweep"` if timer elapsed).
+- `FormatDuration(total_seconds)` helper added to handle days/hours/minutes/seconds formatting.
+
+### Expected Impact
+
+- Champion Relics are now obtainable from artifact boxes and can be activated in the open world to summon a champion-class boss.
+- Expired relics are swept from player storage/banks automatically.
+- Players can inspect relic time-remaining from item tooltip.
+
+---
+
+## 4. Bank Resource Usage Fix - Cartography, Camping, Blacksmithy
+
+### Files Changed
+| File | Change |
+|------|--------|
+| `pkg/std/cartography/cartography.src` | Added `EnsureMapResources`, `ItemIsInBackpackScope`, `GetNewMapMaterialCost` helpers; resource pre-check before each map tier; blank map backpack scope guard |
+| `pkg/std/camping/camping.src` | Added `ItemIsInBackpackScope` check for kindling wood |
+| `pkg/std/blacksmithy/blacksmithy.src` | Added missing `return` after insufficient gold check in `MakeJewelry` |
+
+### Overview
+
+Several crafting scripts had bugs where resources could be consumed from or validated against a bank, or flow would fall through after a validation failure. This commit fixes all three independently.
+
+### Notable Functional Changes
+
+**Cartography:**
+- Added `GetNewMapMaterialCost(who)` — returns material cost (10, or 5 during crafting PH). Replaces inline duplicated logic in `makeNewmap`.
+- Added `EnsureMapResources(who, amount)` — checks `GetAvailableResource(who, mapRequest).total` before proceeding. Returns `0` on failure with a "You don't have enough resources." message.
+- All five map tiers (local/regional/world/newmap-1/newmap-2) now call `EnsureMapResources` before skill check and map creation, preventing erroneous skill gain or map creation with no resources.
+- Added `ItemIsInBackpackScope(who, item)` — returns `1` if item is the backpack itself, directly in backpack, or nested inside backpack. Guards blank maps from being used out of a bank or container.
+- If blank map is not in backpack scope, player sees: "That blank map must be in your backpack."
+- Refactored `makeNewmap` to call `GetNewMapMaterialCost` instead of repeating the inline PH check.
+
+**Camping:**
+- Added `ItemIsInBackpackScope(character, item)` (same pattern as cartography).
+- If kindling wood is inside a container that is not the backpack or ground, player sees: "That kindling must be in your backpack or on the ground."
+
+**Blacksmithy:**
+- `MakeJewelry`: the gold amount check (`ore.amount < 100`) previously sent the error message but did not return. Added `return;` so flow exits instead of proceeding to `CheckSkill`.
+
+### Expected Impact
+
+- Cartography no longer grants skill gain or uses a blank map when the player lacks map materials, regardless of where materials are stored.
+- Camping kindling cannot be sourced from banked containers.
+- Jewelry making no longer falls through to skill check when gold is insufficient.
+
+---
+
+## 5. Player Merchant - Hidden/Concealed Announce Guard
+
+### Files Changed
+| File | Change |
+|------|--------|
+| `pkg/systems/playervendor/playermerchant.src` | Added `who.hidden or who.concealed` guard in `AnnounceRecentStock` |
+
+### Overview
+
+`AnnounceRecentStock(who)` would previously announce new stock events even for players who are currently hidden or concealed. This could leak presence information.
+
+### Notable Functional Changes
+
+- Added `who.hidden or who.concealed` checks to the early-return guard in `AnnounceRecentStock`.
+- If the controlling player is hidden or concealed, the recent stock announcement is suppressed.
+
+### Expected Impact
+
+- Hidden/concealed player merchants no longer announce stock updates, avoiding unintended position reveals.
+
+---
+
+## 6. Commit Timeline
+
+| Commit | Date | Message |
+|--------|------|---------|
+| `8497a62` | 2026-06-03 | Talisman compile fix |
+| `f30136a` | 2026-06-04 | Tamed following fix for under tower overhangs |
+| `1d47820` | 2026-06-25 | Artifact updates — added 2 new artifact items, fixed using resources from banks, fix cartography errors on use and skill gain while in bank |

--- a/patchnotes/developer-changelog-v1.0.6.md
+++ b/patchnotes/developer-changelog-v1.0.6.md
@@ -1,9 +1,9 @@
 # Developer Changelog - v1.0.6
-**Range:** `9b695eb` (origin/Patch-1.0.5) -> `1d47820` (HEAD)  
+**Range:** `9b695eb` (origin/Patch-1.0.5) -> `d1f52d9` (HEAD)  
 **Branch:** Patch-1.0.6  
-**Date:** 2026-06-03 -> 2026-06-25  
-**Commits in range:** 3 (excluding merge commits)  
-**Files changed:** 16 | +407 / -29
+**Date:** 2026-06-03 -> 2026-06-30  
+**Commits in range:** 6 (excluding merge commits)  
+**Files changed:** 30 | +876 / -87
 
 ---
 
@@ -15,7 +15,9 @@
 4. [Bank Resource Usage Fix - Cartography, Camping, Blacksmithy](#4-bank-resource-usage-fix---cartography-camping-blacksmithy)
 5. [Player Merchant - Hidden/Concealed Announce Guard](#5-player-merchant---hiddenconcealed-announce-guard)
 6. [Commit Timeline](#6-commit-timeline)
-7. [Post-Range Hotfixes - Runebook Overflow and MoveObject Migration](#7-post-range-hotfixes---runebook-overflow-and-moveobject-migration)
+7. [Runebook Overflow Fix and MoveObject Migration](#7-runebook-overflow-fix-and-moveobject-migration)
+8. [High Priest Relationship Prompt, Dual Planar Gate Change, and Life Crystal Loot Expansion](#8-high-priest-relationship-prompt-dual-planar-gate-change-and-life-crystal-loot-expansion)
+9. [Patchnotes and Launcher Copy Maintenance](#9-patchnotes-and-launcher-copy-maintenance)
 
 ---
 
@@ -194,10 +196,13 @@ Several crafting scripts had bugs where resources could be consumed from or vali
 | `8497a62` | 2026-06-03 | Talisman compile fix |
 | `f30136a` | 2026-06-04 | Tamed following fix for under tower overhangs |
 | `1d47820` | 2026-06-25 | Artifact updates — added 2 new artifact items, fixed using resources from banks, fix cartography errors on use and skill gain while in bank |
+| `1e993f0` | 2026-06-25 | Patchnotes update |
+| `fd01eae` | 2026-06-25 | Fix for runebooks with full backpack; updated deprecated code |
+| `d1f52d9` | 2026-06-30 | Added more life crystals to junk; High Priest relationship cost prompt; Dual Planar protection check removal |
 
 ---
 
-## 7. Post-Range Hotfixes - Runebook Overflow and MoveObject Migration
+## 7. Runebook Overflow Fix and MoveObject Migration
 
 ### Files Changed
 | File | Change |
@@ -213,7 +218,7 @@ Several crafting scripts had bugs where resources could be consumed from or vali
 
 ### Overview
 
-After the v1.0.6 commit range, a runebook edge case was fixed where inserting a recall-scroll stack larger than remaining book charges could fail in overflow-handling branches and leave bad outcomes when backpack/ground return paths were constrained. The recharge flow now guarantees successful charge application when at least one charge can be consumed, while handling overflow scrolls safely.
+Within the v1.0.6 range, a runebook edge case was fixed where inserting a recall-scroll stack larger than remaining book charges could fail in overflow-handling branches and leave bad outcomes when backpack/ground return paths were constrained. The recharge flow now guarantees successful charge application when at least one charge can be consumed, while handling overflow scrolls safely.
 
 In the same hotfix pass, deprecated `MoveItemToLocation` script calls were migrated to `MoveObjectToLocation` in all touched files to align with modern POL API guidance and avoid reliance on removed/deprecated movement functions.
 
@@ -241,3 +246,67 @@ In the same hotfix pass, deprecated `MoveItemToLocation` script calls were migra
   - else drop to ground if possible;
   - else destroy overflow with explicit player notification.
 - No expected gameplay behavior changes from the movement API migration itself; changes are compatibility/maintenance-focused.
+
+---
+
+## 8. High Priest Relationship Prompt, Dual Planar Gate Change, and Life Crystal Loot Expansion
+
+### Files Changed
+| File | Change |
+|------|--------|
+| `scripts/ai/highpriest.src` | Added `relationship` speech-response path while priest is upset; reports exact donation requirement based on class level |
+| `pkg/systems/combat/dualplanaronhit.src` | Removed (commented out) protection/immunity gate in Dual Planar on-hit flow |
+| `config/nlootgroup.cfg` | Added `lifecrystal` to additional `Group Junk` entries |
+
+### Overview
+
+This pass added three gameplay-facing adjustments: better discoverability for High Priest relationship repair cost, a behavior change in Dual Planar on-hit immunity handling, and broader loot-table coverage for life crystals in junk-group rolls.
+
+### Notable Functional Changes
+
+**High Priest (`highpriest.src`):**
+- When player has `PriestUpset`, priest now checks speech text for `relationship`/`Relationship`.
+- Calculates donation requirement as `GetClasseLevel(player) * 2500`.
+- If class level is unavailable/zero, priest provides fallback line: any donation can begin repair.
+- Existing refusal lines remain for other upset-state speech.
+
+**Dual Planar (`dualplanaronhit.src`):**
+- `IsProtected(...)` immunity/cursed handling block has been disabled (commented).
+- Effect path no longer early-exits on `IMMUNED` in this script block.
+- Circle scaling from `CURSED` branch is no longer applied from that gate.
+
+**Loot Group (`nlootgroup.cfg`):**
+- `Item lifecrystal` added in four additional places under `Group Junk`.
+- Increases junk-table opportunities to roll life crystals.
+
+### Expected Impact
+
+- Players can explicitly ask High Priest how much gold is needed to repair relationship status.
+- Dual Planar on-hit behavior is now more permissive against previously gated protected targets.
+- Life crystals should appear more frequently from junk-category loot sources.
+
+---
+
+## 9. Patchnotes and Launcher Copy Maintenance
+
+### Files Changed
+| File | Change |
+|------|--------|
+| `patchnotes/developer-changelog-v1.0.6.md` | Expanded dev changelog content during patchnote update commit sequence |
+| `patchnotes/patch-v1.0.6.md` | Player-facing patch notes updated with new gameplay changes |
+| `patchnotes/launchernotes.md` | Launcher copy synchronized with player-impact notes |
+
+### Overview
+
+Patchnotes were updated in-range to keep player-facing and developer-facing notes aligned with all delivered v1.0.6 work, including later hotfixes and follow-up gameplay adjustments.
+
+### Notable Functional Changes
+
+- Added/expanded v1.0.6 sections for runebook overflow handling and compatibility migration notes.
+- Synchronized launcher copy to the same player-impact bullets used in patch notes.
+- Preserved the standard launcher structure: `Latest Changes` header, Discord disclaimer line, `## What Changed`, summary, closing thanks line.
+
+### Expected Impact
+
+- No gameplay behavior change directly from this section.
+- Reduces drift between in-game changes and published communication artifacts.

--- a/patchnotes/developer-changelog-v1.0.6.md
+++ b/patchnotes/developer-changelog-v1.0.6.md
@@ -15,6 +15,7 @@
 4. [Bank Resource Usage Fix - Cartography, Camping, Blacksmithy](#4-bank-resource-usage-fix---cartography-camping-blacksmithy)
 5. [Player Merchant - Hidden/Concealed Announce Guard](#5-player-merchant---hiddenconcealed-announce-guard)
 6. [Commit Timeline](#6-commit-timeline)
+7. [Post-Range Hotfixes - Runebook Overflow and MoveObject Migration](#7-post-range-hotfixes---runebook-overflow-and-moveobject-migration)
 
 ---
 
@@ -193,3 +194,50 @@ Several crafting scripts had bugs where resources could be consumed from or vali
 | `8497a62` | 2026-06-03 | Talisman compile fix |
 | `f30136a` | 2026-06-04 | Tamed following fix for under tower overhangs |
 | `1d47820` | 2026-06-25 | Artifact updates — added 2 new artifact items, fixed using resources from banks, fix cartography errors on use and skill gain while in bank |
+
+---
+
+## 7. Post-Range Hotfixes - Runebook Overflow and MoveObject Migration
+
+### Files Changed
+| File | Change |
+|------|--------|
+| `pkg/std/runebook/runeoninsert.src` | Reworked recall-scroll recharge overflow path: partial consume to free-charge amount; overflow return to backpack or ground; fallback destroys only excess scrolls with user message while recharge still succeeds |
+| `pkg/std/runebook/runecaninsert.src` | Kept insertion gate compatible with overflow recharge behavior (does not block oversized stack insert when runebook has free charges) |
+| `scripts/util/loot.inc` | Migrated deprecated `MoveItemToLocation` call to `MoveObjectToLocation` |
+| `scripts/include/std.inc` | Updated movement helper wrappers to use `MoveObjectToLocation` instead of deprecated item-move API |
+| `scripts/include/rituals.inc` | Migrated `MoveItemToLocation` calls to `MoveObjectToLocation` |
+| `scripts/include/possess.inc` | Migrated `MoveItemToLocation` calls to `MoveObjectToLocation` |
+| `scripts/include/chaoseffects.inc` | Migrated `MoveItemToLocation` call to `MoveObjectToLocation` |
+| `pkg/std/housing/utility.inc` | Migrated fallback item placement from `MoveItemToLocation` to `MoveObjectToLocation` |
+
+### Overview
+
+After the v1.0.6 commit range, a runebook edge case was fixed where inserting a recall-scroll stack larger than remaining book charges could fail in overflow-handling branches and leave bad outcomes when backpack/ground return paths were constrained. The recharge flow now guarantees successful charge application when at least one charge can be consumed, while handling overflow scrolls safely.
+
+In the same hotfix pass, deprecated `MoveItemToLocation` script calls were migrated to `MoveObjectToLocation` in all touched files to align with modern POL API guidance and avoid reliance on removed/deprecated movement functions.
+
+### Notable Functional Changes
+
+**Runebook (`runeoninsert.src`):**
+- `recharge_amount` is capped to `maxcharges - charges`.
+- Script subtracts only `recharge_amount` from the inserted stack.
+- Leftover scrolls (`scrolls.amount` after subtraction) are handled in this order:
+  - `MoveItemToContainer(..., who.backpack)`
+  - `MoveObjectToLocation(..., who.x, who.y, GetWorldHeight(...), who.realm, MOVEOBJECT_NORMAL)`
+  - if both fail: `DestroyItem(scrolls)` and user-facing warning about destroyed excess scrolls.
+- Recharge does not fail when overflow return fails; only excess scrolls are discarded.
+- Charge state is still clamped to `maxcharges`, and revision increment is preserved.
+
+**Move API migration:**
+- All modified files now call `MoveObjectToLocation` for world-placement behavior.
+- Helper code in `scripts/include/std.inc` remains backward-compatible at call site level (`MoveItem(...)` wrapper still exists), but internally routes through `MoveObjectToLocation`.
+
+### Expected Impact
+
+- Dragging an oversized recall-scroll stack onto a partially charged runebook now reliably recharges the runebook by available capacity.
+- Overflow scroll behavior is deterministic under constrained inventory/terrain conditions:
+  - return to backpack if possible;
+  - else drop to ground if possible;
+  - else destroy overflow with explicit player notification.
+- No expected gameplay behavior changes from the movement API migration itself; changes are compatibility/maintenance-focused.

--- a/patchnotes/launchernotes.md
+++ b/patchnotes/launchernotes.md
@@ -63,6 +63,55 @@ Cartography had bugs where skill gain could occur or maps could be created even 
 
 ---
 
+## 📘 Runebook - Recall Scroll Overflow Fix
+
+### Player Impact
+
+- Runebooks now recharge correctly when a scroll stack is larger than remaining charges.
+- Example: dropping 2 recall scrolls on a runebook missing 1 charge now recharges the book by 1 as expected.
+- Any extra scrolls are returned to backpack when possible.
+- If backpack is full, extras are dropped to the ground when possible.
+- If backpack return and ground drop both fail, only the excess scrolls are destroyed and recharge still succeeds.
+
+---
+
+## 🛠️ Internal - Script API Compatibility Cleanup
+
+### Player Impact
+
+- No gameplay change expected.
+- Deprecated `MoveItemToLocation` script calls were migrated to `MoveObjectToLocation` in affected scripts for modern POL compatibility.
+
+---
+
+## ⛪ High Priest - Relationship Cost Prompt
+
+### Player Impact
+
+- If your relationship with the High Priest is upset, you can now say **relationship** to see exactly how much gold is required to repair it.
+- The required donation scales with your class level (`class level * 2500`).
+- If no class level is detected, the priest now gives a fallback hint that any donation amount can begin repairing the relationship.
+
+---
+
+## ⚔️ Dual Planar - Protection Gate Removed
+
+### Player Impact
+
+- The protection/immunity gate on Dual Planar's on-hit effect was removed.
+- This means previously protected targets are no longer skipped by that specific immunity branch.
+
+---
+
+## 💎 Loot Tables - More Life Crystal Coverage
+
+### Player Impact
+
+- `lifecrystal` was added to additional entries within the Junk loot group.
+- You should now see broader life crystal availability from junk-group loot rolls.
+
+---
+
 ## 📋 Summary
 
 ✅ Champion Relics added — summon a boss from your artifact  
@@ -70,7 +119,12 @@ Cartography had bugs where skill gain could occur or maps could be created even 
 ✅ Camping kindling sourced only from backpack or ground  
 ✅ Jewelry crafting gold check now properly exits on failure  
 ✅ Tamed pet following fixed for tower/multi overhang geometry  
-✅ Player merchant stock announcements suppressed while hidden/concealed
+✅ Player merchant stock announcements suppressed while hidden/concealed  
+✅ Runebook recall-scroll overflow now recharges safely and handles extras correctly  
+✅ Deprecated item-move API calls migrated for core compatibility  
+✅ High Priest now reports relationship repair gold requirement  
+✅ Dual Planar immunity/protection gate removed on hit logic  
+✅ Life crystal appears in more Junk loot entries
 
 ---
 

--- a/patchnotes/patch-v1.0.6.md
+++ b/patchnotes/patch-v1.0.6.md
@@ -70,6 +70,27 @@ Cartography had bugs where skill gain could occur or maps could be created even 
 
 ---
 
+## 📘 Runebook - Recall Scroll Overflow Fix
+
+### Player Impact
+
+- Runebooks now recharge correctly when a scroll stack is larger than remaining charges.
+- Example: dropping 2 recall scrolls on a runebook missing 1 charge now recharges the book by 1 as expected.
+- Any extra scrolls are returned to backpack when possible.
+- If backpack is full, extras are dropped to the ground when possible.
+- If backpack return and ground drop both fail, only the excess scrolls are destroyed and recharge still succeeds.
+
+---
+
+## 🛠️ Internal - Script API Compatibility Cleanup
+
+### Player Impact
+
+- No gameplay change expected.
+- Deprecated `MoveItemToLocation` script calls were migrated to `MoveObjectToLocation` in affected scripts for modern POL compatibility.
+
+---
+
 ## 📋 Summary
 
 ✅ Champion Relics added — summon a boss from your artifact  
@@ -77,7 +98,9 @@ Cartography had bugs where skill gain could occur or maps could be created even 
 ✅ Camping kindling sourced only from backpack or ground  
 ✅ Jewelry crafting gold check now properly exits on failure  
 ✅ Tamed pet following fixed for tower/multi overhang geometry  
-✅ Player merchant stock announcements suppressed while hidden/concealed
+✅ Player merchant stock announcements suppressed while hidden/concealed  
+✅ Runebook recall-scroll overflow now recharges safely and handles extras correctly  
+✅ Deprecated item-move API calls migrated for core compatibility
 
 ---
 

--- a/patchnotes/patch-v1.0.6.md
+++ b/patchnotes/patch-v1.0.6.md
@@ -1,10 +1,10 @@
 # Patch Notes - v1.0.6
 **Zuluhotel Omega 2.5 | Live Shard**  
-**Date: June 25, 2026**
+**Date: June 30, 2026**
 
 ---
 
-Welcome to **Patch 1.0.6**. This update introduces **Champion Relics** — a new type of artifact that lets you call down a champion boss — alongside a sweep of crafting and skill-gain bug fixes.
+Welcome to **Patch 1.0.6**. This update introduces **Champion Relics**, fixes several crafting/resource edge cases, resolves runebook overflow behavior, and adds follow-up gameplay tuning for High Priest, Dual Planar, and loot tables.
 
 ---
 
@@ -91,6 +91,34 @@ Cartography had bugs where skill gain could occur or maps could be created even 
 
 ---
 
+## ⛪ High Priest - Relationship Cost Prompt
+
+### Player Impact
+
+- If your relationship with the High Priest is upset, you can now say **relationship** to see exactly how much gold is required to repair it.
+- The required donation scales with your class level (`class level * 2500`).
+- If no class level is detected, the priest now gives a fallback hint that any donation amount can begin repairing the relationship.
+
+---
+
+## ⚔️ Dual Planar - Protection Gate Removed
+
+### Player Impact
+
+- The protection/immunity gate on Dual Planar's on-hit effect was removed.
+- This means previously protected targets are no longer skipped by that specific immunity branch.
+
+---
+
+## 💎 Loot Tables - More Life Crystal Coverage
+
+### Player Impact
+
+- `lifecrystal` was added to additional entries within the Junk loot group.
+- You should now see broader life crystal availability from junk-group loot rolls.
+
+---
+
 ## 📋 Summary
 
 ✅ Champion Relics added — summon a boss from your artifact  
@@ -100,7 +128,10 @@ Cartography had bugs where skill gain could occur or maps could be created even 
 ✅ Tamed pet following fixed for tower/multi overhang geometry  
 ✅ Player merchant stock announcements suppressed while hidden/concealed  
 ✅ Runebook recall-scroll overflow now recharges safely and handles extras correctly  
-✅ Deprecated item-move API calls migrated for core compatibility
+✅ Deprecated item-move API calls migrated for core compatibility  
+✅ High Priest now reports relationship repair gold requirement  
+✅ Dual Planar immunity/protection gate removed on hit logic  
+✅ Life crystal appears in more Junk loot entries
 
 ---
 

--- a/patchnotes/patch-v1.0.6.md
+++ b/patchnotes/patch-v1.0.6.md
@@ -1,5 +1,12 @@
-# Latest Changes
-Always check Discord announcements for all the patch notes.
+# Patch Notes - v1.0.6
+**Zuluhotel Omega 2.5 | Live Shard**  
+**Date: June 25, 2026**
+
+---
+
+Welcome to **Patch 1.0.6**. This update introduces **Champion Relics** — a new type of artifact that lets you call down a champion boss — alongside a sweep of crafting and skill-gain bug fixes.
+
+---
 
 ## What Changed
 

--- a/pkg/opt/ArtifactSystem/artifact-system-summary.txt
+++ b/pkg/opt/ArtifactSystem/artifact-system-summary.txt
@@ -1,0 +1,100 @@
+Artifact System Comprehensive Summary (Zuluhotel Omega 2.5)
+
+Overview
+The artifact system is a global recycle-and-random-distribution pool for rare items. It lets staff mark items as artifacts, stores them in a global server-side container, and distributes them to players via consumable artifact boxes. Artifact items are normally recycled back into the pool when destroyed/decayed instead of being permanently deleted.
+
+What You Can Do
+1) Mark any item as an artifact so it is protected from permanent loss on normal destruction.
+2) Store artifact items in a global artifact container (shared server-side storage, not character-specific).
+3) Give players artifact boxes (loot/event rewards) that grant one random artifact from the global pool.
+4) Permanently delete an artifact when needed (admin-only bypass of recycle behavior).
+5) Open and manage the artifact pool directly as staff.
+
+Admin Commands
+1) .makeartifact
+- Purpose: Convert a targeted item into an artifact.
+- Behavior: Sets ObjProperty "Artifact" to 1 on the targeted item.
+- Access: Administrator (CmdLevel 4).
+
+2) .openartifact
+- Purpose: Open the artifact management container.
+- Behavior: Opens the global artifact storage container via special container UI.
+- Access: Administrator (CmdLevel 4).
+
+3) .destroyartifact
+- Purpose: Permanently destroy an artifact item.
+- Behavior: Removes ObjProperty "Artifact" first, then destroys the item so it does not recycle.
+- Access: Administrator (CmdLevel 4).
+
+How It Works Internally
+1) Global storage backend
+- Constant ARTIFACT_BOX is "artifactbox".
+- System opens/creates storage area "World Bank".
+- System finds/creates root item "artifactbox" in World Bank as a bankbox object.
+- This is the persistent global pool that holds artifact items.
+
+2) Recycling behavior on destruction
+- Main shard destruction flow checks for ObjProperty "Artifact".
+- If present, item is moved into the global artifact box and destruction is canceled.
+- Result: artifact item is recycled instead of deleted.
+
+3) Random draw distribution
+- Artifact box (loot item) double-click script:
+  a) Enumerates items in the global artifact box.
+  b) Selects one random entry.
+  c) Moves selected item to player backpack.
+  d) Destroys the artifact box item itself.
+- Result: one box = one random pull from the artifact pool.
+
+4) Artifact box item definition
+- Item type 0x7990.
+- Name: artifactbox.
+- Visual: graphic 0x0E80, color 1997.
+- Script: artifactbox (double-click behavior).
+- DestroyScript: ::maindestroy.
+
+5) Package status
+- Package artifactsystem is enabled by default.
+
+Operational Lifecycle (Typical)
+1) Staff marks curated rare items using .makeartifact.
+2) Staff places those items into the global pool via .openartifact.
+3) Loot/events grant artifactbox items to players.
+4) Player opens box and gets one random artifact from the pool.
+5) If that artifact is later destroyed/decays through normal destroy flow, it is recycled back into the global pool.
+6) If staff needs true deletion, use .destroyartifact.
+
+Important Caveats and Quirks
+1) Global shared pool, uniform randomness
+- Current selection is uniform random over the current container contents.
+- No weighting, pity logic, cooldowns, player-specific filtering, or anti-duplicate logic by default.
+
+2) Empty pool edge case
+- The artifactbox script attempts MoveItemToContainer(item, player.backpack) before checking if item is valid.
+- If the pool is empty, behavior depends on engine tolerance for null item move.
+- Practical note: keep at least one item in pool or add script guard logic.
+
+3) Recycling relies on destroy pipeline
+- Artifact recovery depends on the live maindestroy hook path being used.
+- Items bypassing that path may not recycle.
+
+4) Naming quirk in command script
+- File is destroyartifact.src, but program name is textcmd_destroyunique.
+- Usually works if command registration is file-based; still a maintainability inconsistency.
+
+5) Legacy wording in docs
+- ReadMe mixes "unique" and "artifact" terms from earlier naming history.
+- Functional behavior in code is artifact-based.
+
+Content/Design Guidance
+1) Mark only items that should be recyclable and persistent in circulation.
+2) Curate pool contents regularly; distribution quality is exactly what is currently in pool.
+3) Tune artifactbox drop rate to preserve rarity (each box can produce one artifact pull).
+4) Use .destroyartifact for retirement of problematic artifacts so they do not re-enter rotation.
+
+Potential Improvements (Optional)
+1) Add empty-pool safety check before attempting item move.
+2) Add weighted rarity selection instead of flat random.
+3) Add audit logging (who pulled what, when, source box serial).
+4) Add anti-duplicate or cooldown logic per player/account.
+5) Normalize command naming (textcmd_destroyartifact) for clarity.

--- a/pkg/opt/ArtifactSystem/artifact.inc
+++ b/pkg/opt/ArtifactSystem/artifact.inc
@@ -8,16 +8,23 @@ include "include/random";
 
 const ARTIFACT_BOX := "artifactbox";
 const ARTIFACT_FONT_COLOR := 43;
+const ARTIFACT_EXPIRE_PROP := "#ArtifactExpireAt";
 
 function getItemArtifactBox()
 	
 	var artifact_list := EnumerateItemsInContainer(getArtifactBox());
+	if (!artifact_list || !artifact_list.Size())
+		return 0;
+	endif
 	var rand := 1 + RandomInt(artifact_list.Size());
 
 	return artifact_list[rand];
 endfunction
 
 function toArtifactBox(item)
+	// Once recycled, relic expiry should reset on next pull from the artifact box.
+	EraseObjProperty(item, ARTIFACT_EXPIRE_PROP);
+	EraseObjProperty(item, "RelicUID");
 	MoveItemToContainer(item, getArtifactBox());
 endfunction
 
@@ -43,4 +50,67 @@ function OpenWorldBank()
 		syslog( "Unable to open or create world bank!" );
 	endif
 	return bank;
+endfunction
+
+function SweepExpiredArtifacts(scope)
+	var now := ReadGameClock();
+	var scanned := 0;
+	var swept := 0;
+	var errors := 0;
+
+	var areas := StorageAreas();
+	if (!areas)
+		var msg := "[ArtifactSweep " + scope + "] no storage areas returned.";
+		syslog(msg);
+		print(msg);
+		return 0;
+	endif
+
+	foreach area in areas
+		if (!area)
+			continue;
+		endif
+
+		foreach storage_item in EnumerateItemsInContainer(area)
+			if (!storage_item)
+				continue;
+			endif
+			if (storage_item.isa(POLCLASS_CONTAINER))
+				SweepExpiredArtifactsInContainer(storage_item, now, scanned, swept, errors);
+			endif
+		endforeach
+	endforeach
+
+	var summary := "[ArtifactSweep " + scope + "] scanned=" + scanned + " swept=" + swept + " errors=" + errors;
+	syslog(summary);
+	print(summary);
+	return swept;
+endfunction
+
+function SweepExpiredArtifactsInContainer(container, now, byref scanned, byref swept, byref errors)
+	if (!container)
+		return;
+	endif
+
+	foreach item in EnumerateItemsInContainer(container)
+		if (!item)
+			continue;
+		endif
+
+		scanned := scanned + 1;
+		var should_recurse := 1;
+
+		if (GetObjProperty(item, "Artifact"))
+			var expire_at := CInt(GetObjProperty(item, ARTIFACT_EXPIRE_PROP));
+			if (expire_at && expire_at <= now)
+				DestroyItem(item);
+				swept := swept + 1;
+				should_recurse := 0;
+			endif
+		endif
+
+		if (should_recurse && item.isa(POLCLASS_CONTAINER))
+			SweepExpiredArtifactsInContainer(item, now, scanned, swept, errors);
+		endif
+	endforeach
 endfunction

--- a/pkg/opt/ArtifactSystem/artifact_daily_sweeper.src
+++ b/pkg/opt/ArtifactSystem/artifact_daily_sweeper.src
@@ -1,0 +1,11 @@
+use os;
+include ":ArtifactSystem:artifact";
+
+const ARTIFACT_SWEEP_INTERVAL := 86400;
+
+program artifact_daily_sweeper()
+	while(1)
+		SweepExpiredArtifacts("Daily");
+		sleep(ARTIFACT_SWEEP_INTERVAL);
+	endwhile
+endprogram

--- a/pkg/opt/ArtifactSystem/artifact_startup_sweeper.src
+++ b/pkg/opt/ArtifactSystem/artifact_startup_sweeper.src
@@ -1,0 +1,6 @@
+use os;
+include ":ArtifactSystem:artifact";
+
+program artifact_startup_sweeper()
+	SweepExpiredArtifacts("Startup");
+endprogram

--- a/pkg/opt/ArtifactSystem/artifactbox.src
+++ b/pkg/opt/ArtifactSystem/artifactbox.src
@@ -4,10 +4,24 @@ use util;
 
 include ":ArtifactSystem:artifact";
 
+const UOBJ_CHAMPION_RELIC_T1 := 0x7991;
+const UOBJ_CHAMPION_RELIC_T2 := 0x7992;
+const RELIC_DECAY_SECONDS := 1209600;
+
 program dblclick_artifactbox( player, box )
 
 	var item := getItemArtifactBox();
-	MoveItemToContainer(item, player.backpack);
+	if (item)
+		MoveItemToContainer(item, player.backpack);
+
+		if (item.objtype == UOBJ_CHAMPION_RELIC_T1 || item.objtype == UOBJ_CHAMPION_RELIC_T2)
+			var expire_at := ReadGameClock() + RELIC_DECAY_SECONDS;
+			item.decayat := expire_at;
+			SetObjProperty(item, "#ArtifactExpireAt", expire_at);
+			SetObjProperty(item, "RelicUID", RandomInt(2000000000));
+		endif
+	endif
+
 	DestroyItem( box );
 	
 	if (item)

--- a/pkg/opt/ArtifactSystem/championrelic.src
+++ b/pkg/opt/ArtifactSystem/championrelic.src
@@ -1,0 +1,60 @@
+use uo;
+
+include "include/areas";
+include "include/random";
+include "include/client";
+
+const RELIC_FONT_COLOR := 43;
+
+program championrelic(who, item)
+
+	if(!ReserveItem(item))
+		return 0;
+	endif
+
+	if (IsInSafeArea(who))
+		SendSysMessage(who, "You cannot activate this relic in a safe area.", FONT_NORMAL, RELIC_FONT_COLOR);
+		return 0;
+	endif
+
+	if (IsInGuardedArea(who))
+		SendSysMessage(who, "You cannot activate this relic in a guarded area.", FONT_NORMAL, RELIC_FONT_COLOR);
+		return 0;
+	endif
+
+	if (IsInNOPKArea(who))
+		SendSysMessage(who, "You cannot activate this relic in this area.", FONT_NORMAL, RELIC_FONT_COLOR);
+		return 0;
+	endif
+
+	var level := CInt(GetObjProperty(item, "MagicItemLevel"));
+	var templates;
+
+	if (level == 10)
+		templates := {"barracoon", "erebuschaosgod"};
+	elseif (level == 11)
+		templates := {"rikktor", "nyxseductress"};
+	else
+		SendSysMessage(who, "This relic has an invalid tier.", FONT_NORMAL, 2595);
+		return 0;
+	endif
+
+	var template := templates[RandomInt(templates.Size()) + 1];
+	var spawnx := who.x + RandomInt(3) - 1;
+	var spawny := who.y + RandomInt(3) - 1;
+	var spawnz := who.z;
+	var boss := CreateNpcFromTemplate(template, spawnx, spawny, spawnz, 0, who.realm);
+
+	if (!boss)
+		SendSysMessage(who, "The relic fizzles and fails to summon.", FONT_NORMAL, 2595);
+		return 0;
+	endif
+
+	PlayStationaryEffect(boss.x, boss.y, boss.z, 0x3728, 10, 0x10, 0);
+	PlaySoundEffect(boss, 0x01FE);
+	SendSysMessage(who, "The relic shatters and calls forth a champion!", FONT_NORMAL, RELIC_FONT_COLOR);
+
+	DestroyItem(item);
+	return 1;
+
+endprogram

--- a/pkg/opt/ArtifactSystem/itemdesc.cfg
+++ b/pkg/opt/ArtifactSystem/itemdesc.cfg
@@ -7,3 +7,25 @@ item 0x7990
 	Script	artifactbox
 	DestroyScript	::maindestroy
 }
+
+item 0x7991
+{
+	Name	championrelictier1
+	graphic	0x3CC1
+	desc	Champion Relic (Tier 1)
+	Script	championrelic
+	DestroyScript	::maindestroy
+	CProp	Artifact	i1
+	CProp	MagicItemLevel	i10
+}
+
+item 0x7992
+{
+	Name	championrelictier2
+	graphic	0x3CC1
+	desc	Champion Relic (Tier 2)
+	Script	championrelic
+	DestroyScript	::maindestroy
+	CProp	Artifact	i1
+	CProp	MagicItemLevel	i11
+}

--- a/pkg/packethooks/megacliloc/itemdata.src
+++ b/pkg/packethooks/megacliloc/itemdata.src
@@ -364,6 +364,18 @@ program itemdata(parms)
 			prop.clilocid := 1063514; // "Artifact"
 			prop.values := array {};
 			allprops.append(prop);
+
+			var artifactexpireat := CInt(GetObjProperty(xObject, "#ArtifactExpireAt"));
+			if (artifactexpireat)
+				var remain := artifactexpireat - ReadGameClock();
+				prop.clilocid := 1070722; // Nothing
+				if (remain <= 0)
+					prop.values := array {"Artifact expired, pending sweep"};
+				else
+					prop.values := array {"Artifact expires in " + FormatDuration(remain)};
+				endif
+				allprops.append(prop);
+			endif
 		endif
 		if(IsCBoost(xObject) || xObject.isa(POLCLASS_EQUIPMENT))
 			prop.clilocid := 1063515; // Item Quality:
@@ -462,4 +474,34 @@ function GetSkillName( skillid )
     	var cfg := ReadConfigFile( ":shilhook:skillsdef" );
     	return cfg[skillid].name;
     	
+endfunction
+
+function FormatDuration(total_seconds)
+	var seconds := CInt(total_seconds);
+	if (seconds < 0)
+		seconds := 0;
+	endif
+
+	var days := CInt(seconds / 86400);
+	seconds := seconds - (days * 86400);
+
+	var hours := CInt(seconds / 3600);
+	seconds := seconds - (hours * 3600);
+
+	var minutes := CInt(seconds / 60);
+	seconds := seconds - (minutes * 60);
+
+	var result := "";
+	if (days)
+		result := result + days + "d ";
+	endif
+	if (days || hours)
+		result := result + hours + "h ";
+	endif
+	if (days || hours || minutes)
+		result := result + minutes + "m ";
+	endif
+	result := result + seconds + "s";
+
+	return result;
 endfunction

--- a/pkg/std/blacksmithy/blacksmithy.src
+++ b/pkg/std/blacksmithy/blacksmithy.src
@@ -146,6 +146,7 @@ function MakeJewelry( character , ore )
 	
 	if( ore.amount < 100 )
 		SendSysmessage( character , "It doesn't look like you used enough gold" );
+		return;
 	endif
 
 	if( CheckSkill( character , SKILLID_BLACKSMITHY , -1 , 0 ) )

--- a/pkg/std/camping/camping.src
+++ b/pkg/std/camping/camping.src
@@ -23,6 +23,21 @@ include "include/classes";
 
 CONST POINT_VALUE := 200;
 
+function ItemIsInBackpackScope(character, item)
+    if(item.serial == character.backpack.serial)
+        return 1;
+    elseif(item.container != character.backpack)
+        foreach thing in EnumerateItemsInContainer(character.backpack)
+            if(item.serial == thing.serial)
+                return 1;
+            endif
+        endforeach
+    else
+        return 1;
+    endif
+    return 0;
+endfunction
+
 program UseWood( character, wood )
 
     var newitem;
@@ -37,6 +52,11 @@ program UseWood( character, wood )
         PrintTextAbovePrivate( wood, "You can't reach that!", character );
         return;
     endif
+
+	if(wood.container and !ItemIsInBackpackScope(character, wood))
+		SendSysMessage(character, "That kindling must be in your backpack or on the ground.");
+		return;
+	endif
 
     /*if (wood.container)
         PrintTextAbovePrivate( wood, "Put that on the ground first!", character );

--- a/pkg/std/cartography/cartography.src
+++ b/pkg/std/cartography/cartography.src
@@ -13,6 +13,38 @@ const POINTS_MULTIPLIER := 15;
 // Cache ResourceRequest for blank maps — set when player targets cache
 var mapRequest := 0;
 
+function GetNewMapMaterialCost(who)
+	var material := 10;
+	// Require half resources during Crafting PH
+	if(GetGlobalProperty("PHC") || GetObjProperty(who, "#PPHC"))
+		material := Ceil(material/2);
+	endif
+	return material;
+endfunction
+
+function EnsureMapResources(who, amount)
+	if(GetAvailableResource(who, mapRequest).total < amount)
+		SendSysMessage(who, "You don't have enough resources.");
+		return 0;
+	endif
+	return 1;
+endfunction
+
+function ItemIsInBackpackScope(who, item)
+	if(item.serial == who.backpack.serial)
+		return 1;
+	elseif(item.container != who.backpack)
+		foreach thing in EnumerateItemsInContainer(who.backpack)
+			if(item.serial == thing.serial)
+				return 1;
+			endif
+		endforeach
+	else
+		return 1;
+	endif
+	return 0;
+endfunction
+
 program go_go_gadget_map( who, blank )
 
 	// Handle Omega Cache targeting
@@ -23,6 +55,11 @@ program go_go_gadget_map( who, blank )
 			return;
 		endif
 	else
+		if(blank.objtype == 0x6001 and !ItemIsInBackpackScope(who, blank))
+			SendSysMessage(who, "That blank map must be in your backpack.");
+			return;
+		endif
+
 		if (blank.objtype<>0x6001)
 		foreach item in EnumerateItemsInContainer(who.backpack)
 		if (item.objtype ==0x6001)
@@ -53,6 +90,9 @@ program go_go_gadget_map( who, blank )
 
 	case (choice.index)
 		1: 	difficulty := 20;
+			if(!EnsureMapResources(who, 1))
+				break;
+			endif
 			sendDiff( who , difficulty );
 			if( CheckSkill( who, SKILLID_CARTOGRAPHY , difficulty , Cint(difficulty * POINTS_MULTIPLIER)) )
 				props := array( "var" , who.x - 265 , who.y - 260 , who.x + 265 , who.y + 260 , 200 , 200 );
@@ -64,6 +104,9 @@ program go_go_gadget_map( who, blank )
 			break;
 
 		2: 	difficulty := 50;
+			if(!EnsureMapResources(who, 1))
+				break;
+			endif
 			sendDiff( who , difficulty );
 			if( CheckSkill( who, SKILLID_CARTOGRAPHY , difficulty , Cint(difficulty * POINTS_MULTIPLIER) ))
 				props := array( "regional" , who.x - 850 , who.y - 800 , who.x + 850 , who.y + 800 , 400 , 400 );
@@ -75,6 +118,9 @@ program go_go_gadget_map( who, blank )
 			break;
 
 		3:	difficulty := 80;
+			if(!EnsureMapResources(who, 1))
+				break;
+			endif
 			sendDiff( who , difficulty );
 			if( CheckSkill( who, SKILLID_CARTOGRAPHY , difficulty , Cint(difficulty * POINTS_MULTIPLIER) ))
 	   			props := array( "world" , 0 , 0 , 5119 , 4095 , 500 , 400 );
@@ -86,6 +132,9 @@ program go_go_gadget_map( who, blank )
 			break;
 
 		4:	difficulty := 110;
+			if(!EnsureMapResources(who, GetNewMapMaterialCost(who)))
+				break;
+			endif
 			sendDiff( who , difficulty );
 			if( CheckSkill( who, SKILLID_CARTOGRAPHY , difficulty , Cint(difficulty * POINTS_MULTIPLIER) ))
 				makeNewmap( who , blank, 1 );
@@ -100,6 +149,9 @@ program go_go_gadget_map( who, blank )
 			break;
 
 		5:	difficulty := 110;
+			if(!EnsureMapResources(who, GetNewMapMaterialCost(who)))
+				break;
+			endif
 			sendDiff( who , difficulty );
 			if( CheckSkill( who, SKILLID_CARTOGRAPHY , difficulty , Cint(difficulty * POINTS_MULTIPLIER) ))
 				makeNewmap( who , blank, 2 );
@@ -149,11 +201,7 @@ function makemap( who, mapdef , blank )
 endfunction
 
 function makeNewmap( who, blank, choice )
-	var material := 10;
-	//Require half resources during Crafting PH
-	if(GetGlobalProperty("PHC") || GetObjProperty(who, "#PPHC"))
-		material := Ceil(material/2);
-	endif
+	var material := GetNewMapMaterialCost(who);
 	if(GetAvailableResource(who, mapRequest).total < material)
 		sendsysmessage(who, "You don't have enough materials to do that.");
 		return;

--- a/pkg/std/housing/utility.inc
+++ b/pkg/std/housing/utility.inc
@@ -1,4 +1,5 @@
 include "setup";
+include "include/attributes";
 
 const VIEW_SECURE := 2;
 const ADD_TO_SECURE := 3;
@@ -83,7 +84,7 @@ function UpgradeSecure(who, container, boxo)
 		if (item.serial != boxo.serial)
 			if (item.container.serial == boxo.serial) // Moving top level items only
 				if (!MoveItemToContainer(item, container))
-					MoveItemToLocation(item, who.x, who.y, who.z, MOVEITEM_FORCELOCATION);
+					MoveObjectToLocation(item, who.x, who.y, who.z, who.realm, MOVEOBJECT_FORCELOCATION);
 					SendSysMessage(who, item.desc+" placed at your feet as the secure is full.", 3, 67);
 				endif
 			endif
@@ -106,7 +107,7 @@ endfunction
 // friend list to new. Once world wipse, remove all this.
 //
 ///////////////////////////////////////////////////////////////////////////////////
-function UpdateFriendFunction(house, sign)
+function UpdateFriendFunction(house, unused sign)
 
 	// Friends exist, meaning new system in place
 	if (GetObjProperty(house, "Friends"))

--- a/pkg/std/runebook/runecaninsert.src
+++ b/pkg/std/runebook/runecaninsert.src
@@ -3,7 +3,7 @@ use os;
 
 include "include/objtype";
 
-program can_insert( who, runebook, movetype, inserttype, item, existing_stack, amount_to_add )
+program can_insert( who, runebook, unused movetype, unused inserttype, item, unused existing_stack, unused amount_to_add )
 	
 	if( !ReserveItem( runebook ) )
 		return 0;

--- a/pkg/std/runebook/runeoninsert.src
+++ b/pkg/std/runebook/runeoninsert.src
@@ -5,7 +5,7 @@ use polsys;
 include "include/client";
 include "include/objtype";
 
-program on_insert( who, runebook, movetype, inserttype, item, existing_stack, amount_to_add )
+program on_insert( who, runebook, unused movetype, unused inserttype, item, unused existing_stack, unused amount_to_add )
 	
 	set_critical(1);
 	
@@ -109,24 +109,43 @@ function RechargeBook( who, runebook, scrolls )
 	
 	var maxamount	 := Cint( maxcharges - charges );
 	var amount	 := Cint( scrolls.amount );
+	var recharge_amount := amount;
 	
 	if( maxamount <= 0 )
 		SendSysMessage( who, "This runebook is full." );
 		set_critical(0);
 		return 0;
-		
-	elseif( amount >= maxamount )
-		var to_substract := maxamount;
-		if( SubtractAmount( scrolls, to_substract ) )
-			charges := maxcharges;
-		endif
-		
-	elseif( DestroyItem( scrolls ) )
-		charges := charges + amount;
 	endif
-	
+
+	if( amount > maxamount )
+		recharge_amount := maxamount;
+	endif
+
+	if( !SubtractAmount( scrolls, recharge_amount ) )
+		SendSysMessage( who, "The runebook could not be recharged." );
+		set_critical(0);
+		return 0;
+	endif
+
 	if( scrolls and scrolls.amount )
-		MoveItemToContainer( scrolls, who.backpack );
+		if( !MoveItemToContainer( scrolls, who.backpack ) )
+			if( !MoveObjectToLocation( scrolls, who.x, who.y, GetWorldHeight( who.x, who.y ), who.realm, MOVEOBJECT_NORMAL ) )
+				var lost_scrolls := Cint( scrolls.amount );
+				DestroyItem( scrolls );
+				SendSysMessage( who, "Your backpack is full and the ground is blocked. " + lost_scrolls + " extra recall scrolls were destroyed." );
+			else
+				SendSysMessage( who, "Your backpack is too full, so the extra recall scrolls were dropped at your feet." );
+			endif
+		endif
+	endif
+
+	if( scrolls )
+		DestroyItem( scrolls );
+	endif
+
+	charges := charges + recharge_amount;
+	if( charges > maxcharges )
+		charges := maxcharges;
 	endif
 
 	PlaySoundEffect( who, 0x1f1);
@@ -138,5 +157,4 @@ function RechargeBook( who, runebook, scrolls )
 	
 	set_critical(0);
 	return 1;
-	
 endfunction

--- a/pkg/systems/combat/dualplanaronhit.src
+++ b/pkg/systems/combat/dualplanaronhit.src
@@ -91,14 +91,14 @@ program dualplanaronhit( parms )
 	endif
 	PlaySoundEffect( targ , SFX_SPELL_ASTRAL_STORM );
 	var circle := 5;
-	var immunity := IsProtected( defender , targ , circle );
-	if( immunity == IMMUNED )
-		EraseObjProperty( targ , "Windsbreath" );
-		return;
-	endif
-	if( immunity == CURSED )
-		circle := circle * 2;
-	endif
+	// var immunity := IsProtected( defender , targ , circle );
+	// if( immunity == IMMUNED )
+	// 	EraseObjProperty( targ , "Windsbreath" );
+	// 	return;
+	// endif
+	// if( immunity == CURSED )
+	// 	circle := circle * 2;
+	// endif
 	var duration := ModifyWithMagicEfficiency( defender , 5 );
 
 	//Reduce time from magic resistance

--- a/pkg/systems/playervendor/playermerchant.src
+++ b/pkg/systems/playervendor/playermerchant.src
@@ -190,7 +190,7 @@ function RecentStockTimeText()
 endfunction
 
 function AnnounceRecentStock(who)
-	if(!who or who.npctemplate or !HasRecentStock())
+	if(!who or who.npctemplate or who.hidden or who.concealed or !HasRecentStock())
 		return;
 	endif
 

--- a/scripts/ai/highpriest.src
+++ b/scripts/ai/highpriest.src
@@ -89,9 +89,23 @@ while (1)
 			SYSEVENT_SPEECH:
 				if( GetObjProperty( event.source , "PriestUpset" ) )
 					TurnToward( event.source );
-					Say( "No, I won't listen to thy request.");
-					Sleep( 1 );
-					Say( "Thine past behavior made thee unworthy in the eyes of the Virtues" );
+					if( event.text["relationship"] or event.text["Relationship"] )
+						var player := event.source;
+						var getlevel := GetClasseLevel(player);
+						if(!getlevel)
+							getlevel := 0;
+						endif
+						var repaircost := getlevel*2500;
+						if( repaircost < 1 )
+							Say( "A donation of any amount of gold will let thee begin repairing this relationship." );
+						else
+							Say( "To repair our relationship, thou must donate at least " + repaircost + " gold pieces." );
+						endif
+					else
+						Say( "No, I won't listen to thy request.");
+						Sleep( 1 );
+						Say( "Thine past behavior made thee unworthy in the eyes of the Virtues" );
+					endif
 					
 				elseif( event.text["Greeting"] or event.text["Hail"] or event.text["greeting"] or event.text["Hi"] or event.text["hi"] or event.text["Hello"] or event.text["hello"])
 					TurnToward( event.source );

--- a/scripts/include/chaoseffects.inc
+++ b/scripts/include/chaoseffects.inc
@@ -214,7 +214,7 @@ function ChaosMutation(who)
 			foreach success in ListEquippedItems(who);
 				x := who.x + Random(11) - 5;
 				y := who.y + Random(11) - 5;
-				MoveItemToLocation(success, x, y, GetWorldHeight(x, y),0 );
+				MoveObjectToLocation(success, x, y, GetWorldHeight(x, y), success.realm, MOVEOBJECT_NORMAL );
 			endforeach
 			SendSysMessage(who, "You feel colder...");
 			return;

--- a/scripts/include/possess.inc
+++ b/scripts/include/possess.inc
@@ -50,7 +50,7 @@ function MoveMyPack(me)
 		endif
 	endforeach
 
-	MoveItemToLocation(mypack,5123, 1779, 0, MOVEITEM_FORCELOCATION);
+	MoveObjectToLocation(mypack,5123, 1779, 0, mypack.realm, MOVEOBJECT_FORCELOCATION);
 
 	return mypack;
 
@@ -185,7 +185,7 @@ function SwapClothes(me, npc)
 	var mypack := me.backpack;
 
 	if (hispack)
-		MoveItemToLocation(hispack, 5123, 1779, 0, MOVEITEM_FORCELOCATION);
+		MoveObjectToLocation(hispack, 5123, 1779, 0, hispack.realm, MOVEOBJECT_FORCELOCATION);
 	else
 		hispack := CreateItemAtLocation(5123, 1779, 0, 0xe75,1);
 	endif

--- a/scripts/include/rituals.inc
+++ b/scripts/include/rituals.inc
@@ -314,7 +314,7 @@ function ProcessRitual( who , item , byref magic_circle , the_ritual , keep_circ
 	var manapool := 0;
 
 	if( item )
-		MoveItemToLocation( item , cx , cy , cz , MOVEITEM_FORCELOCATION );
+		MoveObjectToLocation( item , cx , cy , cz , item.realm, MOVEOBJECT_FORCELOCATION );
 		item.movable := 0;
 	endif
 
@@ -553,12 +553,12 @@ function ProcessRitual( who , item , byref magic_circle , the_ritual , keep_circ
 
 				if( item )
 					item.movable := 1;
-					MoveItemToLocation( item , item.x , item.y , item.z+2 , MOVEITEM_FORCELOCATION );
+					MoveObjectToLocation( item , item.x , item.y , item.z+2 , item.realm, MOVEOBJECT_FORCELOCATION );
 					item.movable := 0;
 				endif
 
 				manapile.movable := 1;
-				MoveItemToLocation( manapile , manapile.x , manapile.y , manapile.z-2 , MOVEITEM_FORCELOCATION );
+				MoveObjectToLocation( manapile , manapile.x , manapile.y , manapile.z-2 , manapile.realm, MOVEOBJECT_FORCELOCATION );
 				manapile.movable := 0;
 
 				loop	:= 0;

--- a/scripts/include/std.inc
+++ b/scripts/include/std.inc
@@ -326,11 +326,11 @@ endfunction
 function MoveItemToForcedLocation (item, x, y, z)
 	if (!item.movable)
 		item.movable := 1;
-		var result := MoveItemToLocation(item, x, y, z, MOVEITEM_FORCELOCATION);
+		var result := MoveObjectToLocation(item, x, y, z, item.realm, MOVEOBJECT_FORCELOCATION);
 		item.movable := 0;
 		return result;
 	endif
-	return MoveItemToLocation(item, x, y, z, MOVEITEM_FORCELOCATION);
+	return MoveObjectToLocation(item, x, y, z, item.realm, MOVEOBJECT_FORCELOCATION);
 endfunction
 
 // HellRaider <zion@uo.com.br> 2000-12-13
@@ -348,7 +348,7 @@ function MoveItem (item, byref place, flags := MOVEITEM_NORMAL)
 				place[3] := GetWorldHeight(place[1], place[2]);
 				continue;
 			default:
-				return MoveItemToLocation(item, place[1], place[2], place[3], flags);
+				return MoveObjectToLocation(item, place[1], place[2], place[3], item.realm, flags);
 		endif
 	endif
 	var result := error;

--- a/scripts/start.src
+++ b/scripts/start.src
@@ -28,5 +28,8 @@ find_or_create_storage("Merchant Storage");
 
 start_script("EquipTemplateValidation");
 
+start_script(":ArtifactSystem:artifact_startup_sweeper");
+start_script(":ArtifactSystem:artifact_daily_sweeper");
+
 //start_script("CustomHpFix");
 

--- a/scripts/util/loot.inc
+++ b/scripts/util/loot.inc
@@ -32,7 +32,7 @@ function make_loot (objtype, container)
 	if (mypack)
 		if (GetObjProperty(container, "summoned"))
 			foreach thingie in EnumerateItemsInContainer(mypack)
-				MoveItemToLocation(thingie, container.x, container.y, container.z, MOVEITEM_NORMAL );
+				MoveObjectToLocation(thingie, container.x, container.y, container.z, thingie.realm, MOVEOBJECT_NORMAL );
 			endforeach
 		else
 			foreach thingie in EnumerateItemsInContainer(mypack)


### PR DESCRIPTION
# Patch Notes - v1.0.6
**Zuluhotel Omega 2.5 | Live Shard**  
**Date: June 30, 2026**

---

Welcome to **Patch 1.0.6**. This update introduces **Champion Relics**, fixes several crafting/resource edge cases, resolves runebook overflow behavior, and adds follow-up gameplay tuning for High Priest, Dual Planar, and loot tables.

---

## What Changed

## 🏆 Champion Relics - New Artifact Items

Two new artifacts have been added to the Artifact System: **Champion Relics**.

### Player Impact

- Champion Relics can now drop from the Artifact Box.
- **Tier 1 Relic** summons a Tier 10 champion boss (Barracoon or Chaos God) when activated.
- **Tier 2 Relic** summons a Tier 11 champion boss (Rikktor or Nyx) when activated.
- Relics cannot be used in safe areas, guarded areas, or NOPK zones.
- The relic is destroyed on use.
- Relics have a **14-day expiry timer**. You can check remaining time in the item tooltip.
- Expired relics are automatically removed from storage by a background sweeper.

---

## 🗺️ Cartography - Resource and Skill Gain Fixes

Cartography had bugs where skill gain could occur or maps could be created even without the required materials.

### Player Impact

- All map tiers now correctly check you have enough resources **before** granting skill gain or creating a map.
- Blank maps must now be in your backpack to use — you can no longer drag-target one from a bank or container.
- No functional changes to map content, costs, or difficulty.

---

## 🔥 Camping - Kindling Source Fix

### Player Impact

- Kindling wood used for camping must be in your backpack or on the ground. Targeting wood inside a bank container is no longer allowed.

---

## ⚒️ Blacksmithy - Jewelry Crafting Fix

### Player Impact

- Making jewelry now correctly stops when you don't have enough gold, instead of proceeding to the skill check.

---

## 🐾 Tamed Pets - Overhang Following Fix

### Player Impact

- Tamed pets now follow correctly through tower and multi overhangs. Previously, pets could stall or drop follow state when the path crossed overhang geometry.

---

## 🏪 Player Merchant - Stock Announcement Fix

### Player Impact

- Hidden or concealed characters controlling a player merchant will no longer trigger a stock announcement event, preventing unintended reveals.

---

## 📘 Runebook - Recall Scroll Overflow Fix

### Player Impact

- Runebooks now recharge correctly when a scroll stack is larger than remaining charges.
- Example: dropping 2 recall scrolls on a runebook missing 1 charge now recharges the book by 1 as expected.
- Any extra scrolls are returned to backpack when possible.
- If backpack is full, extras are dropped to the ground when possible.
- If backpack return and ground drop both fail, only the excess scrolls are destroyed and recharge still succeeds.

---

## 🛠️ Internal - Script API Compatibility Cleanup

### Player Impact

- No gameplay change expected.
- Deprecated `MoveItemToLocation` script calls were migrated to `MoveObjectToLocation` in affected scripts for modern POL compatibility.

---

## ⛪ High Priest - Relationship Cost Prompt

### Player Impact

- If your relationship with the High Priest is upset, you can now say **relationship** to see exactly how much gold is required to repair it.
- The required donation scales with your class level (`class level * 2500`).
- If no class level is detected, the priest now gives a fallback hint that any donation amount can begin repairing the relationship.

---

## ⚔️ Dual Planar - Protection Gate Removed

### Player Impact

- The protection/immunity gate on Dual Planar's on-hit effect was removed.
- This means previously protected targets are no longer skipped by that specific immunity branch.

---

## 💎 Loot Tables - More Life Crystal Coverage

### Player Impact

- `lifecrystal` was added to additional entries within the Junk loot group.
- You should now see broader life crystal availability from junk-group loot rolls.

---

## 📋 Summary

✅ Champion Relics added — summon a boss from your artifact  
✅ Cartography resource checks corrected; blank maps must be in backpack  
✅ Camping kindling sourced only from backpack or ground  
✅ Jewelry crafting gold check now properly exits on failure  
✅ Tamed pet following fixed for tower/multi overhang geometry  
✅ Player merchant stock announcements suppressed while hidden/concealed  
✅ Runebook recall-scroll overflow now recharges safely and handles extras correctly  
✅ Deprecated item-move API calls migrated for core compatibility  
✅ High Priest now reports relationship repair gold requirement  
✅ Dual Planar immunity/protection gate removed on hit logic  
✅ Life crystal appears in more Junk loot entries

---

Thanks for playing Zuluhotel Omega 2.5.
