### PR TITLE
Patch notes, and fixes for omega cache, as well as

### DIFF
--- a/patchnotes/developer-changelog-v1.0.8.md
+++ b/patchnotes/developer-changelog-v1.0.8.md
@@ -1,9 +1,9 @@
 # Developer Changelog - v1.0.8
-**Range:** `9f8189f` (origin/Patch-1.0.7) -> `a3c99f6` (HEAD)  
+**Range:** `9f8189f` (origin/Patch-1.0.7) -> `HEAD` + uncommitted working tree  
 **Branch:** Patch-1.0.8  
-**Date:** 2026-06-20 -> 2026-07-20  
-**Commits in range:** 3 (excluding merge commits)  
-**Files changed:** 40 | +10208 / -1253
+**Date:** 2026-06-20 -> 2026-07-23  
+**Commits in range:** 7 (excluding merge commits), plus uncommitted working-tree changes  
+**Files changed:** 48 committed (+10477 / -1316), plus 5 files with uncommitted changes (+343 / -237)
 
 ---
 
@@ -12,31 +12,35 @@
 1. [Scope Summary](#1-scope-summary)
 2. [Commit Timeline](#2-commit-timeline)
 3. [Townstones - Player-Run Town Administration and Membership Cleanup](#3-townstones---player-run-town-administration-and-membership-cleanup)
-4. [Areas - Policy Engine Rewrite and Castle Boundary Fixes](#4-areas---policy-engine-rewrite-and-castle-boundary-fixes)
+4. [Areas - Policy Engine Rewrite, Realm Sanitization, and Mask-Value Cache](#4-areas---policy-engine-rewrite-realm-sanitization-and-mask-value-cache)
 5. [Go Locations - Indexed Config Generation and Range Fallback](#5-go-locations---indexed-config-generation-and-range-fallback)
 6. [Spawnpoint - Restart Helpers and Region-Wide Reset Commands](#6-spawnpoint---restart-helpers-and-region-wide-reset-commands)
-7. [Gameplay Tuning and Script Fixes](#7-gameplay-tuning-and-script-fixes)
-8. [Support Data and Tooling](#8-support-data-and-tooling)
-9. [Exhaustive File-by-File Change List](#9-exhaustive-file-by-file-change-list)
-10. [Risk and Regression Notes](#10-risk-and-regression-notes)
+7. [Housing - Region-Based Placement Restrictions](#7-housing---region-based-placement-restrictions)
+8. [Naming and Identity - Town-Suffix Exploit Closure and Validation Hardening](#8-naming-and-identity---town-suffix-exploit-closure-and-validation-hardening)
+9. [Performance - Shutdown Time and Hot-Path Algorithm Fixes](#9-performance---shutdown-time-and-hot-path-algorithm-fixes)
+10. [Crafting - Omega Cache Integration Fixes](#10-crafting---omega-cache-integration-fixes)
+11. [Omega Cache - Potion Categorization Fix](#11-omega-cache---potion-categorization-fix)
+12. [Gameplay Tuning and Script Fixes](#12-gameplay-tuning-and-script-fixes)
+13. [Support Data and Tooling](#13-support-data-and-tooling)
+14. [Exhaustive File-by-File Change List](#14-exhaustive-file-by-file-change-list)
+15. [Risk and Regression Notes](#15-risk-and-regression-notes)
 
 ---
 
 ## 1. Scope Summary
 
-Patch 1.0.8 is dominated by three big surfaces:
+Patch 1.0.8 grew across two work windows. The first (through `a3c99f6`) was dominated by the datafile-backed area policy rewrite, the go-location indexing pass, and the player-run townstone/admin cleanup — see sections 3, 5, and 6 for that material, carried forward unchanged from the earlier draft of this document.
 
-- a datafile-backed area policy rewrite with cache and invalidation support,
-- a go-location indexing pass driven by a generated `golocs_by_id.cfg`,
-- and a substantial player-run townstone/admin cleanup pass with better persistence and membership handling.
+The second window (`7bdc099` through the current uncommitted state) closed a live-reported name-collision exploit, fixed a duplicate-character bug it was related to, added region-based house placement restrictions, fixed a real performance regression in the areas package and in two hot commands, and completed Omega Cache integration for two crafting scripts that had been missed or left broken during the original cache rollout:
 
-It also includes spawnpoint restart tooling, new staff test commands, and gameplay tuning in the remove-curse, protection, and skill-gain paths.
-
-Large insertion volume comes mostly from generated and expanded data assets:
-
-- `regions/regions.cfg` was expanded heavily to carry the metadata needed for the new go-location index.
-- `config/golocs_by_id.cfg` was generated as the new indexed source used by `.go` and spawnpoint region selection.
-- `pkg/opt/areas/include/areapolicy.inc` is a new policy resolver layer with cache and persistence helpers.
+- A town-suffix name-collision exploit was closed: players could no longer hold both "X" and "X of Town" at once, town names are now blocked in freely-chosen names, and name comparisons are case-insensitive.
+- A live 50-second rename-gump hang, and a resulting duplicate-character bug ("two Paladin Rahl of Occlo"), were root-caused to an O(accounts x 5) full `regions.cfg` re-parse per name check, and fixed with a proper cache.
+- Staff rename paths (`.setprop name`, `.setname`, `.info`'s rename button) now run through the same name validation as player-initiated renames, scoped to player characters only.
+- House placement now blocks city, dungeon, shrine, and graveyard regions by footprint (not just a single point check), replacing an older, narrower check.
+- The area-policy mask lookup (`GetPolicyMask`) is now cached; it was previously hitting the datafile subsystem on every single area-policy check, including every AI tick for every mobile shard-wide.
+- Two independent O(n^2) algorithms (`.go`'s location-reorder pass, and a shared multi-array sort used by `.gotomulti`/`.gotoboat`) were replaced with linear/O(n log n) equivalents after script-log evidence showed both tripping the runaway-script watchdog.
+- The smithy hammer's Omega Cache targeting path was found to be dead code due to a bad merge and was rewritten to match every other crafting script's pattern; the crafter-boost smithy retort had never been integrated with the cache at all and now is.
+- A gap in the Omega Cache's category map left 12 leveled potion objtypes (Greater Strength/Cure Potion tiers, etc.) falling into the "Other" bucket instead of "Potions."
 
 ---
 
@@ -47,6 +51,11 @@ Large insertion volume comes mostly from generated and expanded data assets:
 | `32a2b3a` | 2026-06-20 | backup script path restore |
 | `dbfbe79` | 2026-07-20 | Areas fix for lord british castle and blackthornes |
 | `a3c99f6` | 2026-07-20 | Bunch of patches for player run towns |
+| `7bdc099` | 2026-07-20 | Patch Notes and save datafile error |
+| `065ed28` | 2026-07-20 | House placement not allowed in cities |
+| `21bb91e` | 2026-07-23 | Name Change update |
+| `09bf876` | 2026-07-23 | Areas Fix, and naming fixes |
+| *(uncommitted)* | 2026-07-23 | Blacksmithy/crafter-boost Omega Cache fixes, potion categorization fix, `.go`/sort-helper performance fixes |
 
 ---
 
@@ -84,13 +93,13 @@ Large insertion volume comes mostly from generated and expanded data assets:
 
 ---
 
-## 4. Areas - Policy Engine Rewrite and Castle Boundary Fixes
+## 4. Areas - Policy Engine Rewrite, Realm Sanitization, and Mask-Value Cache
 
 ### Files Changed
 
 | File | Change |
 |------|--------|
-| `pkg/opt/areas/include/areapolicy.inc` | New datafile-backed policy engine, parsed-line cache, global bypass masks, and prune and invalidate helpers |
+| `pkg/opt/areas/include/areapolicy.inc` | New datafile-backed policy engine, parsed-line cache, global bypass masks, realm-name sanitization, and a mask-value cache |
 | `pkg/opt/areas/include/areapolicy.inc.bak` | Backup copy of the pre-rewrite policy implementation |
 | `pkg/opt/areas/textcmd/admin/areas.src` | Rewritten `.areas` admin gump for viewing and toggling area policy flags |
 | `pkg/opt/areas/EnterAreaDelay.src` | Updated to use the new policy resolver path |
@@ -104,12 +113,14 @@ Large insertion volume comes mostly from generated and expanded data assets:
 
 - The area policy layer now lives in a dedicated resolver backed by per-realm datafiles:
   - masks are stored per area id,
-  - a world-catchall bypass mask is OR-merged from known global ids,
+  - a world-catchall bypass mask is OR-merged from known global ids (`feluccawholeworld`, `wholeworld`, `britannia`, `trammelwholeworld`) — confirmed still a one-directional OR merge, so a whole-realm flag (e.g. setting Felucca or Britannia to RP) can force a policy bit on everywhere in that realm, but an individual area still can't opt back out of it since OR can't clear a bit,
   - parsed area lines are cached both per program and in a global property,
   - cache invalidation is fingerprinted by source line count.
 - The admin `.areas` workflow now works as a single gump-driven editor for common policy flags such as guarded, no recall, no marking, anti-magic, forbidden, no looting, safe-area, no-PK, and RP-area behavior.
 - `areas.cfg` includes the specific Lord British Castle and Lord Blackthornes Castle boundary fix from `dbfbe79`.
 - The hot-path area checks now resolve through the new policy layer instead of repeatedly re-parsing config lines.
+- **Realm-name sanitization (`7bdc099`):** every realm-taking function in `areapolicy.inc` (`GetRealmAreaLines`, `GetParsedRealmAreaLines`, `ResolveAreaMatchAtLocation`, `ResolvePolicyAtLocation`, `GetGlobalBypassMask`, `GetRealmPolicyDescriptor`) previously did a bare `Lower(CStr(realm))`. A new `SanitizePolicyRealm(realm)` now falls back to `"britannia"` whenever the incoming realm is blank or the literal string `"<uninitialized object>"`, fixing a datafile-save error that occurred when a realm value hadn't been initialized yet.
+- **Mask-value cache (`09bf876`):** `GetPolicyMask(realm, area_id)` was hitting the datafile subsystem (`OpenDataFile` + `FindElement` + `GetProp`) on every single area-policy check, and `GetGlobalBypassMask()` calls it 4 more times per resolve for the world-catchall ids — up to 5 datafile round trips per check, on every AI tick for every mobile shard-wide. `GetPolicyMask` is now backed by a per-realm `dictionary` (`area_id -> mask`), cached both per-program and in a `GlobalProperty` (`zh.areapolicy.maskcache.<realm>`), using `.Exists()` rather than truthiness so a cached mask of `0` (the common case) isn't mistaken for "not cached." The cache is invalidated precisely on `SetPolicyMask()` writes (single area id) and wholesale on `PruneStaleRealmPolicies()` (whole-realm bulk delete). This mirrors the existing parsed-line cache and was verified against the ZH3.0 sibling repo's simpler (no world-catchall) implementation for reference before implementing.
 
 ---
 
@@ -133,7 +144,7 @@ Large insertion volume comes mostly from generated and expanded data assets:
   - the center point of the configured `Range`.
 - A `dnp` `GoLoc` value is treated as an intentional skip.
 - `0,0,0` explicit coordinates are treated as a placeholder and are replaced from the range center when possible.
-- Location ordering is normalized by type (`Jail`, `City`, `Shrine`, `Graveyard`, `Dungeon`, `POI`, `None`) before any leftover entries are appended.
+- Location ordering is normalized by type (`Jail`, `City`, `Shrine`, `Graveyard`, `Dungeon`, `POI`, `None`) before any leftover entries are appended. See section 9 for the algorithmic rewrite of this ordering pass.
 - The generator script exists so the index can be rebuilt from `regions.cfg` instead of hand-maintaining the go list.
 
 ---
@@ -164,7 +175,113 @@ Large insertion volume comes mostly from generated and expanded data assets:
 
 ---
 
-## 7. Gameplay Tuning and Script Fixes
+## 7. Housing - Region-Based Placement Restrictions
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `pkg/std/housing/housedeed.src` | House placement now checked against region types by footprint; dungeon/system-teleporter proximity check extracted into a helper |
+
+### Notable Functional Changes
+
+- Replaced the old single-tile `CheckCity(character)==1` check (which only tested the placing character's own location) with `IsHousePlacementBlockedByRegionType(housetype, where, region_type)`, called once each for `"city"`, `"dungeon"`, `"shrine"`, and `"graveyard"`. This computes the house's full footprint via `GetHouseFootprintBounds(housetype, x, y)` (multi dimensions applied to the placement point) and rejects placement if that footprint overlaps any `regions.cfg` region of the matching `Type`, scoped to the placing character's realm.
+- `NormalizeRegionType(region_type)` lowercases and validates the region-type string used for comparison against `regions.cfg`'s `Type` field.
+- The old inline dungeon-item / system-teleporter proximity checks (`ListObjectsInBox` scans for objtype `0xa3c8` and `0x6200`) were extracted into `IsHousePlacementBlockedByNearbySpecialObjects(where)`, which returns the rejection message directly instead of duplicating the `ListObjectsInBox` scan and message send inline.
+- Staff (`character.cmdlevel >= 4`) are unaffected — all of the above is still gated behind the existing `if (character.cmdlevel < 4)` check.
+
+---
+
+## 8. Naming and Identity - Town-Suffix Exploit Closure and Validation Hardening
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `scripts/include/NameChecker.inc` | Town-suffix-aware duplicate detection, case-insensitive comparison, whitespace normalization, bad-spacing rejection, and caching |
+| `pkg/opt/townstones/tstone.src` | `Citizenship()`/`CanselCityzenship()` now duplicate-check before applying a town-suffixed or stripped name |
+| `scripts/misc/namechanger.src` | Passes `force_town_check := 1`; added "bad spacing" error message |
+| `scripts/misc/oncreate.src` | Passes `force_town_check := 1` |
+| `scripts/textcmd/admin/setname.src` | `.setname` now runs through `CheckName`, scoped to player characters only |
+| `scripts/textcmd/gm/setprop.src` | `.setprop name` now runs through `CheckName`, scoped to player characters only |
+| `scripts/textcmd/seer/info.src` | `.info`'s rename button now runs through `CheckName`, scoped to player characters only |
+
+### Background
+
+A live exploit was reported: a player could join a town as "X" (becoming "X of Town"), create a second character also named "X" on an alt, then leave the town (reverting the first character to bare "X"), ending up holding both "X" and "X of Town" simultaneously — and bypass case-sensitivity to also claim near-duplicates like "Bop"/"bop"/"BOP". Investigating this also surfaced a live duplicate-character bug (two characters both named "Paladin Rahl of Occlo") and a report of a ~50 second hang with stacked rename gumps after a related fix — both root-caused and fixed here.
+
+### Notable Functional Changes
+
+- **`GetKnownTownNames()`** — replaces the old static `bLTowns`-only blacklist scan with a merged list from three sources: the static `bLTowns` fallback, every `City=1` region in `regions.cfg` (covers player-run townstone regions), and `GetGlobalProperty("townlist")` (covers a townstone whose region entry was later removed). Cached per-program and in a `GlobalProperty` (`zh.namechecker.knowntownnames`); `InvalidateKnownTownNamesCache()` is exposed but not yet wired to any call site (regions.cfg is effectively static at runtime today).
+- **`StripTownSuffix(name, town_names := 0)`** — strips a trailing `" of <Town>"` for any known town so name-uniqueness comparisons treat `"a pig"` and `"a pig of Trinsic"` as the same identity, closing the join/leave/alt exploit above. Accepts an optional pre-fetched `town_names` list to avoid recomputing it in a loop.
+- **`NormalizeNameForCompare(name)`** — lowercases, collapses runs of interior spaces to one, and trims leading/trailing spaces before comparison.
+- **`IsNameTaken(candidate_name, exclude_serial := 0)`** — scans up to 5 character slots per account, comparing `NormalizeNameForCompare(StripTownSuffix(name, town_names))`, case-insensitively, excluding `exclude_serial`. Replaces the old exact-string, case-sensitive comparison in `CheckName` (which never caught `"Bop"` vs `"bop"`).
+- **`CheckName(name, who := 0, force_town_check := 0)`** — new `force_town_check` parameter: pass `1` whenever the player is actively choosing a brand-new name (character creation, the rename gump, staff rename tools) so town names are always blocked regardless of the player's current town membership; login/reconnect revalidation of an already-assigned, legitimately town-suffixed name leaves this `0`. Also added an unconditional bad-spacing rejection (`name[1] == " " || name[len(name)] == " " || find(name, "  ", 0)`) — leading/trailing/doubled spaces were technically "legal characters" under the old per-character validation loop, but let a base name like `"Rahl "` silently become `"Rahl  of Town"` once a town suffix was appended, evading exact-match duplicate detection. This check is unconditional (not gated by `force_town_check`), so it also self-heals an already-malformed stored name on next login revalidation — this is exactly how the shard's one existing malformed record (`"Paladin Rahl  of Occlo"`, confirmed via `data/pcs.txt` to be the only such record shard-wide) will get caught and forced through a rename.
+- **`pkg/opt/townstones/tstone.src`**: `Citizenship(who, item)` now computes the candidate town-suffixed name and calls `IsNameTaken()` before any state mutation, aborting with a message if the resulting name is already in use, rather than mutating town membership and then blindly assigning a colliding name. `CanselCityzenship(who, item)` (leave-town) computes the stripped base name, and if `IsNameTaken()` finds it colliding, sets the character's name to `"AlreadyUsed"` and force-starts `misc/namechanger` instead of blocking the leave — citizen-list removal, population decrement, and the `town` property erasure all still proceed unconditionally, so the player isn't stuck in town membership limbo while they pick a new name.
+- **Staff rename paths** now validate through the same `CheckName()` path as player-driven renames, all explicitly scoped to player characters (`what.acct` / `targ.acct` / `who.acct` checks) so NPC renaming by staff is untouched:
+  - `.setname` (`scripts/textcmd/admin/setname.src`)
+  - `.setprop name` (`scripts/textcmd/gm/setprop.src`)
+  - `.info`'s rename button (`scripts/textcmd/seer/info.src`)
+- **Performance root cause (the 50-second hang):** the original `IsNameTaken`/`StripTownSuffix` implementation called `GetKnownTownNames()` (a full `regions.cfg` re-parse) on every character-slot comparison. With 5,169 accounts x up to 5 slots, that was ~25,000 redundant full-config re-parses per `CheckName` call — the direct cause of the reported hang and stacked rename gumps. Fixed by hoisting `GetKnownTownNames()` to once per `IsNameTaken`/`CheckName` call (passed through as a parameter) and adding the cache described above.
+
+---
+
+## 9. Performance - Shutdown Time and Hot-Path Algorithm Fixes
+
+### Background
+
+Investigated a live report that "POL Cleanup" during shutdown takes noticeably longer since the areas-to-datafile migration, alongside a slow ~1 hour post-startup CPU stabilization period. `log/script.log` showed the runaway-script watchdog firing on `scripts/textcmd/coun/go.ecl` (3 times) and `pkg/opt/alryc/textcmd/test/gotomulti.ecl` (2 times) — both algorithmic, not areas-related. Note: `log/pol.log` does not capture the console-only cleanup messages, so the runaway scripts are strong circumstantial evidence and worthwhile independent fixes on their own merits, not a proven root cause of the shutdown-time regression specifically (the areas mask-value cache in section 4 is the more directly-implicated fix for that).
+
+### Files Changed (uncommitted)
+
+| File | Change |
+|------|--------|
+| `scripts/textcmd/coun/go.src` | `ReorderLocationsForDisplay()` rewritten from an O(n^2)*8 pass to a single O(n) bucketing pass |
+| `scripts/include/string.inc` | `SortMultiArrayByIndex()` rewritten from an O(n^2) selection sort to an O(n log n) iterative bottom-up merge sort |
+
+### Notable Functional Changes
+
+- **`.go`'s `ReorderLocationsForDisplay()`**: previously called `AppendLocationsByType()` once per type bucket (Jail/City/Shrine/Graveyard/Dungeon/POI/None — 7 passes), each of which rescanned the entire, continuously-growing `ordered` output list via `LocationAlreadyAdded()` for every candidate to dedupe by `Id` or by `Name+X+Y+Z+R` — effectively O(n^2) x 8 passes total (7 typed + 1 final catch-all). With ~200 Britannia go-locations alone, this was heavy enough to trip the runaway-script watchdog. Rewritten as a single O(n) pass: build a `LocationDedupeKey(loc)` (prefers `"id:<Id>"`, falls back to `"xy:<Name>:<X>:<Y>:<Z>:<R>"`), dedupe against a `seen` dictionary once, bucket by `GetLocationTypeLabel()` into a `dictionary` of arrays, then emit known-type buckets in priority order followed by any custom/unrecognized-type entries in original encounter order. Output ordering is unchanged from the old implementation; only the algorithm changed. `AppendLocationsByType()` and `LocationAlreadyAdded()` were removed (confirmed via repo-wide grep that nothing else referenced them).
+- **`SortMultiArrayByIndex(MultiArray, SubIndex)`** (`scripts/include/string.inc`): previously an O(n^2) nested-loop selection sort. Rewritten as an iterative bottom-up merge sort (O(n log n)) via a new `MergeRunsByIndex(MultiArray, low, mid, high, SubIndex)` helper, same ascending-by-`SubIndex` output ordering. This is a shared include used by both `pkg/opt/alryc/textcmd/test/gotomulti.src` (`SortHouseMultisByLastLogin`, sorting up to 418 multi records) and `gotoboat.src` (`SortBoatsByLastLogin`) — fixing it here benefits both call sites without touching either file. The merge-loop write-position variable was originally named `out`, which is a reserved word in EScript/POL; renamed to `write_idx`.
+
+---
+
+## 10. Crafting - Omega Cache Integration Fixes
+
+### Files Changed (uncommitted)
+
+| File | Change |
+|------|--------|
+| `pkg/std/blacksmithy/make_blacksmith_items.src` | `use_hammer` rewritten so Omega Cache targeting is reachable; dead/duplicate legacy code removed |
+| `pkg/opt/crafterboost/make_crafter_boosts.src` | Full Omega Cache integration added (previously backpack-only) |
+
+### Notable Functional Changes
+
+- **Blacksmithy (`make_blacksmith_items.src`)**: `use_hammer` previously performed an unconditional `ReserveItem(use_on)` and an unconditional `IsInContainer(character.backpack, use_on)` check *before* any Omega Cache objtype check — unlike every other cache-integrated crafting script (`alchemy.src`, `tinkering.src`, `carpentry.src`, `make_cloth_items.src`, `cooking.src`, `cartography.src`, `inscription.src`), which all check for the cache objtype first. Since the Omega Cache container is a placed house item, it's never "in your backpack," so targeting the cache directly for a plain ingot craft failed with "That item has to be in your backpack." before ever reaching the cache-handling code lower in the file. The only path that worked was the bone-armor sub-flow (target a bone item from backpack first, then target the cache when prompted for ingots), because that second `Target()` call bypassed the broken top-level check. The file also had two near-duplicate copies of the bone/ingot crafting logic (apparent leftover from a bad merge when cache integration was added), including a fallthrough where "no anvil nearby" would silently retry the same target as a plain ingot craft. Rewrote `use_hammer` to check for the cache objtype first (matching the established pattern across the codebase), and factored the repeated ingot-targeting logic into `ResolveIngotTarget(character)` and the anvil-proximity check into `NearAnvil(character)`.
+- **Crafter boosts (`make_crafter_boosts.src`)**: the smithy retort (crafting Oil/Alloy/Varnish/Compound/Recharge Powder from Brimstone/Bloodspawn/Daemon Bone/Bat Wing/Dragon's Blood plus an ingot, log, hide, or gem) had never been integrated with the Omega Cache — it didn't include `resourcemanager.inc` and used the plain backpack-only `FindSubstance`/`ConsumeSubstance` helpers throughout, so it would simply stop (insufficient-materials path) if a player ran out of the targeted material in their backpack, regardless of whether a nearby cache had more. Added `resourcemanager`/`omegacache_utils` includes and converted both the explicitly-targeted material and the implicit fixed reagent (which the player never targets directly) to `ResourceRequest`s:
+  - The initial target and the Brimstone-combine second target now both check for `OMEGACACHE_OBJTYPE` and route through `SelectMaterialFromCache()`, matching the established pattern.
+  - A new `MakeReagentRequest(who, objtype)` builds a backpack-first, cache-fallback `ResourceRequest` for the fixed reagent (mirrors `MakeBackpackRequest()`, but without needing a physical item reference, since the reagent is never targeted by the player).
+  - `LeaseResource`/`ExtendResourceLease`/`ReleaseResourceLease`/`ConsumeResource`/`GetAvailableResource` now drive both materials through the crafting loop, matching `MakeBlacksmithItems`'s pattern; the loop's early-exit paths (missing empty flask, can't reach it, can't reserve it) now `break` instead of `return`, so `AutoLoop_finish()` always runs.
+  - A small `ObjtypeStruct(objtype)` helper lets the existing item-based `IsIngot`/`IsLog`/`IsGem2` (which only ever read `.objtype` off their argument) be reused against a bare objtype from a cache selection, instead of duplicating their range logic locally.
+  - Scope note: the empty-flask consumption for the Recharge Powder product line remains backpack-only (unchanged) — flasks were out of scope for this fix.
+
+---
+
+## 11. Omega Cache - Potion Categorization Fix
+
+### Files Changed (uncommitted)
+
+| File | Change |
+|------|--------|
+| `pkg/opt/omegacache/categories.cfg` | Added 12 missing leveled-potion objtypes to the `Potions` category |
+
+### Notable Functional Changes
+
+- `categories.cfg`'s `Potions` category had two adjacent documented ranges — "Mage-class potion variants (0xFF19-0xFF3F)" ending at `0xFF40`, and "AlchemyPlus potions (0xFF4E-0xFF95, 0xFFA2)" starting at `0xFF4E` — with a gap at `0xFF41`-`0xFF4D` that neither range covered. That gap is exactly where `pkg/std/alchemy/itemdesc.cfg`'s leveled potion tiers live: Strength Potion [Level 2] (`0xFF41`), Greater Strength Potion [Level 1-3] (`0xFF42`-`0xFF44`), Cure Potion [Level 1-3] (`0xFF45`-`0xFF47`), and Greater Cure Potion [Level 1-5] (`0xFF48`-`0xFF4C`). Since `BuildCategoryMap()` in `omegacache.inc` defaults any unmatched objtype straight to `"Other"`, these 12 potions were showing up in the wrong category bucket in the cache UI. Added all 12 objtypes to the `Potions` category, closing the gap. Confirmed via a full cross-reference of `pkg/std/alchemy/itemdesc.cfg` against `categories.cfg` that no other alchemy objtypes have a similar gap. Cosmetic UI-grouping fix only — no gameplay value changes.
+
+---
+
+## 12. Gameplay Tuning and Script Fixes
 
 ### Files Changed
 
@@ -181,6 +298,7 @@ Large insertion volume comes mostly from generated and expanded data assets:
 | `scripts/ai/setup/criersetup.inc` | Crier setup now guards missing config more safely and defaults the flee point cleanly |
 | `scripts/ai/townperson.src` | Town NPC startup now begins wandering immediately after spawn |
 | `scripts/ai/townsfolk.inc` | Townfolk helper updated to stay aligned with the new spawn and movement behavior |
+| `scripts/EquipTemplateValidation.src` | Boot-time equip-config validator deduplicated: removed a dead `else` branch, extracted a shared `ValidateEquipEntries()` used across Armor/Weapon/Equip instead of three near-identical inline blocks |
 
 ### Notable Functional Changes
 
@@ -192,10 +310,11 @@ Large insertion volume comes mostly from generated and expanded data assets:
 - The speech hook fix keeps staff speech logging working even when the packet contains Unicode speech data.
 - Town NPCs no longer sit idle right after spawn; they start their wander cycle immediately.
 - Crier setup became more defensive around missing NPC config entries.
+- `EquipTemplateValidation.src` is a one-shot boot-time validator (~1,279 entries) — the cleanup is a code-quality/maintenance change, not a meaningful perf contributor on its own.
 
 ---
 
-## 8. Support Data and Tooling
+## 13. Support Data and Tooling
 
 ### Files Changed
 
@@ -217,9 +336,9 @@ Large insertion volume comes mostly from generated and expanded data assets:
 
 ---
 
-## 9. Exhaustive File-by-File Change List
+## 14. Exhaustive File-by-File Change List
 
-All files changed in `Patch-1.0.7..Patch-1.0.8`:
+All files changed in `Patch-1.0.7..HEAD`, plus current uncommitted working-tree changes:
 
 | File | Notes |
 |------|-------|
@@ -236,10 +355,12 @@ All files changed in `Patch-1.0.7..Patch-1.0.8`:
 | `pkg/opt/areas/LeaveArea.src` | Switched to the new area-policy resolution flow |
 | `pkg/opt/areas/areaban.src` | Updated for the new area-policy path |
 | `pkg/opt/areas/areas.cfg` | Area policy and region data refresh, including castle fixes |
-| `pkg/opt/areas/include/areapolicy.inc` | New policy resolver and cache layer |
+| `pkg/opt/areas/include/areapolicy.inc` | Policy resolver/cache layer, plus realm sanitization and mask-value cache |
 | `pkg/opt/areas/include/areapolicy.inc.bak` | Backup of the pre-rewrite policy layer |
 | `pkg/opt/areas/textcmd/admin/areas.src` | Rewritten area policy admin gump and flag editor |
+| `pkg/opt/crafterboost/make_crafter_boosts.src` | *(uncommitted)* Full Omega Cache integration added |
 | `pkg/opt/holybook/removecurse.src` | Revised Remove Curse chance logic |
+| `pkg/opt/omegacache/categories.cfg` | *(uncommitted)* 12 leveled-potion objtypes added to the Potions category |
 | `pkg/opt/shilhook/shilhook.src` | Skill gain and difficulty refactor |
 | `pkg/opt/spawnpoint/config/groups.cfg` | Spawnpoint group config update |
 | `pkg/opt/spawnpoint/include/restartspawnpoint.inc` | Shared spawnpoint restart helper |
@@ -249,25 +370,41 @@ All files changed in `Patch-1.0.7..Patch-1.0.8`:
 | `pkg/opt/townstones/textcmd/admin/createtownstone.src` | Creation workflow tightened and state restoration added |
 | `pkg/opt/townstones/textcmd/admin/removetownmember.src` | New town member removal command |
 | `pkg/opt/townstones/textcmd/admin/townbankstatus.src` | Major town status, member management, and runtime state expansion |
+| `pkg/opt/townstones/tstone.src` | `Citizenship`/`CanselCityzenship` now duplicate-check before mutating a name |
 | `pkg/packethooks/speech/receivespeechhook.src` | Unicode speech packet decode fix |
+| `pkg/std/blacksmithy/make_blacksmith_items.src` | *(uncommitted)* Omega Cache targeting fixed, dead code removed |
+| `pkg/std/housing/housedeed.src` | Region-based city/dungeon/shrine/graveyard placement restrictions |
 | `pkg/std/treasuremap/treasure.cfg` | One treasure location adjusted |
 | `pol.cfg` | Profiling and sysload watchers enabled |
 | `pythonscripts/generate_golocs_by_id.py` | New generator for indexed go-location config |
 | `regions/regions.cfg` | Large region metadata expansion and normalization |
+| `scripts/EquipTemplateValidation.src` | Dead branch removed, shared validation helper extracted |
 | `scripts/ai/noble.src` | Nobles now wander immediately after spawn |
 | `scripts/ai/person.src` | Townsfolk now wander immediately after spawn |
 | `scripts/ai/setup/criersetup.inc` | Safer crier config handling |
 | `scripts/ai/townperson.src` | Town NPCs now wander immediately after spawn |
+| `scripts/include/NameChecker.inc` | Town-suffix exploit closure, case-insensitive dedupe, bad-spacing rejection, caching |
 | `scripts/include/anchors.inc` | Anchor and lookup helpers updated for new area behavior |
 | `scripts/include/areas.inc` | Area helper rewrite to match the new policy layer |
+| `scripts/include/string.inc` | *(uncommitted)* `SortMultiArrayByIndex` rewritten to O(n log n) merge sort |
 | `scripts/include/townsfolk.inc` | Townfolk helper alignment update |
-| `scripts/textcmd/coun/go.src` | `.go` rebuilt around indexed go locations and range fallback |
+| `scripts/misc/namechanger.src` | `force_town_check := 1`, "bad spacing" error message |
+| `scripts/misc/oncreate.src` | `force_town_check := 1` |
+| `scripts/textcmd/admin/setname.src` | Now runs through `CheckName`, PC-scoped |
+| `scripts/textcmd/coun/go.src` | *(uncommitted)* `ReorderLocationsForDisplay` rewritten to O(n); `.go` also rebuilt around indexed go locations and range fallback (earlier in the patch) |
+| `scripts/textcmd/gm/setprop.src` | `.setprop name` now runs through `CheckName`, PC-scoped |
+| `scripts/textcmd/seer/info.src` | Rename button now runs through `CheckName`, PC-scoped |
 
 ---
 
-## 10. Risk and Regression Notes
+## 15. Risk and Regression Notes
 
 1. `regions/regions.cfg` and `config/golocs_by_id.cfg` are now tightly coupled. Any future region edit should regenerate the go-location index rather than hand-editing the generated file.
-2. The new area policy cache uses global properties and a line-count fingerprint. If `areas.cfg` changes shape, cache invalidation needs to remain intact or stale policy data can persist.
+2. The area-policy caches (parsed-line cache and the new mask-value cache) use global properties and, for the parsed-line cache, a line-count fingerprint. If `areas.cfg` changes shape, cache invalidation needs to remain intact or stale policy data can persist. The mask-value cache is invalidated precisely on `SetPolicyMask`/`PruneStaleRealmPolicies` writes, so it should stay correct as long as no other code path writes the `AREA_POLICY_MASK_PROP` datafile property directly.
 3. Town member removal now touches citizen lists, population, and election or poll state. That makes the new cleanup path more complete, but it also raises the importance of testing member removal against live stones and offline accounts.
 4. `RestartSpawnPointWithMode(...)` can checkpoint repeatedly during max-fill mode. That is intentional, but it means the new region-wide restart command should still be treated as a staff maintenance tool rather than a routine hot command.
+5. `GetKnownTownNames()`'s cache has no automatic invalidation wired to `createtownstone`/region edits yet — a brand-new town's name won't be recognized as a "town name" for the free-name-choice block, nor will its residents' suffixes be stripped for dedupe purposes, until `InvalidateKnownTownNamesCache()` is called or the server restarts. Low practical risk today since new town creation is infrequent and staff-driven, but worth wiring up if that becomes a live pain point.
+6. The town-suffix duplicate-name fixes and the house-placement region checks are both new *rejection* paths in previously-permissive flows — worth a live smoke test on a known player-run town (join/leave/rename) and a known city-adjacent building parcel before this goes fully live, since both change behavior at the boundary rather than just internals.
+7. The blacksmithy and crafter-boost Omega Cache fixes change previously-broken or entirely-missing behavior into working behavior — this is a net-new capability for players (the failure mode was "doesn't work," not "we're removing something"), but should still get a quick live test: hammer-to-cache targeting for a plain ingot craft, bone-armor dual-material with the cache as either material, and a crafter-boost upgrade with the target material sourced from a cache.
+8. The `.go` and shared-sort algorithmic rewrites are drop-in replacements with verified-identical output ordering (hand-traced on a small example for the merge sort; the `.go` reorder was verified against its old semantics directly). Risk is low, but both are hot, frequently-run staff commands, so a live spot check (a `.go` menu with a large realm, and `.gotomulti`/`.gotoboat` with the current multi/boat counts) is still worthwhile.
+9. The potion-categorization fix is UI-only (Omega Cache category grouping) and carries no gameplay risk.

--- a/patchnotes/launchernotes.md
+++ b/patchnotes/launchernotes.md
@@ -13,13 +13,45 @@ Always check Discord announcements for all the patch notes.
 
 ---
 
-## Areas - Castle Boundary Fixes
+## Name Changes - Exploit Closed and Fixes
 
 ### Player Impact
 
-- Area policy data was moved into per-realm datafiles, and the resolver now caches parsed area lines for lower server load.
+- Closed an exploit where a player could end up holding both a plain name (like "Pig") and a town-suffixed version of it ("Pig of Trinsic") at the same time by juggling alt characters while joining and leaving a town.
+- Name matching is now case-insensitive - "Bop", "bop", and "BOP" are treated as the same name and can no longer all exist at once.
+- New characters, and anyone using the rename gump, can no longer pick a name that contains a town name.
+- Fixed a bug that let a name end up with a leading/trailing/double space, which could silently create duplicate-looking character names.
+- Fixed the cause of a reported ~50 second delay and stacked rename gumps when changing your name.
+- Leaving a town with a name that's already taken by someone else no longer traps you - you'll be prompted to pick a new name instead.
+- Staff renaming tools now check names the same way player renames do, so a player can no longer end up with an invalid or duplicate name through a staff tool.
+
+---
+
+## Housing - Placement Restrictions
+
+### Player Impact
+
+- House placement now checks your entire house footprint (not just where you're standing) against city, dungeon, shrine, and graveyard zones, so houses can no longer be placed overlapping those areas.
+
+---
+
+## Areas - Castle Boundary Fixes and Performance
+
+### Player Impact
+
+- Area policy data was moved into per-realm datafiles, and the resolver now caches parsed area lines and policy flags for lower server load.
 - The area map was expanded and refreshed across all realms, including new shrines, dungeon entrances, and many more points of interest.
 - Enter and leave text was updated alongside the area data, and the Lord British Castle and Lord Blackthornes Castle boundaries were corrected as part of that refresh.
+
+---
+
+## Crafting - Omega Cache Fixes
+
+### Player Impact
+
+- The smithy hammer can now correctly pull ingots (and bone, for bone armor) directly from your Omega Cache - this was supposed to work before but was broken.
+- The smithy retort (used to craft crafting-power upgrades) can now also pull materials from your Omega Cache if you run out in your backpack.
+- Fixed several leveled Strength and Cure Potions (and their Greater versions) showing up under "Other" in the Omega Cache instead of "Potions."
 
 ---
 
@@ -29,7 +61,6 @@ Always check Discord announcements for all the patch notes.
 
 - Remove Curse now only accepts cursed weapons and armor as valid targets.
 - Paladins now use a magery and magic resistance formula for the success chance instead of the older item-identification-only approach.
-- The curse removal success and failure messaging is unchanged.
 
 ---
 
@@ -47,7 +78,6 @@ Always check Discord announcements for all the patch notes.
 ### Player Impact
 
 - Skill gain now correctly checks your base skill when worn gear pushes your effective skill to the cap, so skill-boosting items no longer block advancement.
-- This fixes the edge case where capped effective skill could prevent gains even though your underlying skill still had room to improve.
 
 ---
 
@@ -56,7 +86,14 @@ Always check Discord announcements for all the patch notes.
 ### Player Impact
 
 - Town NPCs and nobles now begin wandering immediately after spawn instead of waiting for their first movement cycle.
-- This reduces the chance of freshly spawned town NPCs appearing idle.
+
+---
+
+## Performance
+
+### Player Impact
+
+- Fixed two commands that were heavy enough to occasionally slow the server - no player-facing behavior change, just faster and lighter on the server.
 
 ---
 
@@ -65,27 +102,23 @@ Always check Discord announcements for all the patch notes.
 ### Player Impact
 
 - No direct gameplay change expected for regular players.
-- Staff tools were updated for area policy management, go-location browsing, spawnpoint restarts, town member cleanup, and related command synopsis coverage.
-
----
-
-## Maintenance and Data Updates
-
-### Player Impact
-
-- No direct gameplay change expected.
-- Support data and scripts were refreshed for the new area and go-location workflow, and the backup script path was updated.
+- Staff tools were updated for area policy management, go-location browsing, spawnpoint restarts, town member cleanup, and related command coverage.
 
 ---
 
 ## Summary
 
 - Townstone status and membership handling were expanded.
+- A town-suffix name-collision exploit was closed, and several related naming bugs were fixed.
+- House placement now respects city, dungeon, shrine, and graveyard boundaries.
 - Lord British Castle and Blackthornes area boundaries were corrected.
+- The smithy hammer and smithy retort now correctly use the Omega Cache.
+- A handful of leveled potions were moved into the correct Omega Cache category.
 - Remove Curse now uses a better success formula and valid target filter.
 - Protection effects now last longer.
 - Skill gain handling was retuned for higher-skill edge cases.
 - Town NPCs start wandering immediately after spawning.
+- Two hot commands were made significantly faster.
 - Staff support commands and data generators were refreshed.
 
 Thanks for playing Zuluhotel Omega 2.5.

--- a/patchnotes/patch-v1.0.8.md
+++ b/patchnotes/patch-v1.0.8.md
@@ -1,10 +1,10 @@
 # Patch Notes - v1.0.8
 **Zuluhotel Omega 2.5 | Live Shard**  
-**Date: July 20, 2026**
+**Date: July 23, 2026**
 
 ---
 
-Welcome to **Patch 1.0.8**. This update focuses on **player-run town administration**, **area-policy fixes**, **town NPC cleanup**, and a set of support-side script and balance updates.
+Welcome to **Patch 1.0.8**. This update focuses on **player-run town administration**, **area-policy fixes**, **name-change exploit closure**, **house placement rules**, **crafting/Omega Cache fixes**, and a set of support-side script, performance, and balance updates.
 
 ---
 
@@ -20,13 +20,46 @@ Welcome to **Patch 1.0.8**. This update focuses on **player-run town administrat
 
 ---
 
-## Areas - Castle Boundary Fixes
+## Name Changes - Exploit Closed and Fixes
 
 ### Player Impact
 
-- Area policy data was moved into per-realm datafiles, and the resolver now caches parsed area lines for lower server load.
+- Closed an exploit where a player could end up holding both a plain name (like "Pig") and a town-suffixed version of it ("Pig of Trinsic") at the same time by juggling alt characters while joining and leaving a town.
+- Name matching is now case-insensitive — "Bop", "bop", and "BOP" are treated as the same name and can no longer all exist at once.
+- New characters, and anyone using the rename gump, can no longer pick a name that contains a town name.
+- Fixed a bug that let a name end up with a leading/trailing/double space, which could silently create duplicate-looking character names.
+- Fixed the cause of a reported ~50 second delay and stacked rename gumps when changing your name.
+- Leaving a town with a name that's already taken by someone else no longer traps you — you'll be prompted to pick a new name instead.
+- Staff renaming tools (`.setname`, `.setprop name`, and the rename button in `.info`) now check names the same way player renames do, so a player can no longer end up with an invalid or duplicate name through a staff tool. This does not affect NPC renaming.
+
+---
+
+## Housing - Placement Restrictions
+
+### Player Impact
+
+- House placement now checks your entire house footprint (not just where you're standing) against city, dungeon, shrine, and graveyard zones, so houses can no longer be placed overlapping those areas.
+
+---
+
+## Areas - Castle Boundary Fixes and Performance
+
+### Player Impact
+
+- Area policy data was moved into per-realm datafiles, and the resolver now caches parsed area lines and policy flags for lower server load.
 - The area map was expanded and refreshed across all realms, including new shrines, dungeon entrances, and many more points of interest.
 - Enter and leave text was updated alongside the area data, and the Lord British Castle and Lord Blackthornes Castle boundaries were corrected as part of that refresh.
+- Fixed a datafile save error that could occur before an area's realm was fully set up.
+
+---
+
+## Crafting - Omega Cache Fixes
+
+### Player Impact
+
+- The smithy hammer can now correctly pull ingots (and bone, for bone armor) directly from your Omega Cache — this was supposed to work before but was broken.
+- The smithy retort (used to craft crafting-power upgrades like Oil, Alloy, Varnish, Compound, and Recharge Powder) can now also pull materials from your Omega Cache if you run out in your backpack.
+- Fixed several leveled Strength and Cure Potions (and their Greater versions) showing up under "Other" in the Omega Cache instead of "Potions."
 
 ---
 
@@ -67,6 +100,14 @@ Welcome to **Patch 1.0.8**. This update focuses on **player-run town administrat
 
 ---
 
+## Performance
+
+### Player Impact
+
+- Fixed two commands (`.go` and the developer house/boat locator tools) that were heavy enough to occasionally trip the server's runaway-script safeguard — no player-facing behavior change, just faster and lighter on the server.
+
+---
+
 ## Staff and Support Tools
 
 ### Player Impact
@@ -88,11 +129,16 @@ Welcome to **Patch 1.0.8**. This update focuses on **player-run town administrat
 ## Summary
 
 - Townstone status and membership handling were expanded.
+- A town-suffix name-collision exploit was closed, and several related naming bugs were fixed.
+- House placement now respects city, dungeon, shrine, and graveyard boundaries.
 - Lord British Castle and Blackthornes area boundaries were corrected.
+- The smithy hammer and smithy retort now correctly use the Omega Cache.
+- A handful of leveled potions were moved into the correct Omega Cache category.
 - Remove Curse now uses a better success formula and valid target filter.
 - Protection effects now last longer.
 - Skill gain handling was retuned for higher-skill edge cases.
 - Town NPCs start wandering immediately after spawning.
+- Two hot commands were made significantly faster.
 - Staff support commands and data generators were refreshed.
 
 Thanks for playing Zuluhotel Omega 2.5.

--- a/pkg/opt/crafterboost/make_crafter_boosts.src
+++ b/pkg/opt/crafterboost/make_crafter_boosts.src
@@ -8,6 +8,8 @@ include "include/classes";
 include "include/autoloop";
 include ":gumps:yesno";
 include "include/math";
+include "include/omegacache_utils";
+include "include/resourcemanager";
 
 const TEXT_COLOR		:= 319;
 const MAT_DIVIDER		:= 3;
@@ -27,71 +29,141 @@ program make_crafter_boosts(character, smithyretort)
 	if( !use_on )
 		SendSysmessage( character, "Canceled" );
 		return 0;
-	elseif( !Accessible( character , use_on ) )
+	endif
+
+	// Handle Omega Cache targeting — no ReserveItem needed (uses leases instead)
+	if(use_on.objtype == OMEGACACHE_OBJTYPE)
+		var cacheRequest := SelectMaterialFromCache(character);
+		if(!cacheRequest)
+			return 0;
+		endif
+		if(!IsUpgradeMaterialObjtype(cacheRequest.objtype))
+			SendSysMessage( character , "You can't make anything with that." );
+			return 0;
+		endif
+		MakeUpgrade(character, cacheRequest, smithyretort);
+		return 0;
+	endif
+
+	if( !Accessible( character , use_on ) )
 		SendSysMessage( character , "You can't reach that." );
 		return 0;
 	elseif( !IsInContainer( character.backpack , use_on ) )
 		SendSysmessage( character, "That item has to be in your backpack." );
 		return 0;
 	endif
-	
+
 	if (IsIngot(use_on) || IsLog(use_on) || IsHide(use_on.objtype) || (use_on.objtype == 0x0F7F) || IsGem2(use_on) )
-		MakeUpgrade(character, use_on, smithyretort);
+		MakeUpgrade(character, MakeBackpackRequest(character, use_on), smithyretort);
 	else
 		SendSysMessage( character , "You can't make anything with that." );
     endif
 
 endprogram
 
-function MakeUpgrade(character, start_material, smithyretort)	
+// True if objtype is a valid starting material for a crafter boost (ingot, log,
+// hide, brimstone, or gem) — used to validate an Omega Cache selection.
+function IsUpgradeMaterialObjtype(objtype)
+	objtype := CInt(objtype);
+	if(IsIngot(ObjtypeStruct(objtype)) || IsLog(ObjtypeStruct(objtype)) || IsHide(objtype) || (objtype == 0x0F7F) || IsGem2(ObjtypeStruct(objtype)))
+		return 1;
+	endif
+	return 0;
+endfunction
+
+// IsIngot/IsLog/IsGem2 only ever read `.objtype` off their argument, so this lets
+// us reuse them against a bare objtype (e.g. from a cache selection) without a real item.
+function ObjtypeStruct(objtype)
+	return struct{ objtype := CInt(objtype) };
+endfunction
+
+// Builds a ResourceRequest for a fixed reagent (Brimstone/Bloodspawn/etc.) that the
+// player never targets directly — backpack-first, falling back to a nearby Omega Cache.
+function MakeReagentRequest(who, objtype)
+	var dataFileHandle := 0;
+	var houseSerial := 0;
+	if(!GetObjProperty(who, "omegacache_no_autodraw"))
+		var access := FindAccessibleContainer(who, array{REMOVE_FROM_SECURE});
+		if(access)
+			dataFileHandle := access.df;
+			if(access.house)
+				houseSerial := access.house.serial;
+			endif
+		endif
+	endif
+
+	return struct{
+		objtype              := CInt(objtype),
+		key                  := 0,
+		color                := 0,
+		quality              := 0,
+		preferredSourceOrder := array{ BACKPACK, OMEGA_CACHE },
+		dataFileHandle       := dataFileHandle,
+		houseSerial          := houseSerial,
+		leaseKey             := 0
+	};
+endfunction
+
+function MakeUpgrade(character, materialRequest, smithyretort)
 	var material_cfg;
 	var skilltype;
 	var mat1_type;
 	var mat1_name;
 	var product_type;
-	var material2 := start_material;
-	if (start_material.objtype == 0x0F7F)
+	var mat2Request := materialRequest;
+	if (materialRequest.objtype == 0x0F7F)
 		SendSysmessage( character, "What would you like to combine that with?" );
-		material2 := Target( character , TGTOPT_CHECK_LOS );
-		if( !material2 )
+		var second_target := Target( character , TGTOPT_CHECK_LOS );
+		if( !second_target )
 			SendSysmessage( character, "Canceled" );
 			return 0;
-		elseif( !Accessible( character , material2 ) )
-			SendSysMessage( character , "You can't reach that." );
-			return 0;
-		elseif( !IsInContainer( character.backpack , material2 ) )
-			SendSysmessage( character, "That item has to be in your backpack." );
-			return 0;
 		endif
-		if (IsIngot(material2))
+
+		if(second_target.objtype == OMEGACACHE_OBJTYPE)
+			mat2Request := SelectMaterialFromCache(character);
+			if(!mat2Request)
+				return 0;
+			endif
+		else
+			if( !Accessible( character , second_target ) )
+				SendSysMessage( character , "You can't reach that." );
+				return 0;
+			elseif( !IsInContainer( character.backpack , second_target ) )
+				SendSysmessage( character, "That item has to be in your backpack." );
+				return 0;
+			endif
+			mat2Request := MakeBackpackRequest(character, second_target);
+		endif
+
+		if (IsIngot(ObjtypeStruct(mat2Request.objtype)))
 			material_cfg := ReadConfigFile( ":blacksmithy:blacksmithy" );
 			skilltype := SKILLID_BLACKSMITHY;
-		elseif(IsLog(material2))
+		elseif(IsLog(ObjtypeStruct(mat2Request.objtype)))
 			material_cfg := ReadConfigFile( ":carpentry:carpentry" );
 			skilltype := SKILLID_TAILORING;
-		elseif(IsHide(material2.objtype))
+		elseif(IsHide(mat2Request.objtype))
 			material_cfg := ReadConfigFile( ":tailoring:tailoring" );
 			skilltype := SKILLID_CARPENTRY;
-		else	
+		else
 			SendSysMessage( character , "You can't make anything with that." );
 			return 0;
 		endif
 		mat1_type := 0x0F7F;
 		mat1_name := "Brimstone";
 		product_type := 0x8B01; //Oil
-	elseif (IsIngot(start_material))
+	elseif (IsIngot(ObjtypeStruct(materialRequest.objtype)))
 		material_cfg := ReadConfigFile( ":blacksmithy:blacksmithy" );
 		skilltype := SKILLID_BLACKSMITHY;
 		mat1_type := 0x0F7C;
 		mat1_name := "Bloodspawn";
 		product_type := 0x8B02; // Alloy
-	elseif(IsLog(start_material))
+	elseif(IsLog(ObjtypeStruct(materialRequest.objtype)))
 		material_cfg := ReadConfigFile( ":carpentry:carpentry" );
 		skilltype := SKILLID_CARPENTRY;
 		mat1_type := 0x0F80;
 		mat1_name := "Daemon Bone";
 		product_type := 0x8B03; // Varnish
-	elseif(IsGem2(start_material))
+	elseif(IsGem2(ObjtypeStruct(materialRequest.objtype)))
 		material_cfg := ReadConfigFile( ":tinkering:tinker" );
 		//material_cfg := ReadConfigFile( ":talisman:config/itemdesc" );
 		skilltype := SKILLID_TINKERING;
@@ -105,7 +177,7 @@ function MakeUpgrade(character, start_material, smithyretort)
 		mat1_name := "Bat Wing";
 		product_type := 0x8B04; // Compound
 	endif
-	var mat2_type := material2.objtype;
+	var mat2_type := CInt(mat2Request.objtype);
 	var material_diff := material_cfg[mat2_type].Difficulty;
 	var mat2_name := material_cfg[mat2_type].Name;
 
@@ -129,11 +201,15 @@ function MakeUpgrade(character, start_material, smithyretort)
 	var final_diff := CInt(item_diff + material_diff/MAT_DIVIDER);
 	var points := CInt((final_diff + mat2_qty)*POINTS_MULTIPLIER);
 	var material_quality := material_cfg[mat2_type].Quality;
-	var char_bkpk := character.backpack;
-	var mat2_color := material2.color;
+	var mat2_color := mat2Request.color;
 	var empty_flask;
+	var mat1Request := MakeReagentRequest(character, mat1_type);
+
+	LeaseResource(character, mat1Request, mat1_qty);
+	LeaseResource(character, mat2Request, mat2_qty);
+
 	AutoLoop_init(character);
-	while(AutoLoop_more() && FindSubstance(char_bkpk, mat2_type, mat2_qty) && FindSubstance(char_bkpk, mat1_type, mat1_qty) && ((product_type != 0x8B05) || FindSubstance(char_bkpk, 0x1832, 1)) && !character.dead)
+	while(AutoLoop_more() && (GetAvailableResource(character, mat2Request).total >= mat2_qty) && (GetAvailableResource(character, mat1Request).total >= mat1_qty) && ((product_type != 0x8B05) || FindObjtypeInContainer(character.backpack, 0x1832)) && !character.dead)
 		sendDiff( character , final_diff );
 
 		PlaySoundEffect(character, SFX_1C9);
@@ -150,28 +226,22 @@ function MakeUpgrade(character, start_material, smithyretort)
 
 		if(CheckSkill(character, skilltype, final_diff, points))
 			if( product_type == 0x8B05 )
-				empty_flask := FindObjtypeInContainer(char_bkpk, 0x1832);
+				empty_flask := FindObjtypeInContainer(character.backpack, 0x1832);
 				if( !empty_flask )
 					SendSysMessage( character , "You need at least 1 empty flask." );
-					return 0;
+					break;
 				endif
 				if( !Accessible( character , empty_flask ) or !empty_flask.movable )
 					SendSysMessage( character , "You can't reach the empty flask." );
-					return 0;
+					break;
 				endif
 				if( !ReserveItem( empty_flask ) )
-					return 0;
+					break;
 				endif
 			endif
 
-			if (!ConsumeSubstance( char_bkpk, mat1_type, mat1_qty ))
-				SendSysMessage( character , "Something went wrong when consuming the"+mat1_name+".");
-				return 0;
-			endif
-			if (!ConsumeSubstance( char_bkpk, mat2_type, mat2_qty ))
-				SendSysMessage( character , "Something went wrong when consuming the"+mat2_name+".");
-				return 0;
-			endif
+			ConsumeResource( character, mat1Request, mat1_qty );
+			ConsumeResource( character, mat2Request, mat2_qty );
 			if( product_type == 0x8B05 )
 				SubtractAmount( empty_flask, 1 );
 			endif
@@ -258,22 +328,29 @@ function MakeUpgrade(character, start_material, smithyretort)
 			var destroy1 := CInt( mat1_qty * destroy/100 );
 			var destroy2 := CInt( mat2_qty * destroy/100 );
 
-			ConsumeSubstance( char_bkpk, mat1_type, destroy1 );
-			ConsumeSubstance( char_bkpk, mat2_type, destroy2 );
+			ConsumeResource( character, mat1Request, destroy1 );
+			ConsumeResource( character, mat2Request, destroy2 );
 			SendSysmessage( character , "You destroyed " + destroy1 + " " + mat1_name + "." );
 			SendSysmessage( character , "You destroyed " + destroy2 + " " + mat2_name + "." );
 		endif
+
+		// Extend leases for next iteration
+		if(!ExtendResourceLease(mat1Request, character, mat1_qty) or !ExtendResourceLease(mat2Request, character, mat2_qty))
+			break;
+		endif
 	endwhile
+	ReleaseResourceLease(mat1Request);
+	ReleaseResourceLease(mat2Request);
 	AutoLoop_finish();
-	if (!FindSubstance(char_bkpk, mat1_type, mat1_qty) || !FindSubstance(char_bkpk, mat2_type, mat2_qty))
-		if (!FindSubstance(char_bkpk, mat2_type, mat2_qty))
+	if (GetAvailableResource(character, mat1Request).total < mat1_qty || GetAvailableResource(character, mat2Request).total < mat2_qty)
+		if (GetAvailableResource(character, mat2Request).total < mat2_qty)
 			SendSysMessage( character , "You need at least "+mat2_qty+" "+mat2_name+"." );
 		endif
-		if (!FindSubstance(char_bkpk, mat1_type, mat1_qty))
+		if (GetAvailableResource(character, mat1Request).total < mat1_qty)
 			SendSysMessage( character , "You need at least "+mat1_qty+" "+mat1_name+"." );
 		endif
 	endif
-	if( product_type == 0x8B05 and !FindSubstance(char_bkpk, 0x1832, 1) )
+	if( product_type == 0x8B05 and !FindObjtypeInContainer(character.backpack, 0x1832) )
 		SendSysMessage( character , "You need at least 1 empty flask." );
 	endif
 endfunction

--- a/pkg/opt/omegacache/categories.cfg
+++ b/pkg/opt/omegacache/categories.cfg
@@ -584,6 +584,22 @@ Category Potions
 	0xFF3E	1
 	0xFF3F	1
 	0xFF40	1
+	// Strength Potion [Level 2]
+	0xFF41	1
+	// Greater Strength Potion [Level 1-3]
+	0xFF42	1
+	0xFF43	1
+	0xFF44	1
+	// Cure Potion [Level 1-3]
+	0xFF45	1
+	0xFF46	1
+	0xFF47	1
+	// Greater Cure Potion [Level 1-5]
+	0xFF48	1
+	0xFF49	1
+	0xFF4A	1
+	0xFF4B	1
+	0xFF4C	1
 	// AlchemyPlus potions (0xFF4E-0xFF95, 0xFFA2)
 	0xFF4E	1
 	0xFF4F	1

--- a/pkg/std/blacksmithy/make_blacksmith_items.src
+++ b/pkg/std/blacksmithy/make_blacksmith_items.src
@@ -65,6 +65,38 @@ program use_hammer( character, hammer )
 		return;
 	endif
 
+	// Handle Omega Cache targeting — no ReserveItem needed (uses leases instead)
+	if(use_on.objtype == OMEGACACHE_OBJTYPE)
+		var resourceRequest := SelectMaterialFromCache(character);
+		if(!resourceRequest)
+			return;
+		endif
+
+		// Determine if the selected material is bone or ingot
+		if(IsBoneObjtype(resourceRequest.objtype))
+			// Bone selected from cache — need ingots too
+			SendSysMessage(character, "What ingots would you like to use?");
+			var ingotRequest := ResolveIngotTarget(character);
+			if(!ingotRequest)
+				return;
+			endif
+			if(!NearAnvil(character))
+				SendSysmessage(character, "You must be near an anvil to smith items!");
+				return;
+			endif
+			MakeBoneItems(character, ingotRequest, resourceRequest);
+		elseif(IsIngotObjtype(resourceRequest.objtype))
+			if(!NearAnvil(character))
+				SendSysmessage(character, "You must be near an anvil to smith items!");
+				return;
+			endif
+			MakeBlacksmithItems(character, resourceRequest);
+		else
+			SendSysMessage(character, "You don't know how to use that.");
+		endif
+		return;
+	endif
+
 	if( !Accessible( character , use_on ) )
 		SendSysMessage( character , "You can't reach that." );
 		return;
@@ -75,189 +107,88 @@ program use_hammer( character, hammer )
 	endif
 
 	if( smith_cfg[use_on.graphic] && use_on.hp && use_on.quality)
-		var near := ListItemsNearLocation( character.x , character.y , character.z , 1 );
- 		foreach thing in near
-	  		if ((thing.objtype == UOBJ_ANVIL1) or (thing.objtype == UOBJ_ANVIL2))
-	   			repair_item( character, use_on, SKILLID_BLACKSMITHY );
-	   			return;
-	  		endif
- 		endforeach
-		SendSysmessage( character , "You must be near an anvil to repair items!" );
+		if(NearAnvil(character))
+			repair_item( character, use_on, SKILLID_BLACKSMITHY );
+		else
+			SendSysmessage( character , "You must be near an anvil to repair items!" );
+		endif
 		return;
-
 	endif
-	
+
 	if( !IsInContainer( character.backpack , use_on ) )
 		SendSysmessage( character, "That item has to be in your backpack." );
 		return;
 	endif
 
- 	if (IsBone(use_on))
+	if (IsBone(use_on))
 		SendSysMessage( character, "What ingots would you like to use?" );
-		var bone := use_on;
-		use_on := Target( character, TGTOPT_CHECK_LOS );
-		
-		if( !use_on )
+		var boneRequest := MakeBackpackRequest(character, use_on);
+		var ingotRequest := ResolveIngotTarget(character);
+		if(!ingotRequest)
 			return;
 		endif
-
-		if( !Accessible( character , use_on ) )
-			SendSysMessage( character , "You can't reach that." );
-			return;
-		endif
-
-		if( !ReserveItem(use_on) )
-			return;
-		endif
-	// Repair path — requires ReserveItem
-	if(use_on.objtype != OMEGACACHE_OBJTYPE)
-		if( !ReserveItem(use_on) )
-			return;
-		endif
-
-		if( smith_cfg[use_on.graphic] && use_on.hp && use_on.quality)
-			var near := ListItemsNearLocation( character.x , character.y , character.z , 1 );
-			foreach thing in near
-				if ((thing.objtype == UOBJ_ANVIL1) or (thing.objtype == UOBJ_ANVIL2))
-					repair_item( character, use_on, SKILLID_BLACKSMITHY );
-					return;
-				endif
-			endforeach
-			SendSysmessage( character , "You must be near an anvil to repair items!" );
-			return;
-		endif
-	endif
-
-	// Handle Omega Cache targeting — no ReserveItem needed (uses leases instead)
-	if(use_on.objtype == OMEGACACHE_OBJTYPE)
-		var resourceRequest := SelectMaterialFromCache(character);
-		if(!resourceRequest)
-			return;
-		endif
-		// Determine if the selected material is bone or ingot
-		if(IsBoneObjtype(resourceRequest.objtype))
-			// Bone selected from cache — need ingots too
-			SendSysMessage(character, "What ingots would you like to use?");
-			var ingot_target := Target(character, TGTOPT_CHECK_LOS);
-			if(!ingot_target)
-				return;
-			endif
-			var ingotRequest;
-			if(ingot_target.objtype == OMEGACACHE_OBJTYPE)
-				ingotRequest := SelectMaterialFromCache(character);
-				if(!ingotRequest)
-					return;
-				endif
-			elseif(IsIngot(ingot_target))
-				if(!IsInContainer(character.backpack, ingot_target))
-					SendSysmessage(character, "That item has to be in your backpack.");
-					return;
-				endif
-				ingotRequest := MakeBackpackRequest(character, ingot_target);
-			else
-				SendSysMessage(character, "You must select ingots!");
-				return;
-			endif
-			var Near_Items := ListItemsNearLocation(character.x, character.y, character.z, 1);
-			foreach item in Near_Items
-				if(item.objtype == UOBJ_ANVIL1 or item.objtype == UOBJ_ANVIL2)
-					MakeBoneItems(character, ingotRequest, resourceRequest);
-					return;
-				endif
-			endforeach
+		if(!NearAnvil(character))
 			SendSysmessage(character, "You must be near an anvil to smith items!");
-		elseif(IsIngotObjtype(resourceRequest.objtype))
-			var Near_Items := ListItemsNearLocation(character.x, character.y, character.z, 1);
-			foreach item in Near_Items
-				if(item.objtype == UOBJ_ANVIL1 or item.objtype == UOBJ_ANVIL2)
-					MakeBlacksmithItems(character, resourceRequest);
-					return;
-				endif
-			endforeach
-			SendSysmessage(character, "You must be near an anvil to smith items!");
-		else
-			SendSysMessage(character, "You don't know how to use that.");
-		endif
-		return;
-	endif
-
-		if( !IsInContainer( character.backpack , use_on ) )
-			SendSysmessage( character, "That item has to be in your backpack." );
 			return;
 		endif
-
-		if ( !IsIngot(use_on) )
-			SendSysMessage( character, "You must select ingots!" );
-			return;
-		endif
-			var Near_Items := ListItemsNearLocation( character.x , character.y , character.z , 1 );
-		foreach item in Near_Items
-			if ((item.objtype == UOBJ_ANVIL1) or (item.objtype == UOBJ_ANVIL2))
-				MakeBoneItems( character , use_on , bone );
-				return;
-			endif
-		endforeach
-
-		SendSysmessage( character , "You must be near an anvil to smith items!" );
-	endif
-	if(IsBone(use_on))
-		SendSysMessage(character, "What ingots would you like to use?");
-		var bone := use_on;
-		var boneRequest := MakeBackpackRequest(character, bone);
-		use_on := Target(character, TGTOPT_CHECK_LOS);
-
-		if(!use_on)
-			return;
-		endif
-
-		var ingotRequest;
-		if(use_on.objtype == OMEGACACHE_OBJTYPE)
-			ingotRequest := SelectMaterialFromCache(character);
-			if(!ingotRequest)
-				return;
-			endif
-		else
-			if(!Accessible(character, use_on))
-				SendSysMessage(character, "You can't reach that.");
-				return;
-			endif
-			if(!ReserveItem(use_on))
-				return;
-			endif
-			if(!IsInContainer(character.backpack, use_on))
-				SendSysmessage(character, "That item has to be in your backpack.");
-				return;
-			endif
-			if(!IsIngot(use_on))
-				SendSysMessage(character, "You must select ingots!");
-				return;
-			endif
-			ingotRequest := MakeBackpackRequest(character, use_on);
-		endif
-
-		var Near_Items := ListItemsNearLocation(character.x, character.y, character.z, 1);
-		foreach item in Near_Items
-			if(item.objtype == UOBJ_ANVIL1 or item.objtype == UOBJ_ANVIL2)
-				MakeBoneItems(character, ingotRequest, boneRequest);
-				return;
-			endif
-		endforeach
-		SendSysmessage(character, "You must be near an anvil to smith items!");
+		MakeBoneItems(character, ingotRequest, boneRequest);
 	elseif(IsIngot(use_on))
 		var ingotRequest := MakeBackpackRequest(character, use_on);
-		var Near_Items := ListItemsNearLocation(character.x, character.y, character.z, 1);
-		foreach item in Near_Items
-			if(item.objtype == UOBJ_ANVIL1 or item.objtype == UOBJ_ANVIL2)
-				MakeBlacksmithItems(character, ingotRequest);
-				return;
-			endif
-		endforeach
-		SendSysmessage(character, "You must be near an anvil to smith items!");
+		if(!NearAnvil(character))
+			SendSysmessage(character, "You must be near an anvil to smith items!");
+			return;
+		endif
+		MakeBlacksmithItems(character, ingotRequest);
 	else
-		SendSysMessage(character, "You don't know how to use that.");
+		SendSysMessage( character, "You don't know how to use that." );
 	endif
 
 endprogram
+
+// True if character is standing next to an anvil.
+function NearAnvil(character)
+	var near := ListItemsNearLocation( character.x , character.y , character.z , 1 );
+	foreach thing in near
+		if ((thing.objtype == UOBJ_ANVIL1) or (thing.objtype == UOBJ_ANVIL2))
+			return 1;
+		endif
+	endforeach
+	return 0;
+endfunction
+
+// Prompts for and resolves the ingot half of a dual-material (bone armor) craft.
+// Accepts either a backpack ingot stack or the Omega Cache. Returns 0 on cancel/failure.
+function ResolveIngotTarget(character)
+	var ingot_target := Target(character, TGTOPT_CHECK_LOS);
+	if(!ingot_target)
+		return 0;
+	endif
+
+	if(ingot_target.objtype == OMEGACACHE_OBJTYPE)
+		return SelectMaterialFromCache(character);
+	endif
+
+	if(!Accessible(character, ingot_target))
+		SendSysMessage(character, "You can't reach that.");
+		return 0;
+	endif
+
+	if(!ReserveItem(ingot_target))
+		return 0;
+	endif
+
+	if(!IsInContainer(character.backpack, ingot_target))
+		SendSysmessage(character, "That item has to be in your backpack.");
+		return 0;
+	endif
+
+	if(!IsIngot(ingot_target))
+		SendSysMessage(character, "You must select ingots!");
+		return 0;
+	endif
+
+	return MakeBackpackRequest(character, ingot_target);
+endfunction
 
 function MakeBlacksmithItems( character, ingotRequest )
 

--- a/scripts/include/string.inc
+++ b/scripts/include/string.inc
@@ -162,6 +162,11 @@ endfunction
 // is, the 'y' member. Returns '0' if the SubIndex is invalid
 // (only checks against the first index)
 
+// Rewritten (2026) from an O(n^2) nested-loop selection sort to an iterative
+// bottom-up merge sort - O(n log n). The old version was heavy enough at a
+// few hundred elements to risk tripping the runaway-script watchdog for any
+// caller sorting a shard-wide collection (houses, boats, etc). Same ascending
+// order by SubIndex as before.
 function SortMultiArrayByIndex(MultiArray, SubIndex)
 
 	var ArrayLen := Len(MultiArray);
@@ -173,21 +178,71 @@ function SortMultiArrayByIndex(MultiArray, SubIndex)
 		return 0;
 	endif
 
-	var i, k, f, s;
-	for(i := 1; i < ArrayLen; i := i + 1)
-		for( k := i+1; k <= ArrayLen; k := k + 1)
-			f := MultiArray[i];
-			s := MultiArray[k];
-			if ( s[SubIndex] < f[SubIndex] )
-				MultiArray[i] := s;
-				MultiArray[k] := f;
+	var width := 1;
+	while ( width < ArrayLen )
+		var i := 1;
+		while ( i <= ArrayLen )
+			var mid := i + width - 1;
+			if ( mid > ArrayLen )
+				mid := ArrayLen;
 			endif
-		endfor
-		//sleepms(2);
-	endfor
+			var high := i + (2 * width) - 1;
+			if ( high > ArrayLen )
+				high := ArrayLen;
+			endif
+			MultiArray := MergeRunsByIndex(MultiArray, i, mid, high, SubIndex);
+			i := i + (2 * width);
+		endwhile
+		width := width * 2;
+	endwhile
 
 	return MultiArray;
 
+endfunction
+
+function MergeRunsByIndex(MultiArray, low, mid, high, SubIndex)
+	if ( mid >= high )
+		return MultiArray;
+	endif
+
+	var left := array;
+	var i;
+	for(i := low; i <= mid; i := i + 1)
+		left.append(MultiArray[i]);
+	endfor
+
+	var right := array;
+	for(i := mid + 1; i <= high; i := i + 1)
+		right.append(MultiArray[i]);
+	endfor
+
+	var li := 1;
+	var ri := 1;
+	var write_idx := low;
+	while ( li <= left.size() && ri <= right.size() )
+		if ( right[ri][SubIndex] < left[li][SubIndex] )
+			MultiArray[write_idx] := right[ri];
+			ri := ri + 1;
+		else
+			MultiArray[write_idx] := left[li];
+			li := li + 1;
+		endif
+		write_idx := write_idx + 1;
+	endwhile
+
+	while ( li <= left.size() )
+		MultiArray[write_idx] := left[li];
+		li := li + 1;
+		write_idx := write_idx + 1;
+	endwhile
+
+	while ( ri <= right.size() )
+		MultiArray[write_idx] := right[ri];
+		ri := ri + 1;
+		write_idx := write_idx + 1;
+	endwhile
+
+	return MultiArray;
 endfunction
 
 

--- a/scripts/textcmd/coun/go.src
+++ b/scripts/textcmd/coun/go.src
@@ -185,47 +185,74 @@ function SelectDestinationGump( who, locs )
   return GFSendGump(who, gump);
 endfunction
 
+// Groups locs by type in priority order (Jail/City/Shrine/Graveyard/Dungeon/
+// POI/None), then appends anything with a custom/unrecognized RegionType
+// label last - same output as before, but a single O(n) pass instead of the
+// old 8-pass approach that re-scanned the growing "ordered" list for every
+// entry (O(n^2)*8). With ~200 go-locations just for Britannia, that old
+// version was heavy enough to occasionally trip the runaway-script watchdog.
 function ReorderLocationsForDisplay( locs )
+  var type_priority := {"Jail", "City", "Shrine", "Graveyard", "Dungeon", "POI", "None"};
+  var known_types := dictionary;
+  foreach wanted_type in type_priority
+    known_types.Insert(wanted_type, 1);
+  endforeach
+
+  // Single pass: dedupe (same Id, or same Name+X+Y+Z+R) and bucket by type.
+  var type_buckets := dictionary;
+  var seen := dictionary;
+
+  foreach entry in locs
+    var dedupe_key := LocationDedupeKey(entry);
+    if (seen.Exists(dedupe_key))
+      continue;
+    endif
+    seen.Insert(dedupe_key, 1);
+
+    var label := GetLocationTypeLabel(entry);
+    var bucket := type_buckets[label];
+    if (!bucket)
+      bucket := {};
+    endif
+    bucket.append(entry);
+    type_buckets[label] := bucket;
+  endforeach
+
   var ordered := {};
 
-  ordered := AppendLocationsByType(ordered, locs, "Jail");
-  ordered := AppendLocationsByType(ordered, locs, "City");
-  ordered := AppendLocationsByType(ordered, locs, "Shrine");
-  ordered := AppendLocationsByType(ordered, locs, "Graveyard");
-  ordered := AppendLocationsByType(ordered, locs, "Dungeon");
-  ordered := AppendLocationsByType(ordered, locs, "POI");
-  ordered := AppendLocationsByType(ordered, locs, "None");
-
-  foreach entry in locs
-    if(!LocationAlreadyAdded(ordered, entry))
-      ordered.append(entry);
+  // Known types first, in priority order, each bucket in original encounter order.
+  foreach wanted_type in type_priority
+    var bucket := type_buckets[wanted_type];
+    if (bucket)
+      foreach entry in bucket
+        ordered.append(entry);
+      endforeach
     endif
   endforeach
 
-  return ordered;
-endfunction
-
-function AppendLocationsByType( ordered, locs, wanted_type )
+  // Anything with a custom RegionType label goes last. Re-walk locs (still
+  // O(n)) rather than flatten type_buckets directly, since dictionary key
+  // order isn't guaranteed to match original encounter order.
+  var emitted := dictionary;
   foreach entry in locs
-    if(GetLocationTypeLabel(entry) == wanted_type && !LocationAlreadyAdded(ordered, entry))
-      ordered.append(entry);
-    endif
-  endforeach
-
-  return ordered;
-endfunction
-
-function LocationAlreadyAdded( ordered, candidate )
-  foreach entry in ordered
-    if(entry.Id && candidate.Id)
-      if(entry.Id == candidate.Id)
-        return 1;
+    var label := GetLocationTypeLabel(entry);
+    if (!known_types.Exists(label))
+      var dedupe_key := LocationDedupeKey(entry);
+      if (seen.Exists(dedupe_key) && !emitted.Exists(dedupe_key))
+        ordered.append(entry);
+        emitted.Insert(dedupe_key, 1);
       endif
-    elseif(entry.Name == candidate.Name && entry.X == candidate.X && entry.Y == candidate.Y && entry.Z == candidate.Z && entry.R == candidate.R)
-      return 1;
     endif
   endforeach
-  return 0;
+
+  return ordered;
+endfunction
+
+function LocationDedupeKey( loc )
+  if (loc.Id)
+    return "id:" + CStr(loc.Id);
+  endif
+  return "xy:" + CStr(loc.Name) + ":" + CStr(loc.X) + ":" + CStr(loc.Y) + ":" + CStr(loc.Z) + ":" + CStr(loc.R);
 endfunction
 
 function GetLocationTypeLabel( loc )


### PR DESCRIPTION
# Developer Changelog - v1.0.8
**Range:** `9f8189f` (origin/Patch-1.0.7) -> `HEAD` + uncommitted working tree  
**Branch:** Patch-1.0.8  
**Date:** 2026-06-20 -> 2026-07-23  
**Commits in range:** 7 (excluding merge commits), plus uncommitted working-tree changes  
**Files changed:** 48 committed (+10477 / -1316), plus 5 files with uncommitted changes (+343 / -237)

---

## Table of Contents

1. [Scope Summary](#1-scope-summary)
2. [Commit Timeline](#2-commit-timeline)
3. [Townstones - Player-Run Town Administration and Membership Cleanup](#3-townstones---player-run-town-administration-and-membership-cleanup)
4. [Areas - Policy Engine Rewrite, Realm Sanitization, and Mask-Value Cache](#4-areas---policy-engine-rewrite-realm-sanitization-and-mask-value-cache)
5. [Go Locations - Indexed Config Generation and Range Fallback](#5-go-locations---indexed-config-generation-and-range-fallback)
6. [Spawnpoint - Restart Helpers and Region-Wide Reset Commands](#6-spawnpoint---restart-helpers-and-region-wide-reset-commands)
7. [Housing - Region-Based Placement Restrictions](#7-housing---region-based-placement-restrictions)
8. [Naming and Identity - Town-Suffix Exploit Closure and Validation Hardening](#8-naming-and-identity---town-suffix-exploit-closure-and-validation-hardening)
9. [Performance - Shutdown Time and Hot-Path Algorithm Fixes](#9-performance---shutdown-time-and-hot-path-algorithm-fixes)
10. [Crafting - Omega Cache Integration Fixes](#10-crafting---omega-cache-integration-fixes)
11. [Omega Cache - Potion Categorization Fix](#11-omega-cache---potion-categorization-fix)
12. [Gameplay Tuning and Script Fixes](#12-gameplay-tuning-and-script-fixes)
13. [Support Data and Tooling](#13-support-data-and-tooling)
14. [Exhaustive File-by-File Change List](#14-exhaustive-file-by-file-change-list)
15. [Risk and Regression Notes](#15-risk-and-regression-notes)

---

## 1. Scope Summary

Patch 1.0.8 grew across two work windows. The first (through `a3c99f6`) was dominated by the datafile-backed area policy rewrite, the go-location indexing pass, and the player-run townstone/admin cleanup — see sections 3, 5, and 6 for that material, carried forward unchanged from the earlier draft of this document.

The second window (`7bdc099` through the current uncommitted state) closed a live-reported name-collision exploit, fixed a duplicate-character bug it was related to, added region-based house placement restrictions, fixed a real performance regression in the areas package and in two hot commands, and completed Omega Cache integration for two crafting scripts that had been missed or left broken during the original cache rollout:

- A town-suffix name-collision exploit was closed: players could no longer hold both "X" and "X of Town" at once, town names are now blocked in freely-chosen names, and name comparisons are case-insensitive.
- A live 50-second rename-gump hang, and a resulting duplicate-character bug ("two Paladin Rahl of Occlo"), were root-caused to an O(accounts x 5) full `regions.cfg` re-parse per name check, and fixed with a proper cache.
- Staff rename paths (`.setprop name`, `.setname`, `.info`'s rename button) now run through the same name validation as player-initiated renames, scoped to player characters only.
- House placement now blocks city, dungeon, shrine, and graveyard regions by footprint (not just a single point check), replacing an older, narrower check.
- The area-policy mask lookup (`GetPolicyMask`) is now cached; it was previously hitting the datafile subsystem on every single area-policy check, including every AI tick for every mobile shard-wide.
- Two independent O(n^2) algorithms (`.go`'s location-reorder pass, and a shared multi-array sort used by `.gotomulti`/`.gotoboat`) were replaced with linear/O(n log n) equivalents after script-log evidence showed both tripping the runaway-script watchdog.
- The smithy hammer's Omega Cache targeting path was found to be dead code due to a bad merge and was rewritten to match every other crafting script's pattern; the crafter-boost smithy retort had never been integrated with the cache at all and now is.
- A gap in the Omega Cache's category map left 12 leveled potion objtypes (Greater Strength/Cure Potion tiers, etc.) falling into the "Other" bucket instead of "Potions."

---

## 2. Commit Timeline

| Commit | Date | Message |
|--------|------|---------|
| `32a2b3a` | 2026-06-20 | backup script path restore |
| `dbfbe79` | 2026-07-20 | Areas fix for lord british castle and blackthornes |
| `a3c99f6` | 2026-07-20 | Bunch of patches for player run towns |
| `7bdc099` | 2026-07-20 | Patch Notes and save datafile error |
| `065ed28` | 2026-07-20 | House placement not allowed in cities |
| `21bb91e` | 2026-07-23 | Name Change update |
| `09bf876` | 2026-07-23 | Areas Fix, and naming fixes |
| *(uncommitted)* | 2026-07-23 | Blacksmithy/crafter-boost Omega Cache fixes, potion categorization fix, `.go`/sort-helper performance fixes |

---

## 3. Townstones - Player-Run Town Administration and Membership Cleanup

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/townstones/textcmd/admin/createtownstone.src` | Creation flow tightened around existing live stones, townlist insertion, and state restoration from the datafile |
| `pkg/opt/townstones/textcmd/admin/removetownmember.src` | New targeted town-member removal command with election and poll cleanup plus datafile sync |
| `pkg/opt/townstones/textcmd/admin/townbankstatus.src` | Large admin gump expansion for treasury, upgrades, donations, availability, purchase state, member management, and deletion |

### Notable Functional Changes

- `townbankstatus` now surfaces and mutates more live town state:
  - treasury gold,
  - population,
  - upgrades enabled or disabled,
  - donations enabled or disabled,
  - player-town availability,
  - player-town purchased state,
  - purchase price,
  - townstone presence,
  - and region deletion when safe.
- Member management now removes citizens more carefully:
  - account membership is removed from the stone's citizen list,
  - per-character `town` properties are cleared,
  - town suffixes are stripped from character names,
  - population and vote counts are refreshed,
  - elections and polls are cleaned up if the removed member was involved.
- `removetownmember` is a direct targeted cleanup path for staff workflows.
- `createtownstone` now checks for active and live conflicts more aggressively before creating a new stone.
- Townstone state sync now persists the current stone serial, mayor data, population, election flags, poll flags, candidate list, vote totals, vote percentage, timer, and citizen list back into the datafile.

---

## 4. Areas - Policy Engine Rewrite, Realm Sanitization, and Mask-Value Cache

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/areas/include/areapolicy.inc` | New datafile-backed policy engine, parsed-line cache, global bypass masks, realm-name sanitization, and a mask-value cache |
| `pkg/opt/areas/include/areapolicy.inc.bak` | Backup copy of the pre-rewrite policy implementation |
| `pkg/opt/areas/textcmd/admin/areas.src` | Rewritten `.areas` admin gump for viewing and toggling area policy flags |
| `pkg/opt/areas/EnterAreaDelay.src` | Updated to use the new policy resolver path |
| `pkg/opt/areas/LeaveArea.src` | Updated to use the new policy resolver path |
| `pkg/opt/areas/areaban.src` | Updated to use the new policy resolver path |
| `pkg/opt/areas/areas.cfg` | Area definitions refreshed, including the Lord British Castle and Lord Blackthornes Castle fix |
| `scripts/include/areas.inc` | Shared area helpers updated for the new resolver model |
| `scripts/include/anchors.inc` | Anchor and lookup helpers updated to cooperate with the new area model |

### Notable Functional Changes

- The area policy layer now lives in a dedicated resolver backed by per-realm datafiles:
  - masks are stored per area id,
  - a world-catchall bypass mask is OR-merged from known global ids (`feluccawholeworld`, `wholeworld`, `britannia`, `trammelwholeworld`) — confirmed still a one-directional OR merge, so a whole-realm flag (e.g. setting Felucca or Britannia to RP) can force a policy bit on everywhere in that realm, but an individual area still can't opt back out of it since OR can't clear a bit,
  - parsed area lines are cached both per program and in a global property,
  - cache invalidation is fingerprinted by source line count.
- The admin `.areas` workflow now works as a single gump-driven editor for common policy flags such as guarded, no recall, no marking, anti-magic, forbidden, no looting, safe-area, no-PK, and RP-area behavior.
- `areas.cfg` includes the specific Lord British Castle and Lord Blackthornes Castle boundary fix from `dbfbe79`.
- The hot-path area checks now resolve through the new policy layer instead of repeatedly re-parsing config lines.
- **Realm-name sanitization (`7bdc099`):** every realm-taking function in `areapolicy.inc` (`GetRealmAreaLines`, `GetParsedRealmAreaLines`, `ResolveAreaMatchAtLocation`, `ResolvePolicyAtLocation`, `GetGlobalBypassMask`, `GetRealmPolicyDescriptor`) previously did a bare `Lower(CStr(realm))`. A new `SanitizePolicyRealm(realm)` now falls back to `"britannia"` whenever the incoming realm is blank or the literal string `"<uninitialized object>"`, fixing a datafile-save error that occurred when a realm value hadn't been initialized yet.
- **Mask-value cache (`09bf876`):** `GetPolicyMask(realm, area_id)` was hitting the datafile subsystem (`OpenDataFile` + `FindElement` + `GetProp`) on every single area-policy check, and `GetGlobalBypassMask()` calls it 4 more times per resolve for the world-catchall ids — up to 5 datafile round trips per check, on every AI tick for every mobile shard-wide. `GetPolicyMask` is now backed by a per-realm `dictionary` (`area_id -> mask`), cached both per-program and in a `GlobalProperty` (`zh.areapolicy.maskcache.<realm>`), using `.Exists()` rather than truthiness so a cached mask of `0` (the common case) isn't mistaken for "not cached." The cache is invalidated precisely on `SetPolicyMask()` writes (single area id) and wholesale on `PruneStaleRealmPolicies()` (whole-realm bulk delete). This mirrors the existing parsed-line cache and was verified against the ZH3.0 sibling repo's simpler (no world-catchall) implementation for reference before implementing.

---

## 5. Go Locations - Indexed Config Generation and Range Fallback

### Files Changed

| File | Change |
|------|--------|
| `config/golocs_by_id.cfg` | New generated index of go locations by region id, realm, type, range, and GoLoc metadata |
| `config/command_synopses.cfg` | Updated synopsis entry for `.go` and new supporting commands |
| `pythonscripts/generate_golocs_by_id.py` | New generator that builds the indexed go-location config from region data |
| `scripts/textcmd/coun/go.src` | `.go` rebuilt around the indexed go-location config, facet selection, type ordering, and range fallback |
| `regions/regions.cfg` | Massive region metadata expansion to feed the new go-location generator |

### Notable Functional Changes

- `.go` now reads `golocs_by_id.cfg` instead of the older ad hoc config path.
- Regions can now be resolved from either:
  - an explicit `GoLoc`, or
  - the center point of the configured `Range`.
- A `dnp` `GoLoc` value is treated as an intentional skip.
- `0,0,0` explicit coordinates are treated as a placeholder and are replaced from the range center when possible.
- Location ordering is normalized by type (`Jail`, `City`, `Shrine`, `Graveyard`, `Dungeon`, `POI`, `None`) before any leftover entries are appended. See section 9 for the algorithmic rewrite of this ordering pass.
- The generator script exists so the index can be rebuilt from `regions.cfg` instead of hand-maintaining the go list.

---

## 6. Spawnpoint - Restart Helpers and Region-Wide Reset Commands

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/spawnpoint/include/restartspawnpoint.inc` | Shared restart helper extracted for normal restart and max-fill modes |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpoint.src` | Restart command updated to use the shared helper and report next spawn timing |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | New region-wide restart and restartmax command that iterates spawnpoints by selected location ranges |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointmax.src` | Force-fill command updated to use the shared helper and report fill counts |
| `pkg/opt/spawnpoint/config/groups.cfg` | Spawnpoint group config adjusted to support the new region restart workflow |

### Notable Functional Changes

- `RestartSpawnPointWithMode(...)` now encapsulates the restart and max-fill logic:
  - normal restart clears active spawned objects and schedules the next spawn based on the configured frequency,
  - max-fill temporarily enables the group flag if needed, repeatedly checkpoints until the target max is reached, then restores the original group flag.
- `.restartspawnpoint` now reports the next spawn delay after the restart.
- `.restartspawnpointmax` now reports the number of spawned objects relative to the configured maximum.
- `.restartspawnpointarea` is a new command that:
  - lets staff choose a facet,
  - then choose a location from the `golocs_by_id.cfg` index,
  - then restarts every spawnpoint whose coordinates fall inside that location's configured ranges.

---

## 7. Housing - Region-Based Placement Restrictions

### Files Changed

| File | Change |
|------|--------|
| `pkg/std/housing/housedeed.src` | House placement now checked against region types by footprint; dungeon/system-teleporter proximity check extracted into a helper |

### Notable Functional Changes

- Replaced the old single-tile `CheckCity(character)==1` check (which only tested the placing character's own location) with `IsHousePlacementBlockedByRegionType(housetype, where, region_type)`, called once each for `"city"`, `"dungeon"`, `"shrine"`, and `"graveyard"`. This computes the house's full footprint via `GetHouseFootprintBounds(housetype, x, y)` (multi dimensions applied to the placement point) and rejects placement if that footprint overlaps any `regions.cfg` region of the matching `Type`, scoped to the placing character's realm.
- `NormalizeRegionType(region_type)` lowercases and validates the region-type string used for comparison against `regions.cfg`'s `Type` field.
- The old inline dungeon-item / system-teleporter proximity checks (`ListObjectsInBox` scans for objtype `0xa3c8` and `0x6200`) were extracted into `IsHousePlacementBlockedByNearbySpecialObjects(where)`, which returns the rejection message directly instead of duplicating the `ListObjectsInBox` scan and message send inline.
- Staff (`character.cmdlevel >= 4`) are unaffected — all of the above is still gated behind the existing `if (character.cmdlevel < 4)` check.

---

## 8. Naming and Identity - Town-Suffix Exploit Closure and Validation Hardening

### Files Changed

| File | Change |
|------|--------|
| `scripts/include/NameChecker.inc` | Town-suffix-aware duplicate detection, case-insensitive comparison, whitespace normalization, bad-spacing rejection, and caching |
| `pkg/opt/townstones/tstone.src` | `Citizenship()`/`CanselCityzenship()` now duplicate-check before applying a town-suffixed or stripped name |
| `scripts/misc/namechanger.src` | Passes `force_town_check := 1`; added "bad spacing" error message |
| `scripts/misc/oncreate.src` | Passes `force_town_check := 1` |
| `scripts/textcmd/admin/setname.src` | `.setname` now runs through `CheckName`, scoped to player characters only |
| `scripts/textcmd/gm/setprop.src` | `.setprop name` now runs through `CheckName`, scoped to player characters only |
| `scripts/textcmd/seer/info.src` | `.info`'s rename button now runs through `CheckName`, scoped to player characters only |

### Background

A live exploit was reported: a player could join a town as "X" (becoming "X of Town"), create a second character also named "X" on an alt, then leave the town (reverting the first character to bare "X"), ending up holding both "X" and "X of Town" simultaneously — and bypass case-sensitivity to also claim near-duplicates like "Bop"/"bop"/"BOP". Investigating this also surfaced a live duplicate-character bug (two characters both named "Paladin Rahl of Occlo") and a report of a ~50 second hang with stacked rename gumps after a related fix — both root-caused and fixed here.

### Notable Functional Changes

- **`GetKnownTownNames()`** — replaces the old static `bLTowns`-only blacklist scan with a merged list from three sources: the static `bLTowns` fallback, every `City=1` region in `regions.cfg` (covers player-run townstone regions), and `GetGlobalProperty("townlist")` (covers a townstone whose region entry was later removed). Cached per-program and in a `GlobalProperty` (`zh.namechecker.knowntownnames`); `InvalidateKnownTownNamesCache()` is exposed but not yet wired to any call site (regions.cfg is effectively static at runtime today).
- **`StripTownSuffix(name, town_names := 0)`** — strips a trailing `" of <Town>"` for any known town so name-uniqueness comparisons treat `"a pig"` and `"a pig of Trinsic"` as the same identity, closing the join/leave/alt exploit above. Accepts an optional pre-fetched `town_names` list to avoid recomputing it in a loop.
- **`NormalizeNameForCompare(name)`** — lowercases, collapses runs of interior spaces to one, and trims leading/trailing spaces before comparison.
- **`IsNameTaken(candidate_name, exclude_serial := 0)`** — scans up to 5 character slots per account, comparing `NormalizeNameForCompare(StripTownSuffix(name, town_names))`, case-insensitively, excluding `exclude_serial`. Replaces the old exact-string, case-sensitive comparison in `CheckName` (which never caught `"Bop"` vs `"bop"`).
- **`CheckName(name, who := 0, force_town_check := 0)`** — new `force_town_check` parameter: pass `1` whenever the player is actively choosing a brand-new name (character creation, the rename gump, staff rename tools) so town names are always blocked regardless of the player's current town membership; login/reconnect revalidation of an already-assigned, legitimately town-suffixed name leaves this `0`. Also added an unconditional bad-spacing rejection (`name[1] == " " || name[len(name)] == " " || find(name, "  ", 0)`) — leading/trailing/doubled spaces were technically "legal characters" under the old per-character validation loop, but let a base name like `"Rahl "` silently become `"Rahl  of Town"` once a town suffix was appended, evading exact-match duplicate detection. This check is unconditional (not gated by `force_town_check`), so it also self-heals an already-malformed stored name on next login revalidation — this is exactly how the shard's one existing malformed record (`"Paladin Rahl  of Occlo"`, confirmed via `data/pcs.txt` to be the only such record shard-wide) will get caught and forced through a rename.
- **`pkg/opt/townstones/tstone.src`**: `Citizenship(who, item)` now computes the candidate town-suffixed name and calls `IsNameTaken()` before any state mutation, aborting with a message if the resulting name is already in use, rather than mutating town membership and then blindly assigning a colliding name. `CanselCityzenship(who, item)` (leave-town) computes the stripped base name, and if `IsNameTaken()` finds it colliding, sets the character's name to `"AlreadyUsed"` and force-starts `misc/namechanger` instead of blocking the leave — citizen-list removal, population decrement, and the `town` property erasure all still proceed unconditionally, so the player isn't stuck in town membership limbo while they pick a new name.
- **Staff rename paths** now validate through the same `CheckName()` path as player-driven renames, all explicitly scoped to player characters (`what.acct` / `targ.acct` / `who.acct` checks) so NPC renaming by staff is untouched:
  - `.setname` (`scripts/textcmd/admin/setname.src`)
  - `.setprop name` (`scripts/textcmd/gm/setprop.src`)
  - `.info`'s rename button (`scripts/textcmd/seer/info.src`)
- **Performance root cause (the 50-second hang):** the original `IsNameTaken`/`StripTownSuffix` implementation called `GetKnownTownNames()` (a full `regions.cfg` re-parse) on every character-slot comparison. With 5,169 accounts x up to 5 slots, that was ~25,000 redundant full-config re-parses per `CheckName` call — the direct cause of the reported hang and stacked rename gumps. Fixed by hoisting `GetKnownTownNames()` to once per `IsNameTaken`/`CheckName` call (passed through as a parameter) and adding the cache described above.

---

## 9. Performance - Shutdown Time and Hot-Path Algorithm Fixes

### Background

Investigated a live report that "POL Cleanup" during shutdown takes noticeably longer since the areas-to-datafile migration, alongside a slow ~1 hour post-startup CPU stabilization period. `log/script.log` showed the runaway-script watchdog firing on `scripts/textcmd/coun/go.ecl` (3 times) and `pkg/opt/alryc/textcmd/test/gotomulti.ecl` (2 times) — both algorithmic, not areas-related. Note: `log/pol.log` does not capture the console-only cleanup messages, so the runaway scripts are strong circumstantial evidence and worthwhile independent fixes on their own merits, not a proven root cause of the shutdown-time regression specifically (the areas mask-value cache in section 4 is the more directly-implicated fix for that).

### Files Changed (uncommitted)

| File | Change |
|------|--------|
| `scripts/textcmd/coun/go.src` | `ReorderLocationsForDisplay()` rewritten from an O(n^2)*8 pass to a single O(n) bucketing pass |
| `scripts/include/string.inc` | `SortMultiArrayByIndex()` rewritten from an O(n^2) selection sort to an O(n log n) iterative bottom-up merge sort |

### Notable Functional Changes

- **`.go`'s `ReorderLocationsForDisplay()`**: previously called `AppendLocationsByType()` once per type bucket (Jail/City/Shrine/Graveyard/Dungeon/POI/None — 7 passes), each of which rescanned the entire, continuously-growing `ordered` output list via `LocationAlreadyAdded()` for every candidate to dedupe by `Id` or by `Name+X+Y+Z+R` — effectively O(n^2) x 8 passes total (7 typed + 1 final catch-all). With ~200 Britannia go-locations alone, this was heavy enough to trip the runaway-script watchdog. Rewritten as a single O(n) pass: build a `LocationDedupeKey(loc)` (prefers `"id:<Id>"`, falls back to `"xy:<Name>:<X>:<Y>:<Z>:<R>"`), dedupe against a `seen` dictionary once, bucket by `GetLocationTypeLabel()` into a `dictionary` of arrays, then emit known-type buckets in priority order followed by any custom/unrecognized-type entries in original encounter order. Output ordering is unchanged from the old implementation; only the algorithm changed. `AppendLocationsByType()` and `LocationAlreadyAdded()` were removed (confirmed via repo-wide grep that nothing else referenced them).
- **`SortMultiArrayByIndex(MultiArray, SubIndex)`** (`scripts/include/string.inc`): previously an O(n^2) nested-loop selection sort. Rewritten as an iterative bottom-up merge sort (O(n log n)) via a new `MergeRunsByIndex(MultiArray, low, mid, high, SubIndex)` helper, same ascending-by-`SubIndex` output ordering. This is a shared include used by both `pkg/opt/alryc/textcmd/test/gotomulti.src` (`SortHouseMultisByLastLogin`, sorting up to 418 multi records) and `gotoboat.src` (`SortBoatsByLastLogin`) — fixing it here benefits both call sites without touching either file. The merge-loop write-position variable was originally named `out`, which is a reserved word in EScript/POL; renamed to `write_idx`.

---

## 10. Crafting - Omega Cache Integration Fixes

### Files Changed (uncommitted)

| File | Change |
|------|--------|
| `pkg/std/blacksmithy/make_blacksmith_items.src` | `use_hammer` rewritten so Omega Cache targeting is reachable; dead/duplicate legacy code removed |
| `pkg/opt/crafterboost/make_crafter_boosts.src` | Full Omega Cache integration added (previously backpack-only) |

### Notable Functional Changes

- **Blacksmithy (`make_blacksmith_items.src`)**: `use_hammer` previously performed an unconditional `ReserveItem(use_on)` and an unconditional `IsInContainer(character.backpack, use_on)` check *before* any Omega Cache objtype check — unlike every other cache-integrated crafting script (`alchemy.src`, `tinkering.src`, `carpentry.src`, `make_cloth_items.src`, `cooking.src`, `cartography.src`, `inscription.src`), which all check for the cache objtype first. Since the Omega Cache container is a placed house item, it's never "in your backpack," so targeting the cache directly for a plain ingot craft failed with "That item has to be in your backpack." before ever reaching the cache-handling code lower in the file. The only path that worked was the bone-armor sub-flow (target a bone item from backpack first, then target the cache when prompted for ingots), because that second `Target()` call bypassed the broken top-level check. The file also had two near-duplicate copies of the bone/ingot crafting logic (apparent leftover from a bad merge when cache integration was added), including a fallthrough where "no anvil nearby" would silently retry the same target as a plain ingot craft. Rewrote `use_hammer` to check for the cache objtype first (matching the established pattern across the codebase), and factored the repeated ingot-targeting logic into `ResolveIngotTarget(character)` and the anvil-proximity check into `NearAnvil(character)`.
- **Crafter boosts (`make_crafter_boosts.src`)**: the smithy retort (crafting Oil/Alloy/Varnish/Compound/Recharge Powder from Brimstone/Bloodspawn/Daemon Bone/Bat Wing/Dragon's Blood plus an ingot, log, hide, or gem) had never been integrated with the Omega Cache — it didn't include `resourcemanager.inc` and used the plain backpack-only `FindSubstance`/`ConsumeSubstance` helpers throughout, so it would simply stop (insufficient-materials path) if a player ran out of the targeted material in their backpack, regardless of whether a nearby cache had more. Added `resourcemanager`/`omegacache_utils` includes and converted both the explicitly-targeted material and the implicit fixed reagent (which the player never targets directly) to `ResourceRequest`s:
  - The initial target and the Brimstone-combine second target now both check for `OMEGACACHE_OBJTYPE` and route through `SelectMaterialFromCache()`, matching the established pattern.
  - A new `MakeReagentRequest(who, objtype)` builds a backpack-first, cache-fallback `ResourceRequest` for the fixed reagent (mirrors `MakeBackpackRequest()`, but without needing a physical item reference, since the reagent is never targeted by the player).
  - `LeaseResource`/`ExtendResourceLease`/`ReleaseResourceLease`/`ConsumeResource`/`GetAvailableResource` now drive both materials through the crafting loop, matching `MakeBlacksmithItems`'s pattern; the loop's early-exit paths (missing empty flask, can't reach it, can't reserve it) now `break` instead of `return`, so `AutoLoop_finish()` always runs.
  - A small `ObjtypeStruct(objtype)` helper lets the existing item-based `IsIngot`/`IsLog`/`IsGem2` (which only ever read `.objtype` off their argument) be reused against a bare objtype from a cache selection, instead of duplicating their range logic locally.
  - Scope note: the empty-flask consumption for the Recharge Powder product line remains backpack-only (unchanged) — flasks were out of scope for this fix.

---

## 11. Omega Cache - Potion Categorization Fix

### Files Changed (uncommitted)

| File | Change |
|------|--------|
| `pkg/opt/omegacache/categories.cfg` | Added 12 missing leveled-potion objtypes to the `Potions` category |

### Notable Functional Changes

- `categories.cfg`'s `Potions` category had two adjacent documented ranges — "Mage-class potion variants (0xFF19-0xFF3F)" ending at `0xFF40`, and "AlchemyPlus potions (0xFF4E-0xFF95, 0xFFA2)" starting at `0xFF4E` — with a gap at `0xFF41`-`0xFF4D` that neither range covered. That gap is exactly where `pkg/std/alchemy/itemdesc.cfg`'s leveled potion tiers live: Strength Potion [Level 2] (`0xFF41`), Greater Strength Potion [Level 1-3] (`0xFF42`-`0xFF44`), Cure Potion [Level 1-3] (`0xFF45`-`0xFF47`), and Greater Cure Potion [Level 1-5] (`0xFF48`-`0xFF4C`). Since `BuildCategoryMap()` in `omegacache.inc` defaults any unmatched objtype straight to `"Other"`, these 12 potions were showing up in the wrong category bucket in the cache UI. Added all 12 objtypes to the `Potions` category, closing the gap. Confirmed via a full cross-reference of `pkg/std/alchemy/itemdesc.cfg` against `categories.cfg` that no other alchemy objtypes have a similar gap. Cosmetic UI-grouping fix only — no gameplay value changes.

---

## 12. Gameplay Tuning and Script Fixes

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/alchemyplus/newpotions.src` | Protection-style potion duration increased significantly |
| `pkg/opt/holybook/removecurse.src` | Remove Curse success chance changed; paladins now use magery and magic resistance for the roll |
| `pkg/opt/shilhook/shilhook.src` | Skill gain and difficulty checks refactored to use a separate gain skill and a clearer chance calculation |
| `pkg/packethooks/speech/receivespeechhook.src` | Unicode speech packet decoding now uses the native Unicode string path instead of the older CChrZ conversion |
| `pkg/std/treasuremap/treasure.cfg` | One buried treasure coordinate was adjusted |
| `pkg/opt/alryc/README.txt` | Stale README removed during the command and tooling reshuffle |
| `scripts/ai/noble.src` | Nobles now begin wandering immediately after spawn |
| `scripts/ai/person.src` | Generic town NPCs now begin wandering immediately after spawn |
| `scripts/ai/setup/criersetup.inc` | Crier setup now guards missing config more safely and defaults the flee point cleanly |
| `scripts/ai/townperson.src` | Town NPC startup now begins wandering immediately after spawn |
| `scripts/ai/townsfolk.inc` | Townfolk helper updated to stay aligned with the new spawn and movement behavior |
| `scripts/EquipTemplateValidation.src` | Boot-time equip-config validator deduplicated: removed a dead `else` branch, extracted a shared `ValidateEquipEntries()` used across Armor/Weapon/Equip instead of three near-identical inline blocks |

### Notable Functional Changes

- Protection effects now last much longer; the underlying strength is unchanged but the duration calculation was extended.
- Remove Curse is now more class-aware:
  - paladins use magery and magic resistance,
  - other casters still use the earlier item-identification-based path.
- Skill gain now uses a cleaner distinction between the skill used for the difficulty check and the skill used for gain calculations.
- The speech hook fix keeps staff speech logging working even when the packet contains Unicode speech data.
- Town NPCs no longer sit idle right after spawn; they start their wander cycle immediately.
- Crier setup became more defensive around missing NPC config entries.
- `EquipTemplateValidation.src` is a one-shot boot-time validator (~1,279 entries) — the cleanup is a code-quality/maintenance change, not a meaningful perf contributor on its own.

---

## 13. Support Data and Tooling

### Files Changed

| File | Change |
|------|--------|
| `ZHO-DataBackup.ps1` | Data backup destination moved to the Koofr path; the log backup line is now commented out |
| `config/command_synopses.cfg` | Synopsis coverage refreshed for the new staff commands and the updated `.areas`, `.go`, `.restartspawnpoint*`, `.playerruntowns`, `.whereat`, and related entries |
| `pkg/opt/alryc/textcmd/test/gotoboat.src` | New developer command to list boats and teleport to the selected tillerman |
| `pkg/opt/alryc/textcmd/test/gotomulti.src` | New developer command to list house multis and teleport to the selected sign |
| `pkg/opt/alryc/textcmd/test/makecheck.src` | New developer command to create a bank cheque |
| `pkg/opt/alryc/textcmd/test/whereat.src` | New developer command to inspect the location details of a selected mobile, item, or map tile |
| `pol.cfg` | Profiling and sysload watchers were enabled for better live diagnostics |

### Notable Functional Changes

- The backup script now writes to the Koofr-backed destination used by the shard.
- The command synopsis file now covers the new or updated admin and developer commands so they show up in the command browser and help surface.
- The new `alryc` test commands are staff and developer tools and are not intended to affect regular gameplay.

---

## 14. Exhaustive File-by-File Change List

All files changed in `Patch-1.0.7..HEAD`, plus current uncommitted working-tree changes:

| File | Notes |
|------|-------|
| `ZHO-DataBackup.ps1` | Backup destination moved; log backup line commented out |
| `config/command_synopses.cfg` | Synopsis refresh for new and updated admin and developer commands |
| `config/golocs_by_id.cfg` | New generated go-location index by region id |
| `pkg/opt/alchemyplus/newpotions.src` | Protection duration extended |
| `pkg/opt/alryc/README.txt` | Removed stale README |
| `pkg/opt/alryc/textcmd/test/gotoboat.src` | New boat location and teleport developer tool |
| `pkg/opt/alryc/textcmd/test/gotomulti.src` | New multi location and teleport developer tool |
| `pkg/opt/alryc/textcmd/test/makecheck.src` | New cheque creation developer tool |
| `pkg/opt/alryc/textcmd/test/whereat.src` | New target-inspection developer tool |
| `pkg/opt/areas/EnterAreaDelay.src` | Switched to the new area-policy resolution flow |
| `pkg/opt/areas/LeaveArea.src` | Switched to the new area-policy resolution flow |
| `pkg/opt/areas/areaban.src` | Updated for the new area-policy path |
| `pkg/opt/areas/areas.cfg` | Area policy and region data refresh, including castle fixes |
| `pkg/opt/areas/include/areapolicy.inc` | Policy resolver/cache layer, plus realm sanitization and mask-value cache |
| `pkg/opt/areas/include/areapolicy.inc.bak` | Backup of the pre-rewrite policy layer |
| `pkg/opt/areas/textcmd/admin/areas.src` | Rewritten area policy admin gump and flag editor |
| `pkg/opt/crafterboost/make_crafter_boosts.src` | *(uncommitted)* Full Omega Cache integration added |
| `pkg/opt/holybook/removecurse.src` | Revised Remove Curse chance logic |
| `pkg/opt/omegacache/categories.cfg` | *(uncommitted)* 12 leveled-potion objtypes added to the Potions category |
| `pkg/opt/shilhook/shilhook.src` | Skill gain and difficulty refactor |
| `pkg/opt/spawnpoint/config/groups.cfg` | Spawnpoint group config update |
| `pkg/opt/spawnpoint/include/restartspawnpoint.inc` | Shared spawnpoint restart helper |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpoint.src` | Restart command now uses the helper |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | New region-wide restart command |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointmax.src` | Force-fill restart command updated |
| `pkg/opt/townstones/textcmd/admin/createtownstone.src` | Creation workflow tightened and state restoration added |
| `pkg/opt/townstones/textcmd/admin/removetownmember.src` | New town member removal command |
| `pkg/opt/townstones/textcmd/admin/townbankstatus.src` | Major town status, member management, and runtime state expansion |
| `pkg/opt/townstones/tstone.src` | `Citizenship`/`CanselCityzenship` now duplicate-check before mutating a name |
| `pkg/packethooks/speech/receivespeechhook.src` | Unicode speech packet decode fix |
| `pkg/std/blacksmithy/make_blacksmith_items.src` | *(uncommitted)* Omega Cache targeting fixed, dead code removed |
| `pkg/std/housing/housedeed.src` | Region-based city/dungeon/shrine/graveyard placement restrictions |
| `pkg/std/treasuremap/treasure.cfg` | One treasure location adjusted |
| `pol.cfg` | Profiling and sysload watchers enabled |
| `pythonscripts/generate_golocs_by_id.py` | New generator for indexed go-location config |
| `regions/regions.cfg` | Large region metadata expansion and normalization |
| `scripts/EquipTemplateValidation.src` | Dead branch removed, shared validation helper extracted |
| `scripts/ai/noble.src` | Nobles now wander immediately after spawn |
| `scripts/ai/person.src` | Townsfolk now wander immediately after spawn |
| `scripts/ai/setup/criersetup.inc` | Safer crier config handling |
| `scripts/ai/townperson.src` | Town NPCs now wander immediately after spawn |
| `scripts/include/NameChecker.inc` | Town-suffix exploit closure, case-insensitive dedupe, bad-spacing rejection, caching |
| `scripts/include/anchors.inc` | Anchor and lookup helpers updated for new area behavior |
| `scripts/include/areas.inc` | Area helper rewrite to match the new policy layer |
| `scripts/include/string.inc` | *(uncommitted)* `SortMultiArrayByIndex` rewritten to O(n log n) merge sort |
| `scripts/include/townsfolk.inc` | Townfolk helper alignment update |
| `scripts/misc/namechanger.src` | `force_town_check := 1`, "bad spacing" error message |
| `scripts/misc/oncreate.src` | `force_town_check := 1` |
| `scripts/textcmd/admin/setname.src` | Now runs through `CheckName`, PC-scoped |
| `scripts/textcmd/coun/go.src` | *(uncommitted)* `ReorderLocationsForDisplay` rewritten to O(n); `.go` also rebuilt around indexed go locations and range fallback (earlier in the patch) |
| `scripts/textcmd/gm/setprop.src` | `.setprop name` now runs through `CheckName`, PC-scoped |
| `scripts/textcmd/seer/info.src` | Rename button now runs through `CheckName`, PC-scoped |

---

## 15. Risk and Regression Notes

1. `regions/regions.cfg` and `config/golocs_by_id.cfg` are now tightly coupled. Any future region edit should regenerate the go-location index rather than hand-editing the generated file.
2. The area-policy caches (parsed-line cache and the new mask-value cache) use global properties and, for the parsed-line cache, a line-count fingerprint. If `areas.cfg` changes shape, cache invalidation needs to remain intact or stale policy data can persist. The mask-value cache is invalidated precisely on `SetPolicyMask`/`PruneStaleRealmPolicies` writes, so it should stay correct as long as no other code path writes the `AREA_POLICY_MASK_PROP` datafile property directly.
3. Town member removal now touches citizen lists, population, and election or poll state. That makes the new cleanup path more complete, but it also raises the importance of testing member removal against live stones and offline accounts.
4. `RestartSpawnPointWithMode(...)` can checkpoint repeatedly during max-fill mode. That is intentional, but it means the new region-wide restart command should still be treated as a staff maintenance tool rather than a routine hot command.
5. `GetKnownTownNames()`'s cache has no automatic invalidation wired to `createtownstone`/region edits yet — a brand-new town's name won't be recognized as a "town name" for the free-name-choice block, nor will its residents' suffixes be stripped for dedupe purposes, until `InvalidateKnownTownNamesCache()` is called or the server restarts. Low practical risk today since new town creation is infrequent and staff-driven, but worth wiring up if that becomes a live pain point.
6. The town-suffix duplicate-name fixes and the house-placement region checks are both new *rejection* paths in previously-permissive flows — worth a live smoke test on a known player-run town (join/leave/rename) and a known city-adjacent building parcel before this goes fully live, since both change behavior at the boundary rather than just internals.
7. The blacksmithy and crafter-boost Omega Cache fixes change previously-broken or entirely-missing behavior into working behavior — this is a net-new capability for players (the failure mode was "doesn't work," not "we're removing something"), but should still get a quick live test: hammer-to-cache targeting for a plain ingot craft, bone-armor dual-material with the cache as either material, and a crafter-boost upgrade with the target material sourced from a cache.
8. The `.go` and shared-sort algorithmic rewrites are drop-in replacements with verified-identical output ordering (hand-traced on a small example for the merge sort; the `.go` reorder was verified against its old semantics directly). Risk is low, but both are hot, frequently-run staff commands, so a live spot check (a `.go` menu with a large realm, and `.gotomulti`/`.gotoboat` with the current multi/boat counts) is still worthwhile.
9. The potion-categorization fix is UI-only (Omega Cache category grouping) and carries no gameplay risk.
