### PR TITLE
Patch 1.0.8

### DIFF
--- a/config/cmds.cfg
+++ b/config/cmds.cfg
@@ -68,6 +68,7 @@ CmdLevel Test
 	DIR scripts/textcmd/test
 	DIR pkg/systems/accounts/textcmd/test
 	DIR pkg/systems/playervendor/commands/test
+	DIR pkg/opt/admin/textcmd/test
 	DIR pkg/opt/alryc/textcmd/test
 	DIR pkg/opt/Donator/textcmd/test
 	DIR pkg/opt/bomberman/textcmd/test

--- a/patchnotes/developer-changelog-v1.0.8.md
+++ b/patchnotes/developer-changelog-v1.0.8.md
@@ -1,9 +1,9 @@
 # Developer Changelog - v1.0.8
-**Range:** `9f8189f` (origin/Patch-1.0.7) -> `HEAD` + uncommitted working tree  
+**Range:** `9f8189f` (origin/Patch-1.0.7) -> `7c27772` (HEAD)  
 **Branch:** Patch-1.0.8  
 **Date:** 2026-06-20 -> 2026-07-23  
-**Commits in range:** 7 (excluding merge commits), plus uncommitted working-tree changes  
-**Files changed:** 48 committed (+10477 / -1316), plus 5 files with uncommitted changes (+343 / -237)
+**Commits in range:** 10 (excluding merge commits)  
+**Files changed:** 84 (+12970 / -1689)
 
 ---
 
@@ -22,8 +22,9 @@
 11. [Omega Cache - Potion Categorization Fix](#11-omega-cache---potion-categorization-fix)
 12. [Gameplay Tuning and Script Fixes](#12-gameplay-tuning-and-script-fixes)
 13. [Support Data and Tooling](#13-support-data-and-tooling)
-14. [Exhaustive File-by-File Change List](#14-exhaustive-file-by-file-change-list)
-15. [Risk and Regression Notes](#15-risk-and-regression-notes)
+14. [Staff Tooling - Character/Account Audit Panel and Name/Death/Poison/Note Tracking](#14-staff-tooling---characteraccount-audit-panel-and-namedeathpoisonnote-tracking)
+15. [Exhaustive File-by-File Change List](#15-exhaustive-file-by-file-change-list)
+16. [Risk and Regression Notes](#16-risk-and-regression-notes)
 
 ---
 
@@ -31,7 +32,7 @@
 
 Patch 1.0.8 grew across two work windows. The first (through `a3c99f6`) was dominated by the datafile-backed area policy rewrite, the go-location indexing pass, and the player-run townstone/admin cleanup — see sections 3, 5, and 6 for that material, carried forward unchanged from the earlier draft of this document.
 
-The second window (`7bdc099` through the current uncommitted state) closed a live-reported name-collision exploit, fixed a duplicate-character bug it was related to, added region-based house placement restrictions, fixed a real performance regression in the areas package and in two hot commands, and completed Omega Cache integration for two crafting scripts that had been missed or left broken during the original cache rollout:
+The second window (`7bdc099` through `b347427`) closed a live-reported name-collision exploit, fixed a duplicate-character bug it was related to, added region-based house placement restrictions, fixed a real performance regression in the areas package and in two hot commands, and completed Omega Cache integration for two crafting scripts that had been missed or left broken during the original cache rollout:
 
 - A town-suffix name-collision exploit was closed: players could no longer hold both "X" and "X of Town" at once, town names are now blocked in freely-chosen names, and name comparisons are case-insensitive.
 - A live 50-second rename-gump hang, and a resulting duplicate-character bug ("two Paladin Rahl of Occlo"), were root-caused to an O(accounts x 5) full `regions.cfg` re-parse per name check, and fixed with a proper cache.
@@ -41,6 +42,8 @@ The second window (`7bdc099` through the current uncommitted state) closed a liv
 - Two independent O(n^2) algorithms (`.go`'s location-reorder pass, and a shared multi-array sort used by `.gotomulti`/`.gotoboat`) were replaced with linear/O(n log n) equivalents after script-log evidence showed both tripping the runaway-script watchdog.
 - The smithy hammer's Omega Cache targeting path was found to be dead code due to a bad merge and was rewritten to match every other crafting script's pattern; the crafter-boost smithy retort had never been integrated with the cache at all and now is.
 - A gap in the Omega Cache's category map left 12 leveled potion objtypes (Greater Strength/Cure Potion tiers, etc.) falling into the "Other" bucket instead of "Potions."
+
+A third window (`7c27772`) added a full staff-facing character/account audit tool and wired full name-change, death, poisoning, and account-note tracking into every script that touches them — see section 14. Two additional commits landed in this range (`b347427`, `232ee95`); `b347427`'s crafting/performance/potion-category work is already covered above (sections 9-11), and `232ee95` (a townstone treasury-race, election-cleanup, and townlist-bootstrap fix pass) is not detailed in this document.
 
 ---
 
@@ -55,7 +58,9 @@ The second window (`7bdc099` through the current uncommitted state) closed a liv
 | `065ed28` | 2026-07-20 | House placement not allowed in cities |
 | `21bb91e` | 2026-07-23 | Name Change update |
 | `09bf876` | 2026-07-23 | Areas Fix, and naming fixes |
-| *(uncommitted)* | 2026-07-23 | Blacksmithy/crafter-boost Omega Cache fixes, potion categorization fix, `.go`/sort-helper performance fixes |
+| `b347427` | 2026-07-23 | Patch notes, and fixes for omega cache, as well as optimization for go gomulti and goboat (see sections 9-11) |
+| `232ee95` | 2026-07-23 | Townstone fixes, Minstel and townsfolk fix (not detailed in this document) |
+| `7c27772` | 2026-07-23 | New test panel up along with datafiles (see section 14) |
 
 ---
 
@@ -336,9 +341,76 @@ Investigated a live report that "POL Cleanup" during shutdown takes noticeably l
 
 ---
 
-## 14. Exhaustive File-by-File Change List
+## 14. Staff Tooling - Character/Account Audit Panel and Name/Death/Poison/Note Tracking
 
-All files changed in `Patch-1.0.7..HEAD`, plus current uncommitted working-tree changes:
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `pkg/opt/admin/pkg.cfg` | New minimal package, created solely to give the new datafile a registered namespace (`data/ds/admin/`) |
+| `pkg/opt/admin/include/adminpanel.inc` | New shared data layer: name/death/poisoning/account-note history recording, retrieval, and summary building |
+| `pkg/opt/admin/textcmd/test/testadminpanel.src` | New `.testadminpanel` staff gump: account browsing and full character audit history |
+| `config/cmds.cfg` | Added `DIR pkg/opt/admin/textcmd/test` under the `Test` cmdlevel block |
+| `scripts/include/NameChecker.inc` | Added `NameCheckFailureReason(reason_code)` to translate a `CheckName()` rejection code into a human-readable reason |
+| `scripts/textcmd/gm/setprop.src` | Fixed a trailing-space bug in the value-rebuild loop; `.setprop name` now shows the real rejection reason and records the change |
+| `scripts/textcmd/admin/setname.src` | `.setname` now shows the real rejection reason and records the change |
+| `scripts/textcmd/seer/info.src` | `.info`'s rename button and `fixnameguild` now show the real rejection reason (rename button) and record the change |
+| `scripts/textcmd/gm/changename.src` | `.changename` now records the change |
+| `scripts/textcmd/test/editcharacter.src` | `.editcharacter` now records the change |
+| `pkg/commands/commands/gm/mobedit.src` | `mobedit`'s name field now records the change |
+| `pkg/opt/spawnpoint/textcmd/admin/newmobedit.src` | `newmobedit`'s name field now records the change |
+| `scripts/misc/namechanger.src` | The player rename gump now records the change |
+| `scripts/items/racegate.src` | Race-gate name suffixing now records the change |
+| `pkg/opt/roleplaying/rperstone.src` | RPer faction join (`[RPer]` suffix) now records the change |
+| `scripts/textcmd/admin/removerper.src` | RPer faction removal (name restore) now records the change |
+| `scripts/textcmd/admin/admin.src` | `admin.src`'s `fixnameguild` now records the change; the NOTES action now records an account note |
+| `scripts/misc/chrdeath.src` | Character death now records a death entry (killer, killer's account, coordinates) |
+| `scripts/include/dotempmods.inc` | `SetPoison()` now records a poisoning entry alongside the existing `PoisonedBy` cprop |
+| `scripts/textcmd/coun/notes.src` | `.notes` now records an account note (Staff-initiated) |
+| `pkg/opt/loot/antiloot.inc` | `AutoJail()` now records an account note (System-initiated) |
+| `pkg/opt/spawnpoint/textcmd/admin/despawn.src` | Fixed `program` name (was still `forcespawn`, copy-pasted from that file); added a null/invalid-spawnpoint guard |
+| `pkg/opt/spawnpoint/textcmd/admin/primespawn.src` | Same `program` name fix and null/invalid-spawnpoint guard as `despawn.src` |
+| `pkg/opt/spawnpoint/textcmd/admin/forcespawn.src` | Added the same null/invalid-spawnpoint guard |
+| `pkg/opt/spawnpoint/textcmd/admin/gotomobtype.src` | Removed a leftover debug `Print("stuff")` call |
+| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | `ReorderLocationsForDisplay()` rewritten from the same O(n^2)*8-pass shape fixed for `.go` in section 9 to a single O(n) dedupe-and-bucket pass |
+
+### Background
+
+Building the audit panel required first finding every place in the codebase where a player character's name can actually change, so each one could be wired into the new tracking layer; that sweep turned up a live bug (`.setprop`'s trailing-space append, section 8 already covers the underlying `CheckName` bad-spacing rejection it was tripping) and several small pre-existing bugs in unrelated spawnpoint commands that were touched only incidentally while adding `RecordCharacterNameChange` calls to `newmobedit.src`'s neighbors.
+
+### Notable Functional Changes
+
+**New staff command `.testadminpanel` (Test cmdlevel):**
+- Gump flow: choose "Account" -> pick a letter A-Z (5-column grid, dynamically sized to the letter count so it can't overflow) -> paged account list (8 per page, each row showing the account name as a button plus its IP and last login date) -> character list for that account -> character detail.
+- `ShowCharacterList` (the account-landing screen) shows the account name, a "Notes" subtitle with the full word-wrapped latest account note (via the existing `GFWordWrap()` utility, so the gump is sized to the actual wrapped line count instead of truncating), an attribution line (`"- <initiator>, <timestamp>"` or `"- Unknown"`), a running count of stored note records, and then the account's characters as buttons.
+- `ShowCharacterDetail` shows a "Character Information" title with "Names", "Killed By", and "Poisoned By" subtitled sections (10/5/5 most-recent-first respectively), each ending with a "more in datafile" total count.
+
+**New shared data layer (`pkg/opt/admin/include/adminpanel.inc`):**
+- One DataFile per account (`AdminPanelFilespec`, under `data/ds/admin/`), created in a dedicated new `admin` package purely because DataFile filespecs must resolve to a real, registered `pkg.cfg` package name.
+- Name and death/poisoning history is keyed per character serial (a reserved `"_account_"` element key holds account-wide note history instead), so history stays attached to a character across renames rather than being keyed by name.
+- Every recorded entry stores a timestamp (`FormatEpochTimestamp`), the recording script's name (`CurrentScriptName()`, via `GetProcess(GetPid()).name` - the same idiom `staff.inc`'s `LogCommand` already uses), and an initiator classification (`Staff`/`Player`/`System`).
+- `TrimHistoryToLimit` caps every history array at 100 entries (`ADMINPANEL_MAX_HISTORY`), erasing from the front, applied on every write so none of the four tracked histories can grow unbounded.
+- `RecordCharacterNameChange` only records when `mobile.isa(POLCLASS_MOBILE) && mobile.acct` - NPCs have no account and are never recorded, confirmed no hook fires on any NPC/template renaming path.
+- The first time a character's name history is recorded, if history is empty, the character's pre-change name is bootstrapped in as an "unknown"-origin entry (blank script/initiator/timestamp) so a character that existed before this tracking was added isn't misattributed a fabricated origin.
+- `RecordCharacterDeath` resolves the killer's account independently via `SystemFindObjectBySerial(killer_serial, SYSFIND_SEARCH_OFFLINE_MOBILES)` rather than depending on `chrdeath.src`'s existing online-only name resolution, so the killer's account still shows if they've since logged off.
+- `RecordAccountNote`/`GetLatestNoteInfo`: the account's existing single `Notes` cprop remains the untouched source of truth for the note itself; a parallel `notes_history` array (also capped at 100) records every write with attribution. `GetLatestNoteInfo` cross-references the two by comparing note text and falls back to blank attribution if they don't match, so a note set through any not-yet-wired path is shown as `"Unknown"` rather than misattributed to the wrong staffer.
+
+**Wiring - every character rename site found in the codebase now calls `RecordCharacterNameChange`, scoped to accounts only:**
+- Staff-initiated: `.setprop name`, `.setname`, `.info`'s rename button, `.info`'s `fixnameguild`, `admin.src`'s `fixnameguild`, `.changename`, `.editcharacter`, `mobedit`/`newmobedit`, `.removerper`.
+- Player-initiated: the rename gump (`namechanger.src`), race-gate name suffixing (`racegate.src`), and RPer faction join (`rperstone.src`, appending `" [RPer]"`).
+- Account notes (`RecordAccountNote`): `.notes`, `.info`'s NOTES action, and `admin.src`'s NOTES action (all Staff-initiated); `antiloot.inc`'s `AutoJail()` (System-initiated, fires on repeat town-looting offenses).
+
+**Bug fixes surfaced during the sweep:**
+- `.setprop`'s value-rebuild loop appended a trailing space after every word, including the last (e.g. `"Paladin Rahl One "`), which silently tripped `CheckName`'s bad-spacing rejection while showing a generic "already in use" message that masked the real cause. Fixed the trailing space (`pval := pval[1, len(pval)-1];`) and added `NameCheckFailureReason()` so `.setprop`, `.setname`, and `.info`'s rename button all now show the actual rejection reason.
+- `despawn.src` and `primespawn.src` both still had `program forcespawn(...)` as their program declaration (evidently copy-pasted from `forcespawn.src` when those two commands were created) instead of matching their own filenames; corrected, and a null/invalid-spawnpoint guard was added to both plus `forcespawn.src` itself.
+- Removed a leftover debug `Print("stuff")` call in `gotomobtype.src`.
+- `restartspawnpointarea.src` had its own copy of the same O(n^2)*8-pass location-reordering logic documented in section 9 for `.go`; rewritten to the identical single O(n) dedupe-then-bucket pattern (dedupe by `Key`, bucket by type label, emit known types in priority order, then unrecognized-type entries in original encounter order).
+
+---
+
+## 15. Exhaustive File-by-File Change List
+
+All files changed in `Patch-1.0.7..HEAD`:
 
 | File | Notes |
 |------|-------|
@@ -351,6 +423,9 @@ All files changed in `Patch-1.0.7..HEAD`, plus current uncommitted working-tree 
 | `pkg/opt/alryc/textcmd/test/gotomulti.src` | New multi location and teleport developer tool |
 | `pkg/opt/alryc/textcmd/test/makecheck.src` | New cheque creation developer tool |
 | `pkg/opt/alryc/textcmd/test/whereat.src` | New target-inspection developer tool |
+| `pkg/opt/admin/pkg.cfg` | New package created to host the audit-panel datafile namespace |
+| `pkg/opt/admin/include/adminpanel.inc` | New name/death/poison/note tracking data layer |
+| `pkg/opt/admin/textcmd/test/testadminpanel.src` | New `.testadminpanel` staff audit gump |
 | `pkg/opt/areas/EnterAreaDelay.src` | Switched to the new area-policy resolution flow |
 | `pkg/opt/areas/LeaveArea.src` | Switched to the new area-policy resolution flow |
 | `pkg/opt/areas/areaban.src` | Updated for the new area-policy path |
@@ -358,23 +433,31 @@ All files changed in `Patch-1.0.7..HEAD`, plus current uncommitted working-tree 
 | `pkg/opt/areas/include/areapolicy.inc` | Policy resolver/cache layer, plus realm sanitization and mask-value cache |
 | `pkg/opt/areas/include/areapolicy.inc.bak` | Backup of the pre-rewrite policy layer |
 | `pkg/opt/areas/textcmd/admin/areas.src` | Rewritten area policy admin gump and flag editor |
-| `pkg/opt/crafterboost/make_crafter_boosts.src` | *(uncommitted)* Full Omega Cache integration added |
+| `pkg/opt/crafterboost/make_crafter_boosts.src` | Full Omega Cache integration added |
 | `pkg/opt/holybook/removecurse.src` | Revised Remove Curse chance logic |
-| `pkg/opt/omegacache/categories.cfg` | *(uncommitted)* 12 leveled-potion objtypes added to the Potions category |
+| `pkg/opt/loot/antiloot.inc` | `AutoJail()` now records an account note (System-initiated) |
+| `pkg/opt/omegacache/categories.cfg` | 12 leveled-potion objtypes added to the Potions category |
+| `pkg/opt/roleplaying/rperstone.src` | RPer faction join now records a name change |
 | `pkg/opt/shilhook/shilhook.src` | Skill gain and difficulty refactor |
 | `pkg/opt/spawnpoint/config/groups.cfg` | Spawnpoint group config update |
 | `pkg/opt/spawnpoint/include/restartspawnpoint.inc` | Shared spawnpoint restart helper |
+| `pkg/opt/spawnpoint/textcmd/admin/despawn.src` | Fixed `program` name mismatch, added null/invalid-spawnpoint guard |
+| `pkg/opt/spawnpoint/textcmd/admin/forcespawn.src` | Added null/invalid-spawnpoint guard |
+| `pkg/opt/spawnpoint/textcmd/admin/gotomobtype.src` | Removed leftover debug `Print("stuff")` call |
+| `pkg/opt/spawnpoint/textcmd/admin/newmobedit.src` | Name field now records a name change |
+| `pkg/opt/spawnpoint/textcmd/admin/primespawn.src` | Fixed `program` name mismatch, added null/invalid-spawnpoint guard |
 | `pkg/opt/spawnpoint/textcmd/admin/restartspawnpoint.src` | Restart command now uses the helper |
-| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | New region-wide restart command |
+| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | New region-wide restart command; `ReorderLocationsForDisplay` also rewritten to O(n) |
 | `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointmax.src` | Force-fill restart command updated |
 | `pkg/opt/townstones/textcmd/admin/createtownstone.src` | Creation workflow tightened and state restoration added |
 | `pkg/opt/townstones/textcmd/admin/removetownmember.src` | New town member removal command |
 | `pkg/opt/townstones/textcmd/admin/townbankstatus.src` | Major town status, member management, and runtime state expansion |
 | `pkg/opt/townstones/tstone.src` | `Citizenship`/`CanselCityzenship` now duplicate-check before mutating a name |
 | `pkg/packethooks/speech/receivespeechhook.src` | Unicode speech packet decode fix |
-| `pkg/std/blacksmithy/make_blacksmith_items.src` | *(uncommitted)* Omega Cache targeting fixed, dead code removed |
+| `pkg/std/blacksmithy/make_blacksmith_items.src` | Omega Cache targeting fixed, dead code removed |
 | `pkg/std/housing/housedeed.src` | Region-based city/dungeon/shrine/graveyard placement restrictions |
 | `pkg/std/treasuremap/treasure.cfg` | One treasure location adjusted |
+| `pkg/commands/commands/gm/mobedit.src` | Name field now records a name change |
 | `pol.cfg` | Profiling and sysload watchers enabled |
 | `pythonscripts/generate_golocs_by_id.py` | New generator for indexed go-location config |
 | `regions/regions.cfg` | Large region metadata expansion and normalization |
@@ -383,21 +466,30 @@ All files changed in `Patch-1.0.7..HEAD`, plus current uncommitted working-tree 
 | `scripts/ai/person.src` | Townsfolk now wander immediately after spawn |
 | `scripts/ai/setup/criersetup.inc` | Safer crier config handling |
 | `scripts/ai/townperson.src` | Town NPCs now wander immediately after spawn |
-| `scripts/include/NameChecker.inc` | Town-suffix exploit closure, case-insensitive dedupe, bad-spacing rejection, caching |
+| `scripts/include/NameChecker.inc` | Town-suffix exploit closure, case-insensitive dedupe, bad-spacing rejection, caching; `NameCheckFailureReason()` added |
 | `scripts/include/anchors.inc` | Anchor and lookup helpers updated for new area behavior |
 | `scripts/include/areas.inc` | Area helper rewrite to match the new policy layer |
-| `scripts/include/string.inc` | *(uncommitted)* `SortMultiArrayByIndex` rewritten to O(n log n) merge sort |
+| `scripts/include/dotempmods.inc` | `SetPoison()` now records a poisoning entry |
+| `scripts/include/string.inc` | `SortMultiArrayByIndex` rewritten to O(n log n) merge sort |
 | `scripts/include/townsfolk.inc` | Townfolk helper alignment update |
-| `scripts/misc/namechanger.src` | `force_town_check := 1`, "bad spacing" error message |
+| `scripts/items/racegate.src` | Race-gate name suffixing now records a name change |
+| `scripts/misc/chrdeath.src` | Character death now records a death entry |
+| `scripts/misc/namechanger.src` | `force_town_check := 1`, "bad spacing" error message; rename gump now records a name change |
 | `scripts/misc/oncreate.src` | `force_town_check := 1` |
-| `scripts/textcmd/admin/setname.src` | Now runs through `CheckName`, PC-scoped |
-| `scripts/textcmd/coun/go.src` | *(uncommitted)* `ReorderLocationsForDisplay` rewritten to O(n); `.go` also rebuilt around indexed go locations and range fallback (earlier in the patch) |
-| `scripts/textcmd/gm/setprop.src` | `.setprop name` now runs through `CheckName`, PC-scoped |
-| `scripts/textcmd/seer/info.src` | Rename button now runs through `CheckName`, PC-scoped |
+| `scripts/textcmd/admin/admin.src` | `fixnameguild` now records a name change; NOTES action now records an account note |
+| `scripts/textcmd/admin/removerper.src` | RPer removal now records a name change |
+| `scripts/textcmd/admin/setname.src` | Now runs through `CheckName`, PC-scoped; shows real rejection reason; records name changes |
+| `scripts/textcmd/coun/go.src` | `ReorderLocationsForDisplay` rewritten to O(n); `.go` also rebuilt around indexed go locations and range fallback (earlier in the patch) |
+| `scripts/textcmd/coun/notes.src` | `.notes` now records an account note |
+| `scripts/textcmd/gm/changename.src` | `.changename` now records a name change |
+| `scripts/textcmd/gm/setprop.src` | `.setprop name` now runs through `CheckName`, PC-scoped; trailing-space bug fixed; shows real rejection reason; records name changes |
+| `scripts/textcmd/seer/info.src` | Rename button now runs through `CheckName`, PC-scoped, shows real rejection reason, and records name changes; `fixnameguild` and NOTES action also record |
+| `scripts/textcmd/test/editcharacter.src` | Name field now records a name change |
+| `config/cmds.cfg` | New `DIR` entry for `.testadminpanel` under the `Test` cmdlevel |
 
 ---
 
-## 15. Risk and Regression Notes
+## 16. Risk and Regression Notes
 
 1. `regions/regions.cfg` and `config/golocs_by_id.cfg` are now tightly coupled. Any future region edit should regenerate the go-location index rather than hand-editing the generated file.
 2. The area-policy caches (parsed-line cache and the new mask-value cache) use global properties and, for the parsed-line cache, a line-count fingerprint. If `areas.cfg` changes shape, cache invalidation needs to remain intact or stale policy data can persist. The mask-value cache is invalidated precisely on `SetPolicyMask`/`PruneStaleRealmPolicies` writes, so it should stay correct as long as no other code path writes the `AREA_POLICY_MASK_PROP` datafile property directly.
@@ -408,3 +500,7 @@ All files changed in `Patch-1.0.7..HEAD`, plus current uncommitted working-tree 
 7. The blacksmithy and crafter-boost Omega Cache fixes change previously-broken or entirely-missing behavior into working behavior — this is a net-new capability for players (the failure mode was "doesn't work," not "we're removing something"), but should still get a quick live test: hammer-to-cache targeting for a plain ingot craft, bone-armor dual-material with the cache as either material, and a crafter-boost upgrade with the target material sourced from a cache.
 8. The `.go` and shared-sort algorithmic rewrites are drop-in replacements with verified-identical output ordering (hand-traced on a small example for the merge sort; the `.go` reorder was verified against its old semantics directly). Risk is low, but both are hot, frequently-run staff commands, so a live spot check (a `.go` menu with a large realm, and `.gotomulti`/`.gotoboat` with the current multi/boat counts) is still worthwhile.
 9. The potion-categorization fix is UI-only (Omega Cache category grouping) and carries no gameplay risk.
+10. The audit panel's four history arrays (names, deaths, poisonings, account notes) hard-trim to 100 entries, erasing the oldest first. This is intentional to bound datafile growth, but it means very active characters/accounts will lose their oldest audit history over time rather than growing indefinitely — worth knowing before staff rely on it for long-term investigation.
+11. `GetLatestNoteInfo()`'s attribution is derived by comparing the account's live `Notes` cprop text against the last `notes_history` entry; if a note is ever set through a path that isn't wired to `RecordAccountNote` (or was set before this feature existed), the panel will correctly show blank/"Unknown" attribution rather than a wrong name — by design, but staff should not read a blank attribution as "nobody knows," only as "not recorded through a tracked path."
+12. `.testadminpanel` is read/write-audit-only and gated to the `Test` cmdlevel; it does not change any player-facing behavior. The only behavior changes with any player visibility from this section are the `.setprop`/`.setname`/`.info` rejection-message wording (now shows the real reason instead of a generic one) and the `despawn`/`primespawn`/`forcespawn` null-spawnpoint guard — both staff-tool-only surfaces.
+13. This document's commit range (`9f8189f..7c27772`) includes two commits not detailed here: `b347427` (already covered by sections 9-11) and `232ee95` ("Townstone fixes, Minstel and townsfolk fix" — a townstone treasury-race-condition fix, election/mayor-removal cleanup, a candidate-list pairing bug fix, and a townlist-bootstrap self-heal on login). If player-facing patch notes are needed for `232ee95`, it should get its own review pass rather than being folded in here secondhand.

--- a/patchnotes/launchernotes.md
+++ b/patchnotes/launchernotes.md
@@ -97,6 +97,16 @@ Always check Discord announcements for all the patch notes.
 
 ---
 
+## Staff Tools - Character and Account History Tracking
+
+### Player Impact
+
+- No direct gameplay change expected. Staff now have a new internal tool to look up an account's characters and review name-change, death, poisoning, and account-note history.
+- If a staff member ever rejects a name change, the message now tells you the actual reason instead of one generic message.
+- Fixed a bug where `.setprop name` could silently reject a valid new name due to an invisible trailing space it was adding itself.
+
+---
+
 ## Staff and Support Tools
 
 ### Player Impact
@@ -119,6 +129,7 @@ Always check Discord announcements for all the patch notes.
 - Skill gain handling was retuned for higher-skill edge cases.
 - Town NPCs start wandering immediately after spawning.
 - Two hot commands were made significantly faster.
+- Staff now have a new character/account history tracking tool, and name-rejection messages are clearer.
 - Staff support commands and data generators were refreshed.
 
 Thanks for playing Zuluhotel Omega 2.5.

--- a/patchnotes/patch-v1.0.8.md
+++ b/patchnotes/patch-v1.0.8.md
@@ -108,6 +108,16 @@ Welcome to **Patch 1.0.8**. This update focuses on **player-run town administrat
 
 ---
 
+## Staff Tools - Character and Account History Tracking
+
+### Player Impact
+
+- No direct gameplay change expected. Staff now have a new internal tool to look up an account's characters and review name-change, death, poisoning, and account-note history, so support and moderation questions can be answered faster.
+- If a staff member ever rejects a name change (via `.setprop`, `.setname`, or `.info`), the message now tells you the actual reason (too long/short, bad spacing, reserved word, contains a town name, or already in use) instead of one generic "invalid or already in use" message.
+- Fixed a bug where `.setprop name` could silently reject a valid new name due to an invisible trailing space it was adding itself.
+
+---
+
 ## Staff and Support Tools
 
 ### Player Impact
@@ -139,6 +149,7 @@ Welcome to **Patch 1.0.8**. This update focuses on **player-run town administrat
 - Skill gain handling was retuned for higher-skill edge cases.
 - Town NPCs start wandering immediately after spawning.
 - Two hot commands were made significantly faster.
+- Staff now have a new character/account history tracking tool, and name-rejection messages are clearer.
 - Staff support commands and data generators were refreshed.
 
 Thanks for playing Zuluhotel Omega 2.5.

--- a/pkg/commands/commands/gm/mobedit.src
+++ b/pkg/commands/commands/gm/mobedit.src
@@ -10,6 +10,7 @@ include "include/attributes";
 include "include/client";
 include ":gumps:gumps";
 include ":gumps:gumps_ex";
+include ":admin:include/adminpanel";
 
 const TEXT_COLOR := 657;
 
@@ -165,6 +166,7 @@ program textcmd_mobedit(who)
 			return 0;
 		endif
 		if (old_stats[1] != new_stats[1])
+			RecordCharacterNameChange(mobile, new_stats[1], ADMINPANEL_INITIATOR_STAFF);
 			mobile.name := new_stats[1];
 			SendSysMessage(who, "Changing Name to: "+new_stats[1]);
 		endif

--- a/pkg/opt/admin/include/adminpanel.inc
+++ b/pkg/opt/admin/include/adminpanel.inc
@@ -1,0 +1,631 @@
+use uo;
+use datafile;
+
+include "include/time";
+
+const ADMINPANEL_PKG := "admin";
+
+const ADMINPANEL_INITIATOR_STAFF  := "Staff";
+const ADMINPANEL_INITIATOR_PLAYER := "Player";
+const ADMINPANEL_INITIATOR_SYSTEM := "System";
+
+// Reserved element key for account-wide (not character-specific) records,
+// e.g. notes_history. Character elements are always keyed by a numeric
+// serial, so this can never collide with one.
+const ADMINPANEL_ACCOUNT_ELEMENT_KEY := "_account_";
+
+// Hard cap on stored entries per history array (name_history/death_history/
+// poison_history/notes_history), enforced on every write so a long-lived,
+// frequently-renamed/killed/noted account or character can't grow any of
+// them without bound.
+const ADMINPANEL_MAX_HISTORY := 100;
+
+function AdminPanelFilespec(acctname)
+	return ":"+ADMINPANEL_PKG+":"+CStr(acctname);
+endfunction
+
+function OpenAdminPanelDataFile(acctname)
+	var filespec := AdminPanelFilespec(acctname);
+	var df := OpenDataFile(filespec);
+	if(!df)
+		CreateDataFile(filespec, flags := DF_KEYTYPE_STRING);
+		df := OpenDataFile(filespec);
+	endif
+	return df;
+endfunction
+
+// Drops the oldest entries until history.size() <= max_count.
+function TrimHistoryToLimit(history, max_count)
+	while(history.size() > max_count)
+		history.erase(1);
+	endwhile
+	return history;
+endfunction
+
+// The name of the currently-running .src (e.g. "setname", "SetProp"),
+// matching the same GetProcess(GetPid())/split-on-"/" idiom staff.inc's
+// LogCommand() already uses elsewhere in this codebase.
+function CurrentScriptName()
+	var script_path := CStr(GetProcess(GetPid()).name);
+	var parts := SplitWords(script_path, "/");
+	if(!parts.size())
+		return script_path;
+	endif
+	return parts[parts.size()];
+endfunction
+
+// Formats a raw epoch/game-clock second count the same way NowString() does
+// (see include/time.inc), so account timestamps (e.g. LastLogin) display
+// consistently with everything else in this panel. "" if secs is falsy.
+function FormatEpochTimestamp(secs)
+	secs := CInt(secs);
+	if(!secs)
+		return "";
+	endif
+	return (GetDateString(secs) + " " + GetTimeString(secs));
+endfunction
+
+// Best-effort account name for whoever (or whatever) holds `serial` right
+// now - works for offline mobiles too. "" if unresolvable or not a PC.
+function ResolveAccountNameFromSerial(serial)
+	serial := CInt(serial);
+	if(!serial)
+		return "";
+	endif
+	var obj := SystemFindObjectBySerial(serial, SYSFIND_SEARCH_OFFLINE_MOBILES);
+	if(!obj)
+		return "";
+	endif
+	return CStr(obj.acctname);
+endfunction
+
+
+///////////////////////////////////////////////////////////////////////////
+// Names
+///////////////////////////////////////////////////////////////////////////
+
+// A single history entry: struct{"name","timestamp","script","initiator"}.
+function MakeNameHistoryEntry(name, initiator_type)
+	var entry := struct;
+	entry.+name := CStr(name);
+	entry.+timestamp := NowString();
+	entry.+script := CurrentScriptName();
+	entry.+initiator := CStr(initiator_type);
+	return entry;
+endfunction
+
+// Bootstrap entry for a name we only know about because it was the OLD name
+// on the first tracked rename - we don't know what actually set it (could be
+// character creation, or a rename from before this system existed), so it's
+// left blank rather than misattributed to the current rename's script/initiator.
+function MakeUnknownNameHistoryEntry(name)
+	var entry := struct;
+	entry.+name := CStr(name);
+	entry.+timestamp := "";
+	entry.+script := "";
+	entry.+initiator := "";
+	return entry;
+endfunction
+
+// Entries recorded before timestamp/script/initiator existed are bare
+// strings, or structs missing the newer fields - normalize so callers only
+// ever deal with the full struct shape.
+function NormalizeNameHistoryEntry(entry)
+	var normalized := struct;
+
+	if(Lower(TypeOf(entry)) == "string")
+		normalized.+name := CStr(entry);
+		normalized.+timestamp := "";
+		normalized.+script := "";
+		normalized.+initiator := "";
+		return normalized;
+	endif
+
+	normalized.+name := entry.name;
+
+	var ts := entry.timestamp;
+	if(!ts)
+		ts := "";
+	endif
+	normalized.+timestamp := ts;
+
+	var scr := entry.script;
+	if(!scr)
+		scr := "";
+	endif
+	normalized.+script := scr;
+
+	var init := entry.initiator;
+	if(!init)
+		init := "";
+	endif
+	normalized.+initiator := init;
+
+	return normalized;
+endfunction
+
+// Call this BEFORE the caller applies the rename (SetName()/.name:=), so
+// mobile.name here still holds the value being replaced. initiator_type
+// should be ADMINPANEL_INITIATOR_STAFF or ADMINPANEL_INITIATOR_PLAYER.
+function RecordCharacterNameChange(mobile, new_name, initiator_type)
+	if(!mobile or !mobile.isa(POLCLASS_MOBILE) or !mobile.acct)
+		return;
+	endif
+
+	var old_name := CStr(mobile.name);
+	new_name := CStr(new_name);
+	if(!new_name or new_name == old_name)
+		return;
+	endif
+
+	var acctname := CStr(mobile.acctname);
+	var df := OpenAdminPanelDataFile(acctname);
+	if(!df)
+		return;
+	endif
+
+	var char_key := CStr(mobile.serial);
+	var elem := df.FindElement(char_key);
+	if(!elem)
+		elem := df.CreateElement(char_key);
+	endif
+	if(!elem)
+		UnloadDataFile(AdminPanelFilespec(acctname));
+		return;
+	endif
+
+	var history := elem.GetProp("name_history");
+	if(!history)
+		history := {};
+	endif
+
+	if(!history.size())
+		history.append(MakeUnknownNameHistoryEntry(old_name));
+	endif
+	history.append(MakeNameHistoryEntry(new_name, initiator_type));
+	history := TrimHistoryToLimit(history, ADMINPANEL_MAX_HISTORY);
+
+	elem.SetProp("name_history", history);
+
+	UnloadDataFile(AdminPanelFilespec(acctname));
+endfunction
+
+// Stored name-history array (chronological, oldest first; each entry a
+// struct{"name","timestamp","script","initiator"}) for a character serial on
+// an account. {} if nothing has been recorded for it yet.
+function GetStoredNameHistory(acctname, serial)
+	var df := OpenDataFile(AdminPanelFilespec(acctname));
+	if(!df)
+		return {};
+	endif
+
+	var elem := df.FindElement(CStr(serial));
+	var history := {};
+	if(elem)
+		history := elem.GetProp("name_history");
+		if(!history)
+			history := {};
+		endif
+	endif
+
+	UnloadDataFile(AdminPanelFilespec(acctname));
+	return history;
+endfunction
+
+// struct{"lines","total","remaining"} - "Current: X (timestamp)" /
+// "Previous: Y (timestamp, initiator, via script)" lines (most recent
+// previous name first) for the given live mobile, capped to the most recent
+// `limit` names total (Current counts as one). "remaining" is how many
+// stored entries didn't fit under that cap.
+function BuildNameHistorySummary(mobile, limit := 10)
+	var lines := {};
+	var current := CStr(mobile.name);
+	var history := GetStoredNameHistory(CStr(mobile.acctname), CStr(mobile.serial));
+
+	var current_line := "Current: "+current;
+	if(history.size())
+		var last_entry := NormalizeNameHistoryEntry(history[history.size()]);
+		if(last_entry.name == current && last_entry.timestamp)
+			current_line := current_line+"  ("+last_entry.timestamp+")";
+		endif
+	endif
+	lines.append(current_line);
+
+	var i;
+	for(i := history.size(); i >= 1; i := i - 1)
+		if(lines.size() >= limit)
+			break;
+		endif
+
+		var entry := NormalizeNameHistoryEntry(history[i]);
+		if(entry.name == current)
+			continue;
+		endif
+
+		var line := "Previous: "+entry.name;
+		var detail := "";
+		if(entry.timestamp)
+			detail := entry.timestamp;
+		endif
+		if(entry.initiator)
+			if(detail)
+				detail := detail+", ";
+			endif
+			detail := detail+entry.initiator;
+		endif
+		if(entry.script)
+			if(detail)
+				detail := detail+", ";
+			endif
+			detail := detail+"via "+entry.script;
+		endif
+		if(detail)
+			line := line+"  ("+detail+")";
+		endif
+		lines.append(line);
+	endfor
+
+	var summary := struct;
+	summary.+lines := lines;
+	summary.+total := history.size();
+	var remaining := history.size() - lines.size();
+	if(remaining < 0)
+		remaining := 0;
+	endif
+	summary.+remaining := remaining;
+
+	return summary;
+endfunction
+
+
+///////////////////////////////////////////////////////////////////////////
+// Deaths
+///////////////////////////////////////////////////////////////////////////
+
+// A single death entry: struct{"killed_by","killed_by_serial","killed_by_account","x","y","z","timestamp"}.
+function MakeDeathHistoryEntry(killed_by, killed_by_serial, x, y, z)
+	var entry := struct;
+	entry.+killed_by := CStr(killed_by);
+	entry.+killed_by_serial := CInt(killed_by_serial);
+	entry.+killed_by_account := ResolveAccountNameFromSerial(killed_by_serial);
+	entry.+x := CInt(x);
+	entry.+y := CInt(y);
+	entry.+z := CInt(z);
+	entry.+timestamp := NowString();
+	return entry;
+endfunction
+
+// Entries recorded before killed_by_account existed are missing that field -
+// normalize so callers only ever deal with the full struct shape.
+function NormalizeDeathHistoryEntry(entry)
+	var acct := entry.killed_by_account;
+	if(!acct)
+		acct := "";
+	endif
+	entry.killed_by_account := acct;
+	return entry;
+endfunction
+
+// Call this once a character's death is confirmed and its KilledBy/
+// KilledBySerial/deathx/deathy/deathz cprops are set (see scripts/misc/chrdeath.src)
+// but before anything erases them.
+function RecordCharacterDeath(mobile, killed_by, killed_by_serial, x, y, z)
+	if(!mobile or !mobile.isa(POLCLASS_MOBILE) or !mobile.acct)
+		return;
+	endif
+
+	var acctname := CStr(mobile.acctname);
+	var df := OpenAdminPanelDataFile(acctname);
+	if(!df)
+		return;
+	endif
+
+	var char_key := CStr(mobile.serial);
+	var elem := df.FindElement(char_key);
+	if(!elem)
+		elem := df.CreateElement(char_key);
+	endif
+	if(!elem)
+		UnloadDataFile(AdminPanelFilespec(acctname));
+		return;
+	endif
+
+	var history := elem.GetProp("death_history");
+	if(!history)
+		history := {};
+	endif
+
+	history.append(MakeDeathHistoryEntry(killed_by, killed_by_serial, x, y, z));
+	history := TrimHistoryToLimit(history, ADMINPANEL_MAX_HISTORY);
+
+	elem.SetProp("death_history", history);
+
+	UnloadDataFile(AdminPanelFilespec(acctname));
+endfunction
+
+// Stored death-history array (chronological, oldest first; each entry a
+// struct{"killed_by","killed_by_serial","killed_by_account","x","y","z","timestamp"})
+// for a character serial on an account. {} if nothing has been recorded yet.
+function GetStoredDeathHistory(acctname, serial)
+	var df := OpenDataFile(AdminPanelFilespec(acctname));
+	if(!df)
+		return {};
+	endif
+
+	var elem := df.FindElement(CStr(serial));
+	var history := {};
+	if(elem)
+		history := elem.GetProp("death_history");
+		if(!history)
+			history := {};
+		endif
+	endif
+
+	UnloadDataFile(AdminPanelFilespec(acctname));
+	return history;
+endfunction
+
+// struct{"lines","total","remaining"} - "Killed by X, account, at (x,y,z)
+// (timestamp)" lines (most recent first) for the given live mobile, capped
+// to the most recent `limit` deaths. "remaining" is how many didn't fit.
+function BuildDeathHistorySummary(mobile, limit := 5)
+	var lines := {};
+	var history := GetStoredDeathHistory(CStr(mobile.acctname), CStr(mobile.serial));
+
+	var i;
+	for(i := history.size(); i >= 1; i := i - 1)
+		if(lines.size() >= limit)
+			break;
+		endif
+
+		var entry := NormalizeDeathHistoryEntry(history[i]);
+		var killed_by := entry.killed_by;
+		if(!killed_by)
+			killed_by := "Unknown";
+		endif
+
+		var line := "Killed by "+killed_by;
+		if(entry.killed_by_account)
+			line := line+", "+entry.killed_by_account;
+		endif
+		line := line+", at ("+entry.x+","+entry.y+","+entry.z+")";
+		if(entry.timestamp)
+			line := line+"  ("+entry.timestamp+")";
+		endif
+		lines.append(line);
+	endfor
+
+	var summary := struct;
+	summary.+lines := lines;
+	summary.+total := history.size();
+	var remaining := history.size() - lines.size();
+	if(remaining < 0)
+		remaining := 0;
+	endif
+	summary.+remaining := remaining;
+
+	return summary;
+endfunction
+
+
+///////////////////////////////////////////////////////////////////////////
+// Poisonings
+///////////////////////////////////////////////////////////////////////////
+
+// A single poison entry: struct{"poisoned_by","level","timestamp"}.
+function MakePoisonHistoryEntry(poisoned_by, level)
+	var entry := struct;
+	entry.+poisoned_by := CStr(poisoned_by);
+	entry.+level := CInt(level);
+	entry.+timestamp := NowString();
+	return entry;
+endfunction
+
+// Call this wherever a character actually gets poisoned (see SetPoison() in
+// scripts/include/dotempmods.inc) - records every poisoning, not just fatal ones.
+function RecordCharacterPoisoning(mobile, poisoned_by, level)
+	if(!mobile or !mobile.isa(POLCLASS_MOBILE) or !mobile.acct)
+		return;
+	endif
+
+	var acctname := CStr(mobile.acctname);
+	var df := OpenAdminPanelDataFile(acctname);
+	if(!df)
+		return;
+	endif
+
+	var char_key := CStr(mobile.serial);
+	var elem := df.FindElement(char_key);
+	if(!elem)
+		elem := df.CreateElement(char_key);
+	endif
+	if(!elem)
+		UnloadDataFile(AdminPanelFilespec(acctname));
+		return;
+	endif
+
+	var history := elem.GetProp("poison_history");
+	if(!history)
+		history := {};
+	endif
+
+	history.append(MakePoisonHistoryEntry(poisoned_by, level));
+	history := TrimHistoryToLimit(history, ADMINPANEL_MAX_HISTORY);
+
+	elem.SetProp("poison_history", history);
+
+	UnloadDataFile(AdminPanelFilespec(acctname));
+endfunction
+
+// Stored poison-history array (chronological, oldest first; each entry a
+// struct{"poisoned_by","level","timestamp"}) for a character serial on an
+// account. {} if nothing has been recorded yet.
+function GetStoredPoisonHistory(acctname, serial)
+	var df := OpenDataFile(AdminPanelFilespec(acctname));
+	if(!df)
+		return {};
+	endif
+
+	var elem := df.FindElement(CStr(serial));
+	var history := {};
+	if(elem)
+		history := elem.GetProp("poison_history");
+		if(!history)
+			history := {};
+		endif
+	endif
+
+	UnloadDataFile(AdminPanelFilespec(acctname));
+	return history;
+endfunction
+
+// struct{"lines","total","remaining"} - "Poisoned by X (timestamp)" lines
+// (most recent first), capped to the most recent `limit` poisonings.
+function BuildPoisonHistorySummary(mobile, limit := 5)
+	var lines := {};
+	var history := GetStoredPoisonHistory(CStr(mobile.acctname), CStr(mobile.serial));
+
+	var i;
+	for(i := history.size(); i >= 1; i := i - 1)
+		if(lines.size() >= limit)
+			break;
+		endif
+
+		var entry := history[i];
+		var poisoned_by := entry.poisoned_by;
+		if(!poisoned_by)
+			poisoned_by := "Unknown";
+		endif
+
+		var line := "Poisoned by "+poisoned_by;
+		if(entry.timestamp)
+			line := line+"  ("+entry.timestamp+")";
+		endif
+		lines.append(line);
+	endfor
+
+	var summary := struct;
+	summary.+lines := lines;
+	summary.+total := history.size();
+	var remaining := history.size() - lines.size();
+	if(remaining < 0)
+		remaining := 0;
+	endif
+	summary.+remaining := remaining;
+
+	return summary;
+endfunction
+
+
+///////////////////////////////////////////////////////////////////////////
+// Account notes
+///////////////////////////////////////////////////////////////////////////
+// Account-wide, not character-specific - stored on the reserved
+// ADMINPANEL_ACCOUNT_ELEMENT_KEY element instead of a character serial.
+// This is purely an audit trail alongside the existing acc.GetProp("Notes")/
+// acc.setprop("Notes", ...) mechanism, which is left completely untouched -
+// staff still read/write the single "latest note" the same way they always
+// have; this just additionally remembers up to the last 100 of them.
+
+function MakeNoteHistoryEntry(note_text, initiator_type)
+	var entry := struct;
+	entry.+note := CStr(note_text);
+	entry.+timestamp := NowString();
+	entry.+script := CurrentScriptName();
+	entry.+initiator := CStr(initiator_type);
+	return entry;
+endfunction
+
+// Call this AFTER acc.setprop("Notes", note_text) succeeds, passing the same
+// account and resulting note text. initiator_type should be
+// ADMINPANEL_INITIATOR_STAFF, ADMINPANEL_INITIATOR_PLAYER, or
+// ADMINPANEL_INITIATOR_SYSTEM (e.g. an automated jail note).
+function RecordAccountNote(account, note_text, initiator_type)
+	if(!account or account.errortext or !note_text)
+		return;
+	endif
+
+	var acctname := CStr(account.name);
+	var df := OpenAdminPanelDataFile(acctname);
+	if(!df)
+		return;
+	endif
+
+	var elem := df.FindElement(ADMINPANEL_ACCOUNT_ELEMENT_KEY);
+	if(!elem)
+		elem := df.CreateElement(ADMINPANEL_ACCOUNT_ELEMENT_KEY);
+	endif
+	if(!elem)
+		UnloadDataFile(AdminPanelFilespec(acctname));
+		return;
+	endif
+
+	var history := elem.GetProp("notes_history");
+	if(!history)
+		history := {};
+	endif
+
+	history.append(MakeNoteHistoryEntry(note_text, initiator_type));
+	history := TrimHistoryToLimit(history, ADMINPANEL_MAX_HISTORY);
+
+	elem.SetProp("notes_history", history);
+
+	UnloadDataFile(AdminPanelFilespec(acctname));
+endfunction
+
+// Stored note-history array (chronological, oldest first; each entry a
+// struct{"note","timestamp","script","initiator"}) for an account. {} if
+// nothing has been recorded yet.
+function GetStoredNoteHistory(acctname)
+	var df := OpenDataFile(AdminPanelFilespec(acctname));
+	if(!df)
+		return {};
+	endif
+
+	var elem := df.FindElement(ADMINPANEL_ACCOUNT_ELEMENT_KEY);
+	var history := {};
+	if(elem)
+		history := elem.GetProp("notes_history");
+		if(!history)
+			history := {};
+		endif
+	endif
+
+	UnloadDataFile(AdminPanelFilespec(acctname));
+	return history;
+endfunction
+
+// struct{"note","timestamp","initiator"} - the current acc.GetProp("Notes")
+// text, paired with who/when recorded it, read off the last matching
+// notes_history entry. If the stored note doesn't match the last history
+// entry (e.g. it was set before this tracking existed, or by a path this
+// panel doesn't hook), timestamp/initiator come back blank rather than
+// misattributed.
+function GetLatestNoteInfo(account)
+	var info := struct;
+	info.+note := CStr(account.GetProp("Notes"));
+	info.+timestamp := "";
+	info.+initiator := "";
+
+	var history := GetStoredNoteHistory(CStr(account.name));
+	if(!history.size())
+		return info;
+	endif
+
+	var last_entry := history[history.size()];
+	if(CStr(last_entry.note) != info.note)
+		return info;
+	endif
+
+	var ts := last_entry.timestamp;
+	if(ts)
+		info.timestamp := ts;
+	endif
+
+	var init := last_entry.initiator;
+	if(init)
+		info.initiator := init;
+	endif
+
+	return info;
+endfunction

--- a/pkg/opt/admin/pkg.cfg
+++ b/pkg/opt/admin/pkg.cfg
@@ -1,0 +1,5 @@
+# Admin data panel: .testadminpanel (textcmd/test/testadminpanel.src) plus
+# its RecordCharacterNameChange() helper (include/adminpanel.inc). Per-account
+# records land under data/ds/admin/.
+Enabled 1
+Name admin

--- a/pkg/opt/admin/textcmd/test/testadminpanel.src
+++ b/pkg/opt/admin/textcmd/test/testadminpanel.src
@@ -1,0 +1,390 @@
+// Synopsis: Browse accounts and view each character's recorded name/death/poison history and account notes
+// command .testadminpanel
+use uo;
+use os;
+
+include ":admin:include/adminpanel";
+include ":accounts:include/accounts";
+include ":gumps:include/gumps";
+
+const BTN_BACK             := 9000;
+const BTN_BROWSE_ACCOUNTS  := 1;
+
+const ACCOUNTS_PER_PAGE := 8;
+
+var LETTERS := {"A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z"};
+
+program textcmd_testadminpanel(who)
+	var state := "main";
+	var selected_letter := "";
+	var selected_account := "";
+	var selected_char := 0;
+
+	while(1)
+		if(state == "main")
+			var choice := ShowMainPanel(who);
+			if(choice == BTN_BROWSE_ACCOUNTS)
+				state := "letters";
+			else
+				return;
+			endif
+
+		elseif(state == "letters")
+			var letter_result := ShowLetterPicker(who);
+			if(!letter_result)
+				return;
+			elseif(letter_result == BTN_BACK)
+				state := "main";
+			else
+				selected_letter := letter_result;
+				state := "accounts";
+			endif
+
+		elseif(state == "accounts")
+			var account_result := ShowAccountList(who, selected_letter);
+			if(!account_result)
+				return;
+			elseif(account_result == BTN_BACK)
+				state := "letters";
+			else
+				selected_account := account_result;
+				state := "characters";
+			endif
+
+		elseif(state == "characters")
+			var char_result := ShowCharacterList(who, selected_account);
+			if(!char_result)
+				return;
+			elseif(char_result == BTN_BACK)
+				state := "accounts";
+			else
+				selected_char := char_result;
+				state := "detail";
+			endif
+
+		elseif(state == "detail")
+			var detail_result := ShowCharacterDetail(who, selected_account, selected_char);
+			if(detail_result == BTN_BACK)
+				state := "characters";
+			else
+				return;
+			endif
+		endif
+	endwhile
+endprogram
+
+
+function ShowMainPanel(who)
+	var gump := GFCreateGump(50, 50, 320, 140);
+	GFResizePic(gump, 0, 0, 9250, 320, 140);
+	GFResizePic(gump, 10, 10, 9350, 300, 120);
+	GFTextLine(gump, 20, 20, 43, "Admin Data Panel");
+
+	GFAddButton(gump, 20, 55, 2117, 2118, GF_CLOSE_BTN, BTN_BROWSE_ACCOUNTS);
+	GFTextLine(gump, 50, 55, 67, "Browse by Account");
+
+	GFAddButton(gump, 20, 95, 4017, 4019, GF_CLOSE_BTN, BTN_BACK);
+	GFTextLine(gump, 50, 95, 33, "Close");
+
+	var result := GFSendGump(who, gump);
+	return result[0];
+endfunction
+
+
+function CountAccountsByLetter()
+	var counts := dictionary;
+	var i;
+	for(i := 1; i <= LETTERS.size(); i := i + 1)
+		counts[LETTERS[i]] := 0;
+	endfor
+
+	foreach acctname in (ListAccounts())
+		var name := CStr(acctname);
+		if(!name)
+			continue;
+		endif
+		var first := Upper(name[1,1]);
+		if(counts.Exists(first))
+			counts[first] := counts[first] + 1;
+		endif
+	endforeach
+
+	return counts;
+endfunction
+
+
+function ShowLetterPicker(who)
+	var counts := CountAccountsByLetter();
+
+	var cols := 5;
+	var col_w := 118;
+	var row_h := 34;
+	var x0 := 25;
+	var y0 := 60;
+
+	var rows := CInt((LETTERS.size() - 1) / cols) + 1;
+	var back_y := y0 + (rows * row_h) + 10;
+	var gump_height := back_y + 40;
+	var gump_width := x0 + (cols * col_w) + 25;
+
+	var gump := GFCreateGump(50, 50, gump_width, gump_height);
+	GFResizePic(gump, 0, 0, 9250, gump_width, gump_height);
+	GFResizePic(gump, 10, 10, 9350, gump_width - 20, gump_height - 20);
+	GFTextLine(gump, 20, 20, 43, "Browse Accounts - Choose a Letter");
+
+	var i;
+	for(i := 1; i <= LETTERS.size(); i := i + 1)
+		var letter := LETTERS[i];
+		var col := (i - 1) % cols;
+		var row := CInt((i - 1) / cols);
+		var x := x0 + (col * col_w);
+		var y := y0 + (row * row_h);
+
+		var count := counts[letter];
+		if(!count)
+			count := 0;
+		endif
+
+		if(count > 0)
+			GFAddButton(gump, x, y, 2117, 2118, GF_CLOSE_BTN, i);
+			GFTextLine(gump, x + 28, y + 2, 67, letter + " (" + count + ")");
+		else
+			GFTextLine(gump, x + 28, y + 2, 900, letter + " (0)");
+		endif
+	endfor
+
+	GFAddButton(gump, 20, back_y, 4017, 4019, GF_CLOSE_BTN, BTN_BACK);
+	GFTextLine(gump, 50, back_y, 33, "Back");
+
+	var result := GFSendGump(who, gump);
+	if(!result[0])
+		return 0;
+	endif
+	if(result[0] == BTN_BACK)
+		return BTN_BACK;
+	endif
+
+	return LETTERS[result[0]];
+endfunction
+
+
+function GetAccountsForLetter(letter)
+	var matches := {};
+	foreach acctname in (ListAccounts())
+		var name := CStr(acctname);
+		if(!name)
+			continue;
+		endif
+		if(Upper(name[1,1]) == letter)
+			matches.append(name);
+		endif
+	endforeach
+	matches.sort();
+	return matches;
+endfunction
+
+
+function ShowAccountList(who, letter)
+	var accounts := GetAccountsForLetter(letter);
+	var total := accounts.size();
+
+	if(!total)
+		SendSysMessage(who, "No accounts start with '" + letter + "'.");
+		return BTN_BACK;
+	endif
+
+	var perpage := ACCOUNTS_PER_PAGE;
+	var total_pages := CInt((total - 1) / perpage) + 1;
+
+	var gump := GFCreateGump(50, 50, 460, 460);
+	GFResizePic(gump, 0, 0, 9250, 460, 460);
+	GFResizePic(gump, 10, 10, 9350, 440, 440);
+	GFTextLine(gump, 20, 20, 43, "Accounts starting with '" + letter + "' (" + total + ")");
+
+	GFAddButton(gump, 20, 420, 4017, 4019, GF_CLOSE_BTN, BTN_BACK);
+	GFTextLine(gump, 50, 420, 33, "Back to Letters");
+
+	var i;
+	var page := 0;
+	var y := 0;
+	for(i := 1; i <= total; i := i + 1)
+		var slot := (i - 1) % perpage;
+		if(slot == 0)
+			page := page + 1;
+			GFPage(gump, page);
+			y := 55;
+
+			if(page > 1)
+				GFAddButton(gump, 20, 390, 4014, 4015, GF_PAGE_BTN, page - 1);
+				GFTextLine(gump, 55, 390, 67, "Prev Page");
+			endif
+			if(page < total_pages)
+				GFAddButton(gump, 280, 390, 4005, 4006, GF_PAGE_BTN, page + 1);
+				GFTextLine(gump, 315, 390, 67, "Next Page");
+			endif
+		endif
+
+		var account_name := accounts[i];
+		var account := FindAccount(account_name);
+		var ip := "";
+		var last_login := "";
+		if(account && !account.errortext)
+			ip := CStr(account.GetProp("IP"));
+			last_login := FormatEpochTimestamp(ACCT_GetLastLogin(account));
+		endif
+		if(!ip)
+			ip := "(unknown)";
+		endif
+		if(!last_login)
+			last_login := "(never)";
+		endif
+
+		GFAddButton(gump, 20, y, 2117, 2118, GF_CLOSE_BTN, i);
+		GFTextLine(gump, 50, y, 0, account_name);
+		GFTextLine(gump, 60, y + 18, 900, "IP: "+ip+"   Last Login: "+last_login);
+		y := y + 40;
+	endfor
+
+	var result := GFSendGump(who, gump);
+	if(!result[0])
+		return 0;
+	endif
+	if(result[0] == BTN_BACK)
+		return BTN_BACK;
+	endif
+
+	return accounts[result[0]];
+endfunction
+
+
+function ShowCharacterList(who, acctname)
+	var account := FindAccount(acctname);
+	if(!account or account.errortext)
+		SendSysMessage(who, "Could not find account '" + acctname + "'.");
+		return BTN_BACK;
+	endif
+
+	var characters := ACCT_GetCharacters(account);
+	if(!characters.size())
+		SendSysMessage(who, "No characters found on '" + acctname + "'.");
+		return BTN_BACK;
+	endif
+
+	var note_info := GetLatestNoteInfo(account);
+	var latest_note := note_info.note;
+	if(!latest_note)
+		latest_note := "(no notes)";
+	endif
+	var note_lines := GFWordWrap(latest_note, 350);
+	var notes_total := GetStoredNoteHistory(acctname).size();
+
+	var attribution := "- ";
+	if(note_info.initiator)
+		attribution := attribution + note_info.initiator;
+	else
+		attribution := attribution + "Unknown";
+	endif
+	if(note_info.timestamp)
+		attribution := attribution + ", " + note_info.timestamp;
+	endif
+
+	var notes_y0 := 66;
+	var note_line_h := 20;
+	var chars_y0 := notes_y0 + (note_lines.size() * note_line_h) + (note_line_h * 2) + 14;
+	var height := chars_y0 + (characters.size() * 24) + 40;
+
+	var gump := GFCreateGump(50, 50, 420, height);
+	GFResizePic(gump, 0, 0, 9250, 420, height);
+	GFResizePic(gump, 10, 10, 9350, 400, height - 20);
+	GFTextLine(gump, 20, 20, 43, "Account: "+acctname);
+	GFTextLine(gump, 20, 44, 67, "Notes");
+
+	var y := notes_y0;
+	var i;
+	for(i := 1; i <= note_lines.size(); i := i + 1)
+		GFTextLine(gump, 25, y, 0, note_lines[i]);
+		y := y + note_line_h;
+	endfor
+	GFTextLine(gump, 25, y, 900, attribution);
+	y := y + note_line_h;
+	GFTextLine(gump, 25, y, 900, "("+notes_total+" note record(s) in datafile)");
+
+	y := chars_y0;
+	for(i := 1; i <= characters.size(); i := i + 1)
+		GFAddButton(gump, 20, y, 2117, 2118, GF_CLOSE_BTN, i);
+		GFTextLine(gump, 50, y, 0, CStr(characters[i].name));
+		y := y + 24;
+	endfor
+
+	GFAddButton(gump, 20, y + 5, 4017, 4019, GF_CLOSE_BTN, BTN_BACK);
+	GFTextLine(gump, 50, y + 5, 33, "Back to Accounts");
+
+	var result := GFSendGump(who, gump);
+	if(!result[0])
+		return 0;
+	endif
+	if(result[0] == BTN_BACK)
+		return BTN_BACK;
+	endif
+
+	return characters[result[0]];
+endfunction
+
+
+// Renders a titled block of lines into `gump`, advancing `y` past it -
+// shared by every section on the character-detail screen so adding another
+// subtitle later is a one-line addition, not a layout rewrite.
+function RenderHistorySection(byref gump, title, lines, byref y)
+	GFTextLine(gump, 20, y, 67, title);
+	y := y + 24;
+	var i;
+	for(i := 1; i <= lines.size(); i := i + 1)
+		GFTextLine(gump, 25, y, 0, lines[i]);
+		y := y + 22;
+	endfor
+	y := y + 10;
+endfunction
+
+
+function ShowCharacterDetail(who, acctname, mobile)
+	var names := BuildNameHistorySummary(mobile, 10);
+	var deaths := BuildDeathHistorySummary(mobile, 5);
+	var poisons := BuildPoisonHistorySummary(mobile, 5);
+
+	if(!deaths.lines.size())
+		deaths.lines.append("(no deaths recorded)");
+	endif
+	if(!poisons.lines.size())
+		poisons.lines.append("(no poisonings recorded)");
+	endif
+
+	var top_offset := 70;
+	var section_heights := (34 + (names.lines.size() * 22))
+		+ (34 + (deaths.lines.size() * 22))
+		+ (34 + (poisons.lines.size() * 22));
+	var footer_h := 22;
+	var button_h := 35;
+
+	var height := top_offset + section_heights + footer_h + button_h;
+
+	var gump := GFCreateGump(50, 50, 480, height);
+	GFResizePic(gump, 0, 0, 9250, 480, height);
+	GFResizePic(gump, 10, 10, 9350, 460, height - 20);
+	GFTextLine(gump, 20, 20, 43, "Character Information");
+	GFTextLine(gump, 20, 44, 67, acctname);
+
+	var y := top_offset;
+	RenderHistorySection(gump, "Names", names.lines, y);
+	RenderHistorySection(gump, "Killed By", deaths.lines, y);
+	RenderHistorySection(gump, "Poisoned By", poisons.lines, y);
+
+	var footer := "More in datafile: "+names.remaining+" name record(s), "+deaths.remaining+" death record(s), "+poisons.remaining+" poison record(s)";
+	GFTextLine(gump, 20, y, 900, footer);
+	y := y + footer_h;
+
+	GFAddButton(gump, 20, y, 4017, 4019, GF_CLOSE_BTN, BTN_BACK);
+	GFTextLine(gump, 50, y, 33, "Back to Characters");
+
+	var result := GFSendGump(who, gump);
+	return result[0];
+endfunction

--- a/pkg/opt/loot/antiloot.inc
+++ b/pkg/opt/loot/antiloot.inc
@@ -7,6 +7,7 @@ include "include/classes";
 include "include/dotempmods";
 include "include/areas";
 include "include/constants/locations";
+include ":admin:include/adminpanel";
 
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -210,6 +211,7 @@ function AutoJail (looter)
 	endif
 	acc.setprop("Release", (ReadGameClock() + jaildays));
 	acc.setprop("Notes", note);
+	RecordAccountNote(acc, note, ADMINPANEL_INITIATOR_SYSTEM);
 	looter.frozen := 1;
 	MoveObjectToLocation( looter, DEFAULT_LOCATION_JAIL_X, DEFAULT_LOCATION_JAIL_Y, DEFAULT_LOCATION_JAIL_Z, "britannia", MOVEOBJECT_FORCELOCATION);
 	SendSysMessage( looter, "You have been jailed for attempted town looting.");

--- a/pkg/opt/roleplaying/rperstone.src
+++ b/pkg/opt/roleplaying/rperstone.src
@@ -4,6 +4,7 @@ use uo;
 include "include/client";
 include "include/classes";
 include "rper";
+include ":admin:include/adminpanel";
 
 program OnUse_RPerFactionStone(who)
 
@@ -252,6 +253,7 @@ program OnUse_RPerFactionStone(who)
                     break;
                 2:	SetObjProperty(who,"IsRPer", 1);
                     SetObjProperty(who,"OrgName", who.name);
+                    RecordCharacterNameChange(who, who.name + " [RPer]", ADMINPANEL_INITIATOR_PLAYER);
                     who.name := who.name + " [RPer]";
                     MoveObjectToLocation( who, 5227, 461, 16, "britannia", MOVEOBJECT_FORCELOCATION );
                     SendSysMessage( who, "You have joined the [RPer] faction and have been sent to the town of Randorin!", FONT_NORMAL, 2595 );

--- a/pkg/opt/spawnpoint/textcmd/admin/despawn.src
+++ b/pkg/opt/spawnpoint/textcmd/admin/despawn.src
@@ -5,7 +5,7 @@ use os;
 include "include/constants";
 include "include/client";
 
-program forcespawn(who, input)
+program despawn(who, input)
     var spawnpoint;
     if(!input)
         SendSysMessage(who, "Select Spawnpoint");
@@ -13,11 +13,16 @@ program forcespawn(who, input)
 	else
         spawnpoint := SystemFindObjectBySerial(Cint(input));
 		if(spawnpoint.objtype != 0xa300)
-			SendSysMessage( who, "That's not a Spawnpoint .forcespawn ([serial])", FONT_NORMAL, 2595);
+			SendSysMessage( who, "That's not a Spawnpoint .despawn ([serial])", FONT_NORMAL, 2595);
 			return 0;
 		endif
 	endif
-	    
+
+	if(!spawnpoint || spawnpoint.objtype != 0xa300)
+		SendSysMessage( who, "No valid spawnpoint selected.", FONT_NORMAL, 2595);
+		return 0;
+	endif
+
     PrintTextAbovePrivate( spawnpoint, "*despawned*", who, FONT_NORMAL, 2595);
     SendSysMessage(who, "Despawned everything from spawnpoint");
 	Start_Script( ":spawnpoint:despawner", spawnpoint );

--- a/pkg/opt/spawnpoint/textcmd/admin/forcespawn.src
+++ b/pkg/opt/spawnpoint/textcmd/admin/forcespawn.src
@@ -18,6 +18,11 @@ program forcespawn(who, input)
 		endif
 	endif
 
+	if(!spawnpoint || spawnpoint.objtype != 0xa300)
+		SendSysMessage( who, "No valid spawnpoint selected.", FONT_NORMAL, 2595);
+		return 0;
+	endif
+
 	var pt_data := GetObjProperty( spawnpoint, PROPID_SPAWNPOINT_SETTING );
 	if(pt_data[15])
 		SetObjProperty(spawnpoint, "Triggered", 1);

--- a/pkg/opt/spawnpoint/textcmd/admin/gotomobtype.src
+++ b/pkg/opt/spawnpoint/textcmd/admin/gotomobtype.src
@@ -39,8 +39,6 @@ program textcmd_gotomobtype( character , text )
 					SleepMs(2);
 				endif
             endif
-		elseif( mobile.IsA())
-			Print("stuff");
         endif
     endforeach
 

--- a/pkg/opt/spawnpoint/textcmd/admin/newmobedit.src
+++ b/pkg/opt/spawnpoint/textcmd/admin/newmobedit.src
@@ -17,6 +17,7 @@ include "include/client";
 include ":gumps:gumps";
 include ":gumps:gumps_ex";
 include "include/spelldata";
+include ":admin:include/adminpanel";
 //include "include/math";
 
 const TEXT_COLOR := 657;
@@ -279,6 +280,7 @@ program textcmd_mobedit(who)
 			return 0;
 		endif
 		if (old_stats[1] != new_stats[1])
+			RecordCharacterNameChange(mobile, new_stats[1], ADMINPANEL_INITIATOR_STAFF);
 			mobile.name := new_stats[1];
 			SendSysMessage(who, "Changing Name to: "+new_stats[1]);
 		endif

--- a/pkg/opt/spawnpoint/textcmd/admin/primespawn.src
+++ b/pkg/opt/spawnpoint/textcmd/admin/primespawn.src
@@ -5,7 +5,7 @@ use os;
 include "include/constants";
 include "include/client";
 
-program forcespawn(who, input)
+program primespawn(who, input)
     var spawnpoint;
     if(!input)
         SendSysMessage(who, "Select Spawnpoint");
@@ -13,11 +13,16 @@ program forcespawn(who, input)
 	else
         spawnpoint := SystemFindObjectBySerial(Cint(input));
 		if(spawnpoint.objtype != 0xa300)
-			SendSysMessage( who, "That's not a Spawnpoint .forcespawn ([serial])", FONT_NORMAL, 2595);
+			SendSysMessage( who, "That's not a Spawnpoint .primespawn ([serial])", FONT_NORMAL, 2595);
 			return 0;
 		endif
 	endif
-	
+
+	if(!spawnpoint || spawnpoint.objtype != 0xa300)
+		SendSysMessage( who, "No valid spawnpoint selected.", FONT_NORMAL, 2595);
+		return 0;
+	endif
+
     EraseObjProperty(spawnpoint, PROPID_SPAWNPOINT_NEXT_SPAWNING);
     PrintTextAbovePrivate( spawnpoint, "*primed*", who, FONT_NORMAL, 2595);
     SendSysMessage(who, "Spawnpoint is now waiting for next trigger");

--- a/pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src
+++ b/pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src
@@ -254,45 +254,61 @@ function BuildLocationsForRealm(realm)
 endfunction
 
 
+// Single O(n) bucketing pass (dedupe by Key, then bucket by type) instead of
+// the old 8-pass approach that re-scanned the growing "ordered" list for
+// every entry (O(n^2)*8) -- same fix as go.src's ReorderLocationsForDisplay.
 function ReorderLocationsForDisplay(locs)
+	var type_priority := {"Jail", "City", "Shrine", "Graveyard", "Dungeon", "POI", "None"};
+	var known_types := dictionary;
+	foreach wanted_type in type_priority
+		known_types.Insert(wanted_type, 1);
+	endforeach
+
+	var type_buckets := dictionary;
+	var seen := dictionary;
+
+	foreach entry in locs
+		var dedupe_key := CStr(entry.Key);
+		if(seen.Exists(dedupe_key))
+			continue;
+		endif
+		seen.Insert(dedupe_key, 1);
+
+		var label := GetLocationTypeLabel(entry);
+		var bucket := type_buckets[label];
+		if(!bucket)
+			bucket := {};
+		endif
+		bucket.append(entry);
+		type_buckets[label] := bucket;
+	endforeach
+
 	var ordered := {};
 
-	ordered := AppendLocationsByType(ordered, locs, "Jail");
-	ordered := AppendLocationsByType(ordered, locs, "City");
-	ordered := AppendLocationsByType(ordered, locs, "Shrine");
-	ordered := AppendLocationsByType(ordered, locs, "Graveyard");
-	ordered := AppendLocationsByType(ordered, locs, "Dungeon");
-	ordered := AppendLocationsByType(ordered, locs, "POI");
-	ordered := AppendLocationsByType(ordered, locs, "None");
+	// Known types first, in priority order, each bucket in original encounter order.
+	foreach wanted_type in type_priority
+		var bucket := type_buckets[wanted_type];
+		if(bucket)
+			foreach entry in bucket
+				ordered.append(entry);
+			endforeach
+		endif
+	endforeach
 
+	// Anything with a custom type label goes last, in original encounter order.
+	var emitted := dictionary;
 	foreach entry in locs
-		if(!LocationAlreadyAdded(ordered, entry))
-			ordered.append(entry);
+		var label := GetLocationTypeLabel(entry);
+		if(!known_types.Exists(label))
+			var dedupe_key := CStr(entry.Key);
+			if(seen.Exists(dedupe_key) && !emitted.Exists(dedupe_key))
+				ordered.append(entry);
+				emitted.Insert(dedupe_key, 1);
+			endif
 		endif
 	endforeach
 
 	return ordered;
-endfunction
-
-
-function AppendLocationsByType(ordered, locs, wanted_type)
-	foreach entry in locs
-		if(GetLocationTypeLabel(entry) == wanted_type && !LocationAlreadyAdded(ordered, entry))
-			ordered.append(entry);
-		endif
-	endforeach
-
-	return ordered;
-endfunction
-
-
-function LocationAlreadyAdded(ordered, candidate)
-	foreach entry in ordered
-		if(entry.Key == candidate.Key)
-			return 1;
-		endif
-	endforeach
-	return 0;
 endfunction
 
 

--- a/scripts/include/NameChecker.inc
+++ b/scripts/include/NameChecker.inc
@@ -241,3 +241,19 @@ endif
 return 1;
 
 endfunction
+
+// Human-readable explanation for a CheckName() failure reason code (the
+// [2] element of its returned {0, reason} array), so callers can tell staff
+// WHY a name was rejected instead of a single generic "invalid" message that
+// makes every rejection look like a duplicate-name hit.
+function NameCheckFailureReason(reason_code)
+	case (reason_code)
+		"too long":    return "it is longer than "+MAX_LENGTH+" characters";
+		"too short":   return "it is shorter than "+MIN_LENGTH+" characters";
+		"bad spacing": return "it starts/ends with a space, or contains a double space";
+		"blacklist":   return "it contains a reserved/blacklisted word";
+		"bLTowns":     return "it contains a town name";
+		"duplicate":   return "another character already has that name";
+		default:       return "it failed name validation";
+	endcase
+endfunction

--- a/scripts/include/dotempmods.inc
+++ b/scripts/include/dotempmods.inc
@@ -9,6 +9,7 @@ include "include/client";
 include "include/spelldata";
 include "include/classes";
 include "include/random";
+include ":admin:include/adminpanel";
 
 
 function AddToPersistedMods( byref allmods , byref mmod )
@@ -409,6 +410,7 @@ function SetPoison( who , plvl , msg := 0, caster := 0, shuriken := 0)
 
 	if(caster)
 		SetObjProperty(who, "PoisonedBy", caster.name);
+		RecordCharacterPoisoning(who, CStr(caster.name), plvl);
 	endif
 
 	var parms := {};

--- a/scripts/items/racegate.src
+++ b/scripts/items/racegate.src
@@ -1,6 +1,8 @@
 use uo;
 use basic;
 
+include ":admin:include/adminpanel";
+
 program walkon_racegate(who, me)
 
 var equipt := getobjproperty(me, "equipt");
@@ -31,5 +33,6 @@ if (color)
         who.truecolor := color;
 endif
 setobjproperty(who, "race", racename);
+RecordCharacterNameChange(who, who.name + " [" + racename + "]", ADMINPANEL_INITIATOR_PLAYER);
 who.name := who.name + " [" + racename + "]";
 endprogram

--- a/scripts/misc/chrdeath.src
+++ b/scripts/misc/chrdeath.src
@@ -16,6 +16,7 @@ include "include/camouflage";
 include "include/constants/propids";
 include "include/packets";
 include ":areas:include/areafunctions";
+include ":admin:include/adminpanel";
 
 program chrdeath(corpse,ghost)
 
@@ -59,6 +60,8 @@ program chrdeath(corpse,ghost)
 	SetObjProperty( ghost, "deathx", dx);
 	SetObjProperty( ghost, "deathy", dy);
 	SetObjProperty( ghost, "deathz", dz);
+
+	RecordCharacterDeath( ghost, killer, GetObjProperty(ghost, "KilledBySerial"), dx, dy, dz );
 
 	if( GetObjProperty( ghost, PROPID_MOBILE_GUARD_KILLED ) )
 		SetObjProperty( ghost, "Killer", "Guards");

--- a/scripts/misc/namechanger.src
+++ b/scripts/misc/namechanger.src
@@ -3,6 +3,7 @@ use uo;
 include ":gumps:include/gumps";
 include ":gumps:include/gumps_ex";
 include "include/NameChecker";
+include ":admin:include/adminpanel";
 
 program SendNameChangeGump(who, msg)
 
@@ -68,6 +69,7 @@ who.concealed := 0;
 if (newname == who.name);
 	SendSysMessage(who, "Your name is unchanged.", 3, 67);
 else
+	RecordCharacterNameChange(who, newname, ADMINPANEL_INITIATOR_PLAYER);
 	who.name := newname;
 	SendSysMessage(who, "Your name has been changed to "+who.name+".", 3, 67);
 endif

--- a/scripts/textcmd/admin/admin.src
+++ b/scripts/textcmd/admin/admin.src
@@ -13,6 +13,7 @@ include "include/findcity";
 include ":gumps:gumps_ex";
 include ":gumps:yesno";
 include "include/constants/locations";
+include ":admin:include/adminpanel";
 
 var layout := {
 "page 0",
@@ -327,6 +328,7 @@ program textcmd_testgump( who )
 		endfor
 
 		acc.setprop( "Notes" , note );
+		RecordAccountNote( acc, note, ADMINPANEL_INITIATOR_STAFF );
 
 		return;
 
@@ -484,6 +486,7 @@ var abv:=getobjproperty(who,"abv"),result:=find(who.name," ["+abv+"]",1),name:=w
 
 result:=result-1;
 name:=name[1,result];
+RecordCharacterNameChange(who,name,ADMINPANEL_INITIATOR_STAFF);
 who.name:=name;
 endfunction
 

--- a/scripts/textcmd/admin/removerper.src
+++ b/scripts/textcmd/admin/removerper.src
@@ -3,6 +3,7 @@ use uo;
 use os;
 
 include ":staff:include/staff";
+include ":admin:include/adminpanel";
 
 program textcmd_removerper(who)
 
@@ -13,6 +14,7 @@ program textcmd_removerper(who)
 	if( rper )
 		var getOrgName := GetObjProperty(player, "OrgName");
 		EraseObjProperty(player, "IsRPer");
+		RecordCharacterNameChange(player, getOrgName, ADMINPANEL_INITIATOR_STAFF);
 		player.name := getOrgName;
 		EraseObjProperty(player, "OrgName");
 		SendSysMessage( player, "You have been kicked from the [RPer] faction!", FONT_NORMAL, 2595 );

--- a/scripts/textcmd/admin/setname.src
+++ b/scripts/textcmd/admin/setname.src
@@ -3,6 +3,7 @@ use uo;
 use polsys;
 include ":staff:include/staff";
 include "include/NameChecker";
+include ":admin:include/adminpanel";
 
 program setobjectname(who, text)
 
@@ -23,13 +24,17 @@ elseif (!what.isa(POLCLASS_ITEM) && !what.isa(POLCLASS_MOBILE))
 	return 0;
 endif
 
-if (what.isa(POLCLASS_MOBILE) && what.acct && CheckName(text, what, 1) != 1)
-	SendSysMessage(who, "The name you chose is either in use, or invalid.");
-	return 0;
+if (what.isa(POLCLASS_MOBILE) && what.acct)
+	var name_check := CheckName(text, what, 1);
+	if (name_check != 1)
+		SendSysMessage(who, "That name was rejected because "+NameCheckFailureReason(name_check[2])+".");
+		return 0;
+	endif
 endif
 
 LogCommand(who, GetProcess(GetPid()).name, what.name+"/"+what.serial, "Renamed To: "+text);
 SendSysMessage(who, "Old Name: "+what.name, 3, 40);
+RecordCharacterNameChange(what, text, ADMINPANEL_INITIATOR_STAFF);
 SetName(what, text);
 SendSysMessage(who, "New Name: "+what.name, 3, 53);
 IncRevision(what);

--- a/scripts/textcmd/coun/notes.src
+++ b/scripts/textcmd/coun/notes.src
@@ -5,6 +5,7 @@ include ":gumps:yesno";
 include ":gumps:gumps_ex";
 //Include "include/gumputil";
 include ":staff:include/staff";
+include ":admin:include/adminpanel";
 
 var layout3 := {
 "page 0",
@@ -80,6 +81,7 @@ EndFor
 
 if(note)
 	acc.setprop("Notes", note);
+	RecordAccountNote(acc, note, ADMINPANEL_INITIATOR_STAFF);
 endif
 LogCommand(character, GetProcess(GetPid()).name, who.name+"/"+who.serial, "Set Note: "+note);
 return;

--- a/scripts/textcmd/gm/changename.src
+++ b/scripts/textcmd/gm/changename.src
@@ -3,6 +3,7 @@ use uo;
 
 include ":staff:include/staff";
 include "include/client";
+include ":admin:include/adminpanel";
 
 program changename( who  )
 	SendSysMessage( who , "Who do you want to give a name change?", FONT_NORMAL, 2601 );
@@ -23,6 +24,7 @@ program changename( who  )
 
 	if(newname)
 		SetObjProperty(targ, "OldName", oldname);
+		RecordCharacterNameChange(targ, Cstr(newname), ADMINPANEL_INITIATOR_STAFF);
 		targ.name := Cstr(newname);
 		PrintTextAbove(targ, "I was known as "+oldname+" and now I'm now known as "+newname);
 	else

--- a/scripts/textcmd/gm/setprop.src
+++ b/scripts/textcmd/gm/setprop.src
@@ -10,6 +10,7 @@ use os;
 
 include ":staff:include/staff";
 include "include/NameChecker";
+include ":admin:include/adminpanel";
 
 program SetProp(who, text)
 
@@ -30,6 +31,7 @@ if (text.size() > 1)
 	foreach thing in text
 		pval := pval+thing+" ";
 	endforeach
+	pval := pval[1, len(pval)-1];
 else
 	pval := text[1];
 endif
@@ -65,9 +67,10 @@ endif
 if (Lower(pname) == "name" && targ.isa(POLCLASS_MOBILE) && targ.acct)
 	var name_check := CheckName(pval, targ, 1);
 	if (name_check != 1)
-		SendSysMessage(who, "That name is invalid or already in use - cannot set it on a player character.", 3, 33);
+		SendSysMessage(who, "Cannot set that name - "+NameCheckFailureReason(name_check[2])+".", 3, 33);
 		return 0;
 	endif
+	RecordCharacterNameChange(targ, pval, ADMINPANEL_INITIATOR_STAFF);
 endif
 
 // First part of the message

--- a/scripts/textcmd/seer/info.src
+++ b/scripts/textcmd/seer/info.src
@@ -18,6 +18,7 @@ include ":gumps:yesno";
 include ":gumps:gumps_ex";
 include "include/math";
 include ":staff:include/staff";
+include ":admin:include/adminpanel";
 include "include/constants/locations";
 include "include/NameChecker";
 
@@ -772,12 +773,17 @@ program textcmd_info( character , whom )
   if (result[0]==24) // rename
 
     newname := RequestInput( character, character.backpack, "Enter a new name:");
+    var name_check := 1;
+    if (who.acct)
+      name_check := CheckName(newname, who, 1);
+    endif
 
     if (!newname)
       SendSysMessage(character, "Canceled.");
-    elseif (who.acct && CheckName(newname, who, 1) != 1)
-      SendSysMessage(character, "That name is invalid or already in use.");
+    elseif (name_check != 1)
+      SendSysMessage(character, "That name was rejected because "+NameCheckFailureReason(name_check[2])+".");
     else
+      RecordCharacterNameChange( who , newname, ADMINPANEL_INITIATOR_STAFF );
       SetName( who , newname );
       SendSysMessage(who, "Your name has been changed.");
       LogCommand(character, GetProcess(GetPid()).name, who.name+"/"+who.serial, "Name Change: "+newname);
@@ -943,6 +949,7 @@ program textcmd_info( character , whom )
 
   if(note)
     acc.setprop("Notes", note);
+    RecordAccountNote(acc, note, ADMINPANEL_INITIATOR_STAFF);
   endif
   LogCommand(character, GetProcess(GetPid()).name, who.name+"/"+who.serial, "Set Note: "+note);
   return;
@@ -1102,6 +1109,7 @@ function fixnameguild(who)
 
   result:=result-1;
   name:=name[1,result];
+  RecordCharacterNameChange(who,name,ADMINPANEL_INITIATOR_STAFF);
   who.name:=name;
 endfunction
 

--- a/scripts/textcmd/test/editcharacter.src
+++ b/scripts/textcmd/test/editcharacter.src
@@ -5,6 +5,7 @@ use vitals;
 
 include "include/attributes";
 include ":gumps:include/gumps";
+include ":admin:include/adminpanel";
 
 const BTN_CANCEL := 9000;
 const BTN_APPLY  := 9001;
@@ -82,6 +83,7 @@ program editcharacter( who )
 	var dexterity := ClampInt( CInt( GFExtractData(result, ENTRY_DEX) ), 10, 300 );
 	var intelligence := ClampInt( CInt( GFExtractData(result, ENTRY_INT) ), 10, 300 );
 
+	RecordCharacterNameChange( target_char, name, ADMINPANEL_INITIATOR_STAFF );
 	SetName( target_char, name );
 	target_char.gender := gender;
 	target_char.trueobjtype := graphic;


### PR DESCRIPTION
# Developer Changelog - v1.0.8
**Range:** `9f8189f` (origin/Patch-1.0.7) -> `7c27772` (HEAD)  
**Branch:** Patch-1.0.8  
**Date:** 2026-06-20 -> 2026-07-23  
**Commits in range:** 10 (excluding merge commits)  
**Files changed:** 84 (+12970 / -1689)

---

## Table of Contents

1. [Scope Summary](#1-scope-summary)
2. [Commit Timeline](#2-commit-timeline)
3. [Townstones - Player-Run Town Administration and Membership Cleanup](#3-townstones---player-run-town-administration-and-membership-cleanup)
4. [Areas - Policy Engine Rewrite, Realm Sanitization, and Mask-Value Cache](#4-areas---policy-engine-rewrite-realm-sanitization-and-mask-value-cache)
5. [Go Locations - Indexed Config Generation and Range Fallback](#5-go-locations---indexed-config-generation-and-range-fallback)
6. [Spawnpoint - Restart Helpers and Region-Wide Reset Commands](#6-spawnpoint---restart-helpers-and-region-wide-reset-commands)
7. [Housing - Region-Based Placement Restrictions](#7-housing---region-based-placement-restrictions)
8. [Naming and Identity - Town-Suffix Exploit Closure and Validation Hardening](#8-naming-and-identity---town-suffix-exploit-closure-and-validation-hardening)
9. [Performance - Shutdown Time and Hot-Path Algorithm Fixes](#9-performance---shutdown-time-and-hot-path-algorithm-fixes)
10. [Crafting - Omega Cache Integration Fixes](#10-crafting---omega-cache-integration-fixes)
11. [Omega Cache - Potion Categorization Fix](#11-omega-cache---potion-categorization-fix)
12. [Gameplay Tuning and Script Fixes](#12-gameplay-tuning-and-script-fixes)
13. [Support Data and Tooling](#13-support-data-and-tooling)
14. [Staff Tooling - Character/Account Audit Panel and Name/Death/Poison/Note Tracking](#14-staff-tooling---characteraccount-audit-panel-and-namedeathpoisonnote-tracking)
15. [Exhaustive File-by-File Change List](#15-exhaustive-file-by-file-change-list)
16. [Risk and Regression Notes](#16-risk-and-regression-notes)

---

## 1. Scope Summary

Patch 1.0.8 grew across two work windows. The first (through `a3c99f6`) was dominated by the datafile-backed area policy rewrite, the go-location indexing pass, and the player-run townstone/admin cleanup — see sections 3, 5, and 6 for that material, carried forward unchanged from the earlier draft of this document.

The second window (`7bdc099` through `b347427`) closed a live-reported name-collision exploit, fixed a duplicate-character bug it was related to, added region-based house placement restrictions, fixed a real performance regression in the areas package and in two hot commands, and completed Omega Cache integration for two crafting scripts that had been missed or left broken during the original cache rollout:

- A town-suffix name-collision exploit was closed: players could no longer hold both "X" and "X of Town" at once, town names are now blocked in freely-chosen names, and name comparisons are case-insensitive.
- A live 50-second rename-gump hang, and a resulting duplicate-character bug ("two Paladin Rahl of Occlo"), were root-caused to an O(accounts x 5) full `regions.cfg` re-parse per name check, and fixed with a proper cache.
- Staff rename paths (`.setprop name`, `.setname`, `.info`'s rename button) now run through the same name validation as player-initiated renames, scoped to player characters only.
- House placement now blocks city, dungeon, shrine, and graveyard regions by footprint (not just a single point check), replacing an older, narrower check.
- The area-policy mask lookup (`GetPolicyMask`) is now cached; it was previously hitting the datafile subsystem on every single area-policy check, including every AI tick for every mobile shard-wide.
- Two independent O(n^2) algorithms (`.go`'s location-reorder pass, and a shared multi-array sort used by `.gotomulti`/`.gotoboat`) were replaced with linear/O(n log n) equivalents after script-log evidence showed both tripping the runaway-script watchdog.
- The smithy hammer's Omega Cache targeting path was found to be dead code due to a bad merge and was rewritten to match every other crafting script's pattern; the crafter-boost smithy retort had never been integrated with the cache at all and now is.
- A gap in the Omega Cache's category map left 12 leveled potion objtypes (Greater Strength/Cure Potion tiers, etc.) falling into the "Other" bucket instead of "Potions."

A third window (`7c27772`) added a full staff-facing character/account audit tool and wired full name-change, death, poisoning, and account-note tracking into every script that touches them — see section 14. Two additional commits landed in this range (`b347427`, `232ee95`); `b347427`'s crafting/performance/potion-category work is already covered above (sections 9-11), and `232ee95` (a townstone treasury-race, election-cleanup, and townlist-bootstrap fix pass) is not detailed in this document.

---

## 2. Commit Timeline

| Commit | Date | Message |
|--------|------|---------|
| `32a2b3a` | 2026-06-20 | backup script path restore |
| `dbfbe79` | 2026-07-20 | Areas fix for lord british castle and blackthornes |
| `a3c99f6` | 2026-07-20 | Bunch of patches for player run towns |
| `7bdc099` | 2026-07-20 | Patch Notes and save datafile error |
| `065ed28` | 2026-07-20 | House placement not allowed in cities |
| `21bb91e` | 2026-07-23 | Name Change update |
| `09bf876` | 2026-07-23 | Areas Fix, and naming fixes |
| `b347427` | 2026-07-23 | Patch notes, and fixes for omega cache, as well as optimization for go gomulti and goboat (see sections 9-11) |
| `232ee95` | 2026-07-23 | Townstone fixes, Minstel and townsfolk fix (not detailed in this document) |
| `7c27772` | 2026-07-23 | New test panel up along with datafiles (see section 14) |

---

## 3. Townstones - Player-Run Town Administration and Membership Cleanup

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/townstones/textcmd/admin/createtownstone.src` | Creation flow tightened around existing live stones, townlist insertion, and state restoration from the datafile |
| `pkg/opt/townstones/textcmd/admin/removetownmember.src` | New targeted town-member removal command with election and poll cleanup plus datafile sync |
| `pkg/opt/townstones/textcmd/admin/townbankstatus.src` | Large admin gump expansion for treasury, upgrades, donations, availability, purchase state, member management, and deletion |

### Notable Functional Changes

- `townbankstatus` now surfaces and mutates more live town state:
  - treasury gold,
  - population,
  - upgrades enabled or disabled,
  - donations enabled or disabled,
  - player-town availability,
  - player-town purchased state,
  - purchase price,
  - townstone presence,
  - and region deletion when safe.
- Member management now removes citizens more carefully:
  - account membership is removed from the stone's citizen list,
  - per-character `town` properties are cleared,
  - town suffixes are stripped from character names,
  - population and vote counts are refreshed,
  - elections and polls are cleaned up if the removed member was involved.
- `removetownmember` is a direct targeted cleanup path for staff workflows.
- `createtownstone` now checks for active and live conflicts more aggressively before creating a new stone.
- Townstone state sync now persists the current stone serial, mayor data, population, election flags, poll flags, candidate list, vote totals, vote percentage, timer, and citizen list back into the datafile.

---

## 4. Areas - Policy Engine Rewrite, Realm Sanitization, and Mask-Value Cache

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/areas/include/areapolicy.inc` | New datafile-backed policy engine, parsed-line cache, global bypass masks, realm-name sanitization, and a mask-value cache |
| `pkg/opt/areas/include/areapolicy.inc.bak` | Backup copy of the pre-rewrite policy implementation |
| `pkg/opt/areas/textcmd/admin/areas.src` | Rewritten `.areas` admin gump for viewing and toggling area policy flags |
| `pkg/opt/areas/EnterAreaDelay.src` | Updated to use the new policy resolver path |
| `pkg/opt/areas/LeaveArea.src` | Updated to use the new policy resolver path |
| `pkg/opt/areas/areaban.src` | Updated to use the new policy resolver path |
| `pkg/opt/areas/areas.cfg` | Area definitions refreshed, including the Lord British Castle and Lord Blackthornes Castle fix |
| `scripts/include/areas.inc` | Shared area helpers updated for the new resolver model |
| `scripts/include/anchors.inc` | Anchor and lookup helpers updated to cooperate with the new area model |

### Notable Functional Changes

- The area policy layer now lives in a dedicated resolver backed by per-realm datafiles:
  - masks are stored per area id,
  - a world-catchall bypass mask is OR-merged from known global ids (`feluccawholeworld`, `wholeworld`, `britannia`, `trammelwholeworld`) — confirmed still a one-directional OR merge, so a whole-realm flag (e.g. setting Felucca or Britannia to RP) can force a policy bit on everywhere in that realm, but an individual area still can't opt back out of it since OR can't clear a bit,
  - parsed area lines are cached both per program and in a global property,
  - cache invalidation is fingerprinted by source line count.
- The admin `.areas` workflow now works as a single gump-driven editor for common policy flags such as guarded, no recall, no marking, anti-magic, forbidden, no looting, safe-area, no-PK, and RP-area behavior.
- `areas.cfg` includes the specific Lord British Castle and Lord Blackthornes Castle boundary fix from `dbfbe79`.
- The hot-path area checks now resolve through the new policy layer instead of repeatedly re-parsing config lines.
- **Realm-name sanitization (`7bdc099`):** every realm-taking function in `areapolicy.inc` (`GetRealmAreaLines`, `GetParsedRealmAreaLines`, `ResolveAreaMatchAtLocation`, `ResolvePolicyAtLocation`, `GetGlobalBypassMask`, `GetRealmPolicyDescriptor`) previously did a bare `Lower(CStr(realm))`. A new `SanitizePolicyRealm(realm)` now falls back to `"britannia"` whenever the incoming realm is blank or the literal string `"<uninitialized object>"`, fixing a datafile-save error that occurred when a realm value hadn't been initialized yet.
- **Mask-value cache (`09bf876`):** `GetPolicyMask(realm, area_id)` was hitting the datafile subsystem (`OpenDataFile` + `FindElement` + `GetProp`) on every single area-policy check, and `GetGlobalBypassMask()` calls it 4 more times per resolve for the world-catchall ids — up to 5 datafile round trips per check, on every AI tick for every mobile shard-wide. `GetPolicyMask` is now backed by a per-realm `dictionary` (`area_id -> mask`), cached both per-program and in a `GlobalProperty` (`zh.areapolicy.maskcache.<realm>`), using `.Exists()` rather than truthiness so a cached mask of `0` (the common case) isn't mistaken for "not cached." The cache is invalidated precisely on `SetPolicyMask()` writes (single area id) and wholesale on `PruneStaleRealmPolicies()` (whole-realm bulk delete). This mirrors the existing parsed-line cache and was verified against the ZH3.0 sibling repo's simpler (no world-catchall) implementation for reference before implementing.

---

## 5. Go Locations - Indexed Config Generation and Range Fallback

### Files Changed

| File | Change |
|------|--------|
| `config/golocs_by_id.cfg` | New generated index of go locations by region id, realm, type, range, and GoLoc metadata |
| `config/command_synopses.cfg` | Updated synopsis entry for `.go` and new supporting commands |
| `pythonscripts/generate_golocs_by_id.py` | New generator that builds the indexed go-location config from region data |
| `scripts/textcmd/coun/go.src` | `.go` rebuilt around the indexed go-location config, facet selection, type ordering, and range fallback |
| `regions/regions.cfg` | Massive region metadata expansion to feed the new go-location generator |

### Notable Functional Changes

- `.go` now reads `golocs_by_id.cfg` instead of the older ad hoc config path.
- Regions can now be resolved from either:
  - an explicit `GoLoc`, or
  - the center point of the configured `Range`.
- A `dnp` `GoLoc` value is treated as an intentional skip.
- `0,0,0` explicit coordinates are treated as a placeholder and are replaced from the range center when possible.
- Location ordering is normalized by type (`Jail`, `City`, `Shrine`, `Graveyard`, `Dungeon`, `POI`, `None`) before any leftover entries are appended. See section 9 for the algorithmic rewrite of this ordering pass.
- The generator script exists so the index can be rebuilt from `regions.cfg` instead of hand-maintaining the go list.

---

## 6. Spawnpoint - Restart Helpers and Region-Wide Reset Commands

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/spawnpoint/include/restartspawnpoint.inc` | Shared restart helper extracted for normal restart and max-fill modes |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpoint.src` | Restart command updated to use the shared helper and report next spawn timing |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | New region-wide restart and restartmax command that iterates spawnpoints by selected location ranges |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointmax.src` | Force-fill command updated to use the shared helper and report fill counts |
| `pkg/opt/spawnpoint/config/groups.cfg` | Spawnpoint group config adjusted to support the new region restart workflow |

### Notable Functional Changes

- `RestartSpawnPointWithMode(...)` now encapsulates the restart and max-fill logic:
  - normal restart clears active spawned objects and schedules the next spawn based on the configured frequency,
  - max-fill temporarily enables the group flag if needed, repeatedly checkpoints until the target max is reached, then restores the original group flag.
- `.restartspawnpoint` now reports the next spawn delay after the restart.
- `.restartspawnpointmax` now reports the number of spawned objects relative to the configured maximum.
- `.restartspawnpointarea` is a new command that:
  - lets staff choose a facet,
  - then choose a location from the `golocs_by_id.cfg` index,
  - then restarts every spawnpoint whose coordinates fall inside that location's configured ranges.

---

## 7. Housing - Region-Based Placement Restrictions

### Files Changed

| File | Change |
|------|--------|
| `pkg/std/housing/housedeed.src` | House placement now checked against region types by footprint; dungeon/system-teleporter proximity check extracted into a helper |

### Notable Functional Changes

- Replaced the old single-tile `CheckCity(character)==1` check (which only tested the placing character's own location) with `IsHousePlacementBlockedByRegionType(housetype, where, region_type)`, called once each for `"city"`, `"dungeon"`, `"shrine"`, and `"graveyard"`. This computes the house's full footprint via `GetHouseFootprintBounds(housetype, x, y)` (multi dimensions applied to the placement point) and rejects placement if that footprint overlaps any `regions.cfg` region of the matching `Type`, scoped to the placing character's realm.
- `NormalizeRegionType(region_type)` lowercases and validates the region-type string used for comparison against `regions.cfg`'s `Type` field.
- The old inline dungeon-item / system-teleporter proximity checks (`ListObjectsInBox` scans for objtype `0xa3c8` and `0x6200`) were extracted into `IsHousePlacementBlockedByNearbySpecialObjects(where)`, which returns the rejection message directly instead of duplicating the `ListObjectsInBox` scan and message send inline.
- Staff (`character.cmdlevel >= 4`) are unaffected — all of the above is still gated behind the existing `if (character.cmdlevel < 4)` check.

---

## 8. Naming and Identity - Town-Suffix Exploit Closure and Validation Hardening

### Files Changed

| File | Change |
|------|--------|
| `scripts/include/NameChecker.inc` | Town-suffix-aware duplicate detection, case-insensitive comparison, whitespace normalization, bad-spacing rejection, and caching |
| `pkg/opt/townstones/tstone.src` | `Citizenship()`/`CanselCityzenship()` now duplicate-check before applying a town-suffixed or stripped name |
| `scripts/misc/namechanger.src` | Passes `force_town_check := 1`; added "bad spacing" error message |
| `scripts/misc/oncreate.src` | Passes `force_town_check := 1` |
| `scripts/textcmd/admin/setname.src` | `.setname` now runs through `CheckName`, scoped to player characters only |
| `scripts/textcmd/gm/setprop.src` | `.setprop name` now runs through `CheckName`, scoped to player characters only |
| `scripts/textcmd/seer/info.src` | `.info`'s rename button now runs through `CheckName`, scoped to player characters only |

### Background

A live exploit was reported: a player could join a town as "X" (becoming "X of Town"), create a second character also named "X" on an alt, then leave the town (reverting the first character to bare "X"), ending up holding both "X" and "X of Town" simultaneously — and bypass case-sensitivity to also claim near-duplicates like "Bop"/"bop"/"BOP". Investigating this also surfaced a live duplicate-character bug (two characters both named "Paladin Rahl of Occlo") and a report of a ~50 second hang with stacked rename gumps after a related fix — both root-caused and fixed here.

### Notable Functional Changes

- **`GetKnownTownNames()`** — replaces the old static `bLTowns`-only blacklist scan with a merged list from three sources: the static `bLTowns` fallback, every `City=1` region in `regions.cfg` (covers player-run townstone regions), and `GetGlobalProperty("townlist")` (covers a townstone whose region entry was later removed). Cached per-program and in a `GlobalProperty` (`zh.namechecker.knowntownnames`); `InvalidateKnownTownNamesCache()` is exposed but not yet wired to any call site (regions.cfg is effectively static at runtime today).
- **`StripTownSuffix(name, town_names := 0)`** — strips a trailing `" of <Town>"` for any known town so name-uniqueness comparisons treat `"a pig"` and `"a pig of Trinsic"` as the same identity, closing the join/leave/alt exploit above. Accepts an optional pre-fetched `town_names` list to avoid recomputing it in a loop.
- **`NormalizeNameForCompare(name)`** — lowercases, collapses runs of interior spaces to one, and trims leading/trailing spaces before comparison.
- **`IsNameTaken(candidate_name, exclude_serial := 0)`** — scans up to 5 character slots per account, comparing `NormalizeNameForCompare(StripTownSuffix(name, town_names))`, case-insensitively, excluding `exclude_serial`. Replaces the old exact-string, case-sensitive comparison in `CheckName` (which never caught `"Bop"` vs `"bop"`).
- **`CheckName(name, who := 0, force_town_check := 0)`** — new `force_town_check` parameter: pass `1` whenever the player is actively choosing a brand-new name (character creation, the rename gump, staff rename tools) so town names are always blocked regardless of the player's current town membership; login/reconnect revalidation of an already-assigned, legitimately town-suffixed name leaves this `0`. Also added an unconditional bad-spacing rejection (`name[1] == " " || name[len(name)] == " " || find(name, "  ", 0)`) — leading/trailing/doubled spaces were technically "legal characters" under the old per-character validation loop, but let a base name like `"Rahl "` silently become `"Rahl  of Town"` once a town suffix was appended, evading exact-match duplicate detection. This check is unconditional (not gated by `force_town_check`), so it also self-heals an already-malformed stored name on next login revalidation — this is exactly how the shard's one existing malformed record (`"Paladin Rahl  of Occlo"`, confirmed via `data/pcs.txt` to be the only such record shard-wide) will get caught and forced through a rename.
- **`pkg/opt/townstones/tstone.src`**: `Citizenship(who, item)` now computes the candidate town-suffixed name and calls `IsNameTaken()` before any state mutation, aborting with a message if the resulting name is already in use, rather than mutating town membership and then blindly assigning a colliding name. `CanselCityzenship(who, item)` (leave-town) computes the stripped base name, and if `IsNameTaken()` finds it colliding, sets the character's name to `"AlreadyUsed"` and force-starts `misc/namechanger` instead of blocking the leave — citizen-list removal, population decrement, and the `town` property erasure all still proceed unconditionally, so the player isn't stuck in town membership limbo while they pick a new name.
- **Staff rename paths** now validate through the same `CheckName()` path as player-driven renames, all explicitly scoped to player characters (`what.acct` / `targ.acct` / `who.acct` checks) so NPC renaming by staff is untouched:
  - `.setname` (`scripts/textcmd/admin/setname.src`)
  - `.setprop name` (`scripts/textcmd/gm/setprop.src`)
  - `.info`'s rename button (`scripts/textcmd/seer/info.src`)
- **Performance root cause (the 50-second hang):** the original `IsNameTaken`/`StripTownSuffix` implementation called `GetKnownTownNames()` (a full `regions.cfg` re-parse) on every character-slot comparison. With 5,169 accounts x up to 5 slots, that was ~25,000 redundant full-config re-parses per `CheckName` call — the direct cause of the reported hang and stacked rename gumps. Fixed by hoisting `GetKnownTownNames()` to once per `IsNameTaken`/`CheckName` call (passed through as a parameter) and adding the cache described above.

---

## 9. Performance - Shutdown Time and Hot-Path Algorithm Fixes

### Background

Investigated a live report that "POL Cleanup" during shutdown takes noticeably longer since the areas-to-datafile migration, alongside a slow ~1 hour post-startup CPU stabilization period. `log/script.log` showed the runaway-script watchdog firing on `scripts/textcmd/coun/go.ecl` (3 times) and `pkg/opt/alryc/textcmd/test/gotomulti.ecl` (2 times) — both algorithmic, not areas-related. Note: `log/pol.log` does not capture the console-only cleanup messages, so the runaway scripts are strong circumstantial evidence and worthwhile independent fixes on their own merits, not a proven root cause of the shutdown-time regression specifically (the areas mask-value cache in section 4 is the more directly-implicated fix for that).

### Files Changed (uncommitted)

| File | Change |
|------|--------|
| `scripts/textcmd/coun/go.src` | `ReorderLocationsForDisplay()` rewritten from an O(n^2)*8 pass to a single O(n) bucketing pass |
| `scripts/include/string.inc` | `SortMultiArrayByIndex()` rewritten from an O(n^2) selection sort to an O(n log n) iterative bottom-up merge sort |

### Notable Functional Changes

- **`.go`'s `ReorderLocationsForDisplay()`**: previously called `AppendLocationsByType()` once per type bucket (Jail/City/Shrine/Graveyard/Dungeon/POI/None — 7 passes), each of which rescanned the entire, continuously-growing `ordered` output list via `LocationAlreadyAdded()` for every candidate to dedupe by `Id` or by `Name+X+Y+Z+R` — effectively O(n^2) x 8 passes total (7 typed + 1 final catch-all). With ~200 Britannia go-locations alone, this was heavy enough to trip the runaway-script watchdog. Rewritten as a single O(n) pass: build a `LocationDedupeKey(loc)` (prefers `"id:<Id>"`, falls back to `"xy:<Name>:<X>:<Y>:<Z>:<R>"`), dedupe against a `seen` dictionary once, bucket by `GetLocationTypeLabel()` into a `dictionary` of arrays, then emit known-type buckets in priority order followed by any custom/unrecognized-type entries in original encounter order. Output ordering is unchanged from the old implementation; only the algorithm changed. `AppendLocationsByType()` and `LocationAlreadyAdded()` were removed (confirmed via repo-wide grep that nothing else referenced them).
- **`SortMultiArrayByIndex(MultiArray, SubIndex)`** (`scripts/include/string.inc`): previously an O(n^2) nested-loop selection sort. Rewritten as an iterative bottom-up merge sort (O(n log n)) via a new `MergeRunsByIndex(MultiArray, low, mid, high, SubIndex)` helper, same ascending-by-`SubIndex` output ordering. This is a shared include used by both `pkg/opt/alryc/textcmd/test/gotomulti.src` (`SortHouseMultisByLastLogin`, sorting up to 418 multi records) and `gotoboat.src` (`SortBoatsByLastLogin`) — fixing it here benefits both call sites without touching either file. The merge-loop write-position variable was originally named `out`, which is a reserved word in EScript/POL; renamed to `write_idx`.

---

## 10. Crafting - Omega Cache Integration Fixes

### Files Changed (uncommitted)

| File | Change |
|------|--------|
| `pkg/std/blacksmithy/make_blacksmith_items.src` | `use_hammer` rewritten so Omega Cache targeting is reachable; dead/duplicate legacy code removed |
| `pkg/opt/crafterboost/make_crafter_boosts.src` | Full Omega Cache integration added (previously backpack-only) |

### Notable Functional Changes

- **Blacksmithy (`make_blacksmith_items.src`)**: `use_hammer` previously performed an unconditional `ReserveItem(use_on)` and an unconditional `IsInContainer(character.backpack, use_on)` check *before* any Omega Cache objtype check — unlike every other cache-integrated crafting script (`alchemy.src`, `tinkering.src`, `carpentry.src`, `make_cloth_items.src`, `cooking.src`, `cartography.src`, `inscription.src`), which all check for the cache objtype first. Since the Omega Cache container is a placed house item, it's never "in your backpack," so targeting the cache directly for a plain ingot craft failed with "That item has to be in your backpack." before ever reaching the cache-handling code lower in the file. The only path that worked was the bone-armor sub-flow (target a bone item from backpack first, then target the cache when prompted for ingots), because that second `Target()` call bypassed the broken top-level check. The file also had two near-duplicate copies of the bone/ingot crafting logic (apparent leftover from a bad merge when cache integration was added), including a fallthrough where "no anvil nearby" would silently retry the same target as a plain ingot craft. Rewrote `use_hammer` to check for the cache objtype first (matching the established pattern across the codebase), and factored the repeated ingot-targeting logic into `ResolveIngotTarget(character)` and the anvil-proximity check into `NearAnvil(character)`.
- **Crafter boosts (`make_crafter_boosts.src`)**: the smithy retort (crafting Oil/Alloy/Varnish/Compound/Recharge Powder from Brimstone/Bloodspawn/Daemon Bone/Bat Wing/Dragon's Blood plus an ingot, log, hide, or gem) had never been integrated with the Omega Cache — it didn't include `resourcemanager.inc` and used the plain backpack-only `FindSubstance`/`ConsumeSubstance` helpers throughout, so it would simply stop (insufficient-materials path) if a player ran out of the targeted material in their backpack, regardless of whether a nearby cache had more. Added `resourcemanager`/`omegacache_utils` includes and converted both the explicitly-targeted material and the implicit fixed reagent (which the player never targets directly) to `ResourceRequest`s:
  - The initial target and the Brimstone-combine second target now both check for `OMEGACACHE_OBJTYPE` and route through `SelectMaterialFromCache()`, matching the established pattern.
  - A new `MakeReagentRequest(who, objtype)` builds a backpack-first, cache-fallback `ResourceRequest` for the fixed reagent (mirrors `MakeBackpackRequest()`, but without needing a physical item reference, since the reagent is never targeted by the player).
  - `LeaseResource`/`ExtendResourceLease`/`ReleaseResourceLease`/`ConsumeResource`/`GetAvailableResource` now drive both materials through the crafting loop, matching `MakeBlacksmithItems`'s pattern; the loop's early-exit paths (missing empty flask, can't reach it, can't reserve it) now `break` instead of `return`, so `AutoLoop_finish()` always runs.
  - A small `ObjtypeStruct(objtype)` helper lets the existing item-based `IsIngot`/`IsLog`/`IsGem2` (which only ever read `.objtype` off their argument) be reused against a bare objtype from a cache selection, instead of duplicating their range logic locally.
  - Scope note: the empty-flask consumption for the Recharge Powder product line remains backpack-only (unchanged) — flasks were out of scope for this fix.

---

## 11. Omega Cache - Potion Categorization Fix

### Files Changed (uncommitted)

| File | Change |
|------|--------|
| `pkg/opt/omegacache/categories.cfg` | Added 12 missing leveled-potion objtypes to the `Potions` category |

### Notable Functional Changes

- `categories.cfg`'s `Potions` category had two adjacent documented ranges — "Mage-class potion variants (0xFF19-0xFF3F)" ending at `0xFF40`, and "AlchemyPlus potions (0xFF4E-0xFF95, 0xFFA2)" starting at `0xFF4E` — with a gap at `0xFF41`-`0xFF4D` that neither range covered. That gap is exactly where `pkg/std/alchemy/itemdesc.cfg`'s leveled potion tiers live: Strength Potion [Level 2] (`0xFF41`), Greater Strength Potion [Level 1-3] (`0xFF42`-`0xFF44`), Cure Potion [Level 1-3] (`0xFF45`-`0xFF47`), and Greater Cure Potion [Level 1-5] (`0xFF48`-`0xFF4C`). Since `BuildCategoryMap()` in `omegacache.inc` defaults any unmatched objtype straight to `"Other"`, these 12 potions were showing up in the wrong category bucket in the cache UI. Added all 12 objtypes to the `Potions` category, closing the gap. Confirmed via a full cross-reference of `pkg/std/alchemy/itemdesc.cfg` against `categories.cfg` that no other alchemy objtypes have a similar gap. Cosmetic UI-grouping fix only — no gameplay value changes.

---

## 12. Gameplay Tuning and Script Fixes

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/alchemyplus/newpotions.src` | Protection-style potion duration increased significantly |
| `pkg/opt/holybook/removecurse.src` | Remove Curse success chance changed; paladins now use magery and magic resistance for the roll |
| `pkg/opt/shilhook/shilhook.src` | Skill gain and difficulty checks refactored to use a separate gain skill and a clearer chance calculation |
| `pkg/packethooks/speech/receivespeechhook.src` | Unicode speech packet decoding now uses the native Unicode string path instead of the older CChrZ conversion |
| `pkg/std/treasuremap/treasure.cfg` | One buried treasure coordinate was adjusted |
| `pkg/opt/alryc/README.txt` | Stale README removed during the command and tooling reshuffle |
| `scripts/ai/noble.src` | Nobles now begin wandering immediately after spawn |
| `scripts/ai/person.src` | Generic town NPCs now begin wandering immediately after spawn |
| `scripts/ai/setup/criersetup.inc` | Crier setup now guards missing config more safely and defaults the flee point cleanly |
| `scripts/ai/townperson.src` | Town NPC startup now begins wandering immediately after spawn |
| `scripts/ai/townsfolk.inc` | Townfolk helper updated to stay aligned with the new spawn and movement behavior |
| `scripts/EquipTemplateValidation.src` | Boot-time equip-config validator deduplicated: removed a dead `else` branch, extracted a shared `ValidateEquipEntries()` used across Armor/Weapon/Equip instead of three near-identical inline blocks |

### Notable Functional Changes

- Protection effects now last much longer; the underlying strength is unchanged but the duration calculation was extended.
- Remove Curse is now more class-aware:
  - paladins use magery and magic resistance,
  - other casters still use the earlier item-identification-based path.
- Skill gain now uses a cleaner distinction between the skill used for the difficulty check and the skill used for gain calculations.
- The speech hook fix keeps staff speech logging working even when the packet contains Unicode speech data.
- Town NPCs no longer sit idle right after spawn; they start their wander cycle immediately.
- Crier setup became more defensive around missing NPC config entries.
- `EquipTemplateValidation.src` is a one-shot boot-time validator (~1,279 entries) — the cleanup is a code-quality/maintenance change, not a meaningful perf contributor on its own.

---

## 13. Support Data and Tooling

### Files Changed

| File | Change |
|------|--------|
| `ZHO-DataBackup.ps1` | Data backup destination moved to the Koofr path; the log backup line is now commented out |
| `config/command_synopses.cfg` | Synopsis coverage refreshed for the new staff commands and the updated `.areas`, `.go`, `.restartspawnpoint*`, `.playerruntowns`, `.whereat`, and related entries |
| `pkg/opt/alryc/textcmd/test/gotoboat.src` | New developer command to list boats and teleport to the selected tillerman |
| `pkg/opt/alryc/textcmd/test/gotomulti.src` | New developer command to list house multis and teleport to the selected sign |
| `pkg/opt/alryc/textcmd/test/makecheck.src` | New developer command to create a bank cheque |
| `pkg/opt/alryc/textcmd/test/whereat.src` | New developer command to inspect the location details of a selected mobile, item, or map tile |
| `pol.cfg` | Profiling and sysload watchers were enabled for better live diagnostics |

### Notable Functional Changes

- The backup script now writes to the Koofr-backed destination used by the shard.
- The command synopsis file now covers the new or updated admin and developer commands so they show up in the command browser and help surface.
- The new `alryc` test commands are staff and developer tools and are not intended to affect regular gameplay.

---

## 14. Staff Tooling - Character/Account Audit Panel and Name/Death/Poison/Note Tracking

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/admin/pkg.cfg` | New minimal package, created solely to give the new datafile a registered namespace (`data/ds/admin/`) |
| `pkg/opt/admin/include/adminpanel.inc` | New shared data layer: name/death/poisoning/account-note history recording, retrieval, and summary building |
| `pkg/opt/admin/textcmd/test/testadminpanel.src` | New `.testadminpanel` staff gump: account browsing and full character audit history |
| `config/cmds.cfg` | Added `DIR pkg/opt/admin/textcmd/test` under the `Test` cmdlevel block |
| `scripts/include/NameChecker.inc` | Added `NameCheckFailureReason(reason_code)` to translate a `CheckName()` rejection code into a human-readable reason |
| `scripts/textcmd/gm/setprop.src` | Fixed a trailing-space bug in the value-rebuild loop; `.setprop name` now shows the real rejection reason and records the change |
| `scripts/textcmd/admin/setname.src` | `.setname` now shows the real rejection reason and records the change |
| `scripts/textcmd/seer/info.src` | `.info`'s rename button and `fixnameguild` now show the real rejection reason (rename button) and record the change |
| `scripts/textcmd/gm/changename.src` | `.changename` now records the change |
| `scripts/textcmd/test/editcharacter.src` | `.editcharacter` now records the change |
| `pkg/commands/commands/gm/mobedit.src` | `mobedit`'s name field now records the change |
| `pkg/opt/spawnpoint/textcmd/admin/newmobedit.src` | `newmobedit`'s name field now records the change |
| `scripts/misc/namechanger.src` | The player rename gump now records the change |
| `scripts/items/racegate.src` | Race-gate name suffixing now records the change |
| `pkg/opt/roleplaying/rperstone.src` | RPer faction join (`[RPer]` suffix) now records the change |
| `scripts/textcmd/admin/removerper.src` | RPer faction removal (name restore) now records the change |
| `scripts/textcmd/admin/admin.src` | `admin.src`'s `fixnameguild` now records the change; the NOTES action now records an account note |
| `scripts/misc/chrdeath.src` | Character death now records a death entry (killer, killer's account, coordinates) |
| `scripts/include/dotempmods.inc` | `SetPoison()` now records a poisoning entry alongside the existing `PoisonedBy` cprop |
| `scripts/textcmd/coun/notes.src` | `.notes` now records an account note (Staff-initiated) |
| `pkg/opt/loot/antiloot.inc` | `AutoJail()` now records an account note (System-initiated) |
| `pkg/opt/spawnpoint/textcmd/admin/despawn.src` | Fixed `program` name (was still `forcespawn`, copy-pasted from that file); added a null/invalid-spawnpoint guard |
| `pkg/opt/spawnpoint/textcmd/admin/primespawn.src` | Same `program` name fix and null/invalid-spawnpoint guard as `despawn.src` |
| `pkg/opt/spawnpoint/textcmd/admin/forcespawn.src` | Added the same null/invalid-spawnpoint guard |
| `pkg/opt/spawnpoint/textcmd/admin/gotomobtype.src` | Removed a leftover debug `Print("stuff")` call |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | `ReorderLocationsForDisplay()` rewritten from the same O(n^2)*8-pass shape fixed for `.go` in section 9 to a single O(n) dedupe-and-bucket pass |

### Background

Building the audit panel required first finding every place in the codebase where a player character's name can actually change, so each one could be wired into the new tracking layer; that sweep turned up a live bug (`.setprop`'s trailing-space append, section 8 already covers the underlying `CheckName` bad-spacing rejection it was tripping) and several small pre-existing bugs in unrelated spawnpoint commands that were touched only incidentally while adding `RecordCharacterNameChange` calls to `newmobedit.src`'s neighbors.

### Notable Functional Changes

**New staff command `.testadminpanel` (Test cmdlevel):**
- Gump flow: choose "Account" -> pick a letter A-Z (5-column grid, dynamically sized to the letter count so it can't overflow) -> paged account list (8 per page, each row showing the account name as a button plus its IP and last login date) -> character list for that account -> character detail.
- `ShowCharacterList` (the account-landing screen) shows the account name, a "Notes" subtitle with the full word-wrapped latest account note (via the existing `GFWordWrap()` utility, so the gump is sized to the actual wrapped line count instead of truncating), an attribution line (`"- <initiator>, <timestamp>"` or `"- Unknown"`), a running count of stored note records, and then the account's characters as buttons.
- `ShowCharacterDetail` shows a "Character Information" title with "Names", "Killed By", and "Poisoned By" subtitled sections (10/5/5 most-recent-first respectively), each ending with a "more in datafile" total count.

**New shared data layer (`pkg/opt/admin/include/adminpanel.inc`):**
- One DataFile per account (`AdminPanelFilespec`, under `data/ds/admin/`), created in a dedicated new `admin` package purely because DataFile filespecs must resolve to a real, registered `pkg.cfg` package name.
- Name and death/poisoning history is keyed per character serial (a reserved `"_account_"` element key holds account-wide note history instead), so history stays attached to a character across renames rather than being keyed by name.
- Every recorded entry stores a timestamp (`FormatEpochTimestamp`), the recording script's name (`CurrentScriptName()`, via `GetProcess(GetPid()).name` - the same idiom `staff.inc`'s `LogCommand` already uses), and an initiator classification (`Staff`/`Player`/`System`).
- `TrimHistoryToLimit` caps every history array at 100 entries (`ADMINPANEL_MAX_HISTORY`), erasing from the front, applied on every write so none of the four tracked histories can grow unbounded.
- `RecordCharacterNameChange` only records when `mobile.isa(POLCLASS_MOBILE) && mobile.acct` - NPCs have no account and are never recorded, confirmed no hook fires on any NPC/template renaming path.
- The first time a character's name history is recorded, if history is empty, the character's pre-change name is bootstrapped in as an "unknown"-origin entry (blank script/initiator/timestamp) so a character that existed before this tracking was added isn't misattributed a fabricated origin.
- `RecordCharacterDeath` resolves the killer's account independently via `SystemFindObjectBySerial(killer_serial, SYSFIND_SEARCH_OFFLINE_MOBILES)` rather than depending on `chrdeath.src`'s existing online-only name resolution, so the killer's account still shows if they've since logged off.
- `RecordAccountNote`/`GetLatestNoteInfo`: the account's existing single `Notes` cprop remains the untouched source of truth for the note itself; a parallel `notes_history` array (also capped at 100) records every write with attribution. `GetLatestNoteInfo` cross-references the two by comparing note text and falls back to blank attribution if they don't match, so a note set through any not-yet-wired path is shown as `"Unknown"` rather than misattributed to the wrong staffer.

**Wiring - every character rename site found in the codebase now calls `RecordCharacterNameChange`, scoped to accounts only:**
- Staff-initiated: `.setprop name`, `.setname`, `.info`'s rename button, `.info`'s `fixnameguild`, `admin.src`'s `fixnameguild`, `.changename`, `.editcharacter`, `mobedit`/`newmobedit`, `.removerper`.
- Player-initiated: the rename gump (`namechanger.src`), race-gate name suffixing (`racegate.src`), and RPer faction join (`rperstone.src`, appending `" [RPer]"`).
- Account notes (`RecordAccountNote`): `.notes`, `.info`'s NOTES action, and `admin.src`'s NOTES action (all Staff-initiated); `antiloot.inc`'s `AutoJail()` (System-initiated, fires on repeat town-looting offenses).

**Bug fixes surfaced during the sweep:**
- `.setprop`'s value-rebuild loop appended a trailing space after every word, including the last (e.g. `"Paladin Rahl One "`), which silently tripped `CheckName`'s bad-spacing rejection while showing a generic "already in use" message that masked the real cause. Fixed the trailing space (`pval := pval[1, len(pval)-1];`) and added `NameCheckFailureReason()` so `.setprop`, `.setname`, and `.info`'s rename button all now show the actual rejection reason.
- `despawn.src` and `primespawn.src` both still had `program forcespawn(...)` as their program declaration (evidently copy-pasted from `forcespawn.src` when those two commands were created) instead of matching their own filenames; corrected, and a null/invalid-spawnpoint guard was added to both plus `forcespawn.src` itself.
- Removed a leftover debug `Print("stuff")` call in `gotomobtype.src`.
- `restartspawnpointarea.src` had its own copy of the same O(n^2)*8-pass location-reordering logic documented in section 9 for `.go`; rewritten to the identical single O(n) dedupe-then-bucket pattern (dedupe by `Key`, bucket by type label, emit known types in priority order, then unrecognized-type entries in original encounter order).

---

## 15. Exhaustive File-by-File Change List

All files changed in `Patch-1.0.7..HEAD`:

| File | Notes |
|------|-------|
| `ZHO-DataBackup.ps1` | Backup destination moved; log backup line commented out |
| `config/command_synopses.cfg` | Synopsis refresh for new and updated admin and developer commands |
| `config/golocs_by_id.cfg` | New generated go-location index by region id |
| `pkg/opt/alchemyplus/newpotions.src` | Protection duration extended |
| `pkg/opt/alryc/README.txt` | Removed stale README |
| `pkg/opt/alryc/textcmd/test/gotoboat.src` | New boat location and teleport developer tool |
| `pkg/opt/alryc/textcmd/test/gotomulti.src` | New multi location and teleport developer tool |
| `pkg/opt/alryc/textcmd/test/makecheck.src` | New cheque creation developer tool |
| `pkg/opt/alryc/textcmd/test/whereat.src` | New target-inspection developer tool |
| `pkg/opt/admin/pkg.cfg` | New package created to host the audit-panel datafile namespace |
| `pkg/opt/admin/include/adminpanel.inc` | New name/death/poison/note tracking data layer |
| `pkg/opt/admin/textcmd/test/testadminpanel.src` | New `.testadminpanel` staff audit gump |
| `pkg/opt/areas/EnterAreaDelay.src` | Switched to the new area-policy resolution flow |
| `pkg/opt/areas/LeaveArea.src` | Switched to the new area-policy resolution flow |
| `pkg/opt/areas/areaban.src` | Updated for the new area-policy path |
| `pkg/opt/areas/areas.cfg` | Area policy and region data refresh, including castle fixes |
| `pkg/opt/areas/include/areapolicy.inc` | Policy resolver/cache layer, plus realm sanitization and mask-value cache |
| `pkg/opt/areas/include/areapolicy.inc.bak` | Backup of the pre-rewrite policy layer |
| `pkg/opt/areas/textcmd/admin/areas.src` | Rewritten area policy admin gump and flag editor |
| `pkg/opt/crafterboost/make_crafter_boosts.src` | Full Omega Cache integration added |
| `pkg/opt/holybook/removecurse.src` | Revised Remove Curse chance logic |
| `pkg/opt/loot/antiloot.inc` | `AutoJail()` now records an account note (System-initiated) |
| `pkg/opt/omegacache/categories.cfg` | 12 leveled-potion objtypes added to the Potions category |
| `pkg/opt/roleplaying/rperstone.src` | RPer faction join now records a name change |
| `pkg/opt/shilhook/shilhook.src` | Skill gain and difficulty refactor |
| `pkg/opt/spawnpoint/config/groups.cfg` | Spawnpoint group config update |
| `pkg/opt/spawnpoint/include/restartspawnpoint.inc` | Shared spawnpoint restart helper |
| `pkg/opt/spawnpoint/textcmd/admin/despawn.src` | Fixed `program` name mismatch, added null/invalid-spawnpoint guard |
| `pkg/opt/spawnpoint/textcmd/admin/forcespawn.src` | Added null/invalid-spawnpoint guard |
| `pkg/opt/spawnpoint/textcmd/admin/gotomobtype.src` | Removed leftover debug `Print("stuff")` call |
| `pkg/opt/spawnpoint/textcmd/admin/newmobedit.src` | Name field now records a name change |
| `pkg/opt/spawnpoint/textcmd/admin/primespawn.src` | Fixed `program` name mismatch, added null/invalid-spawnpoint guard |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpoint.src` | Restart command now uses the helper |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | New region-wide restart command; `ReorderLocationsForDisplay` also rewritten to O(n) |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointmax.src` | Force-fill restart command updated |
| `pkg/opt/townstones/textcmd/admin/createtownstone.src` | Creation workflow tightened and state restoration added |
| `pkg/opt/townstones/textcmd/admin/removetownmember.src` | New town member removal command |
| `pkg/opt/townstones/textcmd/admin/townbankstatus.src` | Major town status, member management, and runtime state expansion |
| `pkg/opt/townstones/tstone.src` | `Citizenship`/`CanselCityzenship` now duplicate-check before mutating a name |
| `pkg/packethooks/speech/receivespeechhook.src` | Unicode speech packet decode fix |
| `pkg/std/blacksmithy/make_blacksmith_items.src` | Omega Cache targeting fixed, dead code removed |
| `pkg/std/housing/housedeed.src` | Region-based city/dungeon/shrine/graveyard placement restrictions |
| `pkg/std/treasuremap/treasure.cfg` | One treasure location adjusted |
| `pkg/commands/commands/gm/mobedit.src` | Name field now records a name change |
| `pol.cfg` | Profiling and sysload watchers enabled |
| `pythonscripts/generate_golocs_by_id.py` | New generator for indexed go-location config |
| `regions/regions.cfg` | Large region metadata expansion and normalization |
| `scripts/EquipTemplateValidation.src` | Dead branch removed, shared validation helper extracted |
| `scripts/ai/noble.src` | Nobles now wander immediately after spawn |
| `scripts/ai/person.src` | Townsfolk now wander immediately after spawn |
| `scripts/ai/setup/criersetup.inc` | Safer crier config handling |
| `scripts/ai/townperson.src` | Town NPCs now wander immediately after spawn |
| `scripts/include/NameChecker.inc` | Town-suffix exploit closure, case-insensitive dedupe, bad-spacing rejection, caching; `NameCheckFailureReason()` added |
| `scripts/include/anchors.inc` | Anchor and lookup helpers updated for new area behavior |
| `scripts/include/areas.inc` | Area helper rewrite to match the new policy layer |
| `scripts/include/dotempmods.inc` | `SetPoison()` now records a poisoning entry |
| `scripts/include/string.inc` | `SortMultiArrayByIndex` rewritten to O(n log n) merge sort |
| `scripts/include/townsfolk.inc` | Townfolk helper alignment update |
| `scripts/items/racegate.src` | Race-gate name suffixing now records a name change |
| `scripts/misc/chrdeath.src` | Character death now records a death entry |
| `scripts/misc/namechanger.src` | `force_town_check := 1`, "bad spacing" error message; rename gump now records a name change |
| `scripts/misc/oncreate.src` | `force_town_check := 1` |
| `scripts/textcmd/admin/admin.src` | `fixnameguild` now records a name change; NOTES action now records an account note |
| `scripts/textcmd/admin/removerper.src` | RPer removal now records a name change |
| `scripts/textcmd/admin/setname.src` | Now runs through `CheckName`, PC-scoped; shows real rejection reason; records name changes |
| `scripts/textcmd/coun/go.src` | `ReorderLocationsForDisplay` rewritten to O(n); `.go` also rebuilt around indexed go locations and range fallback (earlier in the patch) |
| `scripts/textcmd/coun/notes.src` | `.notes` now records an account note |
| `scripts/textcmd/gm/changename.src` | `.changename` now records a name change |
| `scripts/textcmd/gm/setprop.src` | `.setprop name` now runs through `CheckName`, PC-scoped; trailing-space bug fixed; shows real rejection reason; records name changes |
| `scripts/textcmd/seer/info.src` | Rename button now runs through `CheckName`, PC-scoped, shows real rejection reason, and records name changes; `fixnameguild` and NOTES action also record |
| `scripts/textcmd/test/editcharacter.src` | Name field now records a name change |
| `config/cmds.cfg` | New `DIR` entry for `.testadminpanel` under the `Test` cmdlevel |

---

## 16. Risk and Regression Notes

1. `regions/regions.cfg` and `config/golocs_by_id.cfg` are now tightly coupled. Any future region edit should regenerate the go-location index rather than hand-editing the generated file.
2. The area-policy caches (parsed-line cache and the new mask-value cache) use global properties and, for the parsed-line cache, a line-count fingerprint. If `areas.cfg` changes shape, cache invalidation needs to remain intact or stale policy data can persist. The mask-value cache is invalidated precisely on `SetPolicyMask`/`PruneStaleRealmPolicies` writes, so it should stay correct as long as no other code path writes the `AREA_POLICY_MASK_PROP` datafile property directly.
3. Town member removal now touches citizen lists, population, and election or poll state. That makes the new cleanup path more complete, but it also raises the importance of testing member removal against live stones and offline accounts.
4. `RestartSpawnPointWithMode(...)` can checkpoint repeatedly during max-fill mode. That is intentional, but it means the new region-wide restart command should still be treated as a staff maintenance tool rather than a routine hot command.
5. `GetKnownTownNames()`'s cache has no automatic invalidation wired to `createtownstone`/region edits yet — a brand-new town's name won't be recognized as a "town name" for the free-name-choice block, nor will its residents' suffixes be stripped for dedupe purposes, until `InvalidateKnownTownNamesCache()` is called or the server restarts. Low practical risk today since new town creation is infrequent and staff-driven, but worth wiring up if that becomes a live pain point.
6. The town-suffix duplicate-name fixes and the house-placement region checks are both new *rejection* paths in previously-permissive flows — worth a live smoke test on a known player-run town (join/leave/rename) and a known city-adjacent building parcel before this goes fully live, since both change behavior at the boundary rather than just internals.
7. The blacksmithy and crafter-boost Omega Cache fixes change previously-broken or entirely-missing behavior into working behavior — this is a net-new capability for players (the failure mode was "doesn't work," not "we're removing something"), but should still get a quick live test: hammer-to-cache targeting for a plain ingot craft, bone-armor dual-material with the cache as either material, and a crafter-boost upgrade with the target material sourced from a cache.
8. The `.go` and shared-sort algorithmic rewrites are drop-in replacements with verified-identical output ordering (hand-traced on a small example for the merge sort; the `.go` reorder was verified against its old semantics directly). Risk is low, but both are hot, frequently-run staff commands, so a live spot check (a `.go` menu with a large realm, and `.gotomulti`/`.gotoboat` with the current multi/boat counts) is still worthwhile.
9. The potion-categorization fix is UI-only (Omega Cache category grouping) and carries no gameplay risk.
10. The audit panel's four history arrays (names, deaths, poisonings, account notes) hard-trim to 100 entries, erasing the oldest first. This is intentional to bound datafile growth, but it means very active characters/accounts will lose their oldest audit history over time rather than growing indefinitely — worth knowing before staff rely on it for long-term investigation.
11. `GetLatestNoteInfo()`'s attribution is derived by comparing the account's live `Notes` cprop text against the last `notes_history` entry; if a note is ever set through a path that isn't wired to `RecordAccountNote` (or was set before this feature existed), the panel will correctly show blank/"Unknown" attribution rather than a wrong name — by design, but staff should not read a blank attribution as "nobody knows," only as "not recorded through a tracked path."
12. `.testadminpanel` is read/write-audit-only and gated to the `Test` cmdlevel; it does not change any player-facing behavior. The only behavior changes with any player visibility from this section are the `.setprop`/`.setname`/`.info` rejection-message wording (now shows the real reason instead of a generic one) and the `despawn`/`primespawn`/`forcespawn` null-spawnpoint guard — both staff-tool-only surfaces.
13. This document's commit range (`9f8189f..7c27772`) includes two commits not detailed here: `b347427` (already covered by sections 9-11) and `232ee95` ("Townstone fixes, Minstel and townsfolk fix" — a townstone treasury-race-condition fix, election/mayor-removal cleanup, a candidate-list pairing bug fix, and a townlist-bootstrap self-heal on login). If player-facing patch notes are needed for `232ee95`, it should get its own review pass rather than being folded in here secondhand.
