### PR TITLE
Many updates and fixes to Areas

### DIFF
--- a/ainotes/armor-zone-damage-calc.md
+++ b/ainotes/armor-zone-damage-calc.md
@@ -1,0 +1,49 @@
+Good question — the zone roll and the damage-reduction math are actually two separate systems that don't talk to each other much. Total armor is what matters for how much damage gets through; the zone only decides which single piece takes the durability hit.
+
+## The actual reduction formula
+
+In [pkg/systems/combat/include/hitscriptinc.inc:107-189](pkg/systems/combat/include/hitscriptinc.inc#L107-L189) (`RecalcPhysicalDmg`):
+
+```
+var ar := defender.ar;          // <-- the mobile's aggregate AR stat, NOT the hit-zone item
+...
+absorbed := ArAbsorptionCalc(ar, basedamage);
+rawdamage -= absorbed;
+```
+
+`armor` (the item `GetHitArmor` picked for that zone) is passed into this function too, but it's only used for `CheckEquipmentDamage(defender, armor)` (durability wear) and to check for an `OnHitScript` on that specific piece. **It never feeds into `absorbed`.** The number that reduces damage is `defender.ar` — a single number the core (and `CS_GetEffectiveArmor`, which mirrors it) computes across **every equipped piece**, not just whichever one the RNG says got struck.
+
+The absorption curve itself, [hitscriptinc.inc:777-789](pkg/systems/combat/include/hitscriptinc.inc#L777-L789):
+```
+percent := (ar/5)^0.5 * 0.05     // capped at 0.99
+absorbed := basedamage * percent
+```
+
+## Applying your numbers
+
+`defender.ar` is built the same way `CS_GetEffectiveArmor` computes it ([armorZones.inc:121-152](pkg/items/armor/include/armorZones.inc#L121-L152)): for **every** equipped item, `item.ar * (sum of that item's covered zones' Chance)/100`, all added together. Critically, this is a straight sum — it does *not* pick the best piece per zone the way `GetHitArmor` does. So both your platemail legs (25) and the ringmail legs underneath (20) each contribute independently, since both cover "Legs/feet."
+
+Using `armrzone.cfg` weights (Body 44, Arms 14, Head 14, Legs/feet 14, Neck 7, Hands 7):
+
+| Piece | AR | Zone | Contribution |
+|---|---|---|---|
+| Breastplate | 60 | Body 44% | 26.4 |
+| Arms | 25 | Arms 14% | 3.5 |
+| Head | 25 | Head 14% | 3.5 |
+| Neck | 25 | Neck 7% | 1.75 |
+| Hands | 25 | Hands 7% | 1.75 |
+| Platemail legs | 25 | Legs/feet 14% | 3.5 |
+| Ringmail legs (under) | 20 | Legs/feet 14% | 2.8 |
+
+Total (shield aside) ≈ **43.2 AR**
+
+Plug into `ArAbsorptionCalc(43.2, 100)`:
+`percent = sqrt(43.2/5) * 0.05 ≈ 0.147` → absorbs **~14.7 damage**, leaving ~85 before other modifiers (protection spell, mace stamina drain, etc.).
+
+**This number is identical whether the RNG rolled Body or Legs/feet.** The only thing the zone roll changes is which item `CheckEquipmentDamage` degrades and whether that specific piece's `OnHitScript`/reactive-armor trigger fires ([mainhit.src:631-725](pkg/systems/combat/include/hitscriptinc.inc#L631)).
+
+## The shield is the exception
+
+Your 60-AR shield doesn't fold into `defender.ar` the normal way — shields are excluded from the zone-coverage sum (per the comment at [armorZones.inc:119](pkg/items/armor/include/armorZones.inc#L119)) and instead only matter through `GetShieldAbsorption()` ([hitscriptinc.inc:550-628](pkg/systems/combat/include/hitscriptinc.inc#L550-L628)): on a **successful parry roll** (skill-based), it flatly knocks off `shield.ar / 2` from basedamage — independent of, and in addition to, the AR-percent absorption above. If parry doesn't proc, the shield does nothing for that swing.
+
+**Bottom line:** total AR (summed across every worn piece, weighted by its zone coverage) is what determines the damage reduction percentage — not whichever single piece the zone roll happened to land on. The zone roll only decides who takes durability wear and whose on-hit effects trigger.

--- a/config/command_synopses.cfg
+++ b/config/command_synopses.cfg
@@ -1163,6 +1163,13 @@ Command mdestroy
 	CmdLevel	5
 }
 
+Command migrateclassfirsts
+{
+	Synopsis	One-time migration of legacy "first to reach class level" CProps into the classfirsts datafile
+	Level		Administrator
+	CmdLevel	4
+}
+
 Command migratevendorstorage
 {
 	Synopsis	Migrate player-merchant inventory from legacy 1C containers to FS containers
@@ -1971,6 +1978,13 @@ Command teleto
 Command test
 {
 	Synopsis	Enable a targeted player account (test utility)
+	Level		Developer
+	CmdLevel	5
+}
+
+Command testadminpanel
+{
+	Synopsis	Browse accounts and view each character's recorded name/death/poison history and account notes
 	Level		Developer
 	CmdLevel	5
 }

--- a/config/itemdesc.cfg
+++ b/config/itemdesc.cfg
@@ -2966,7 +2966,6 @@ Armor 0x8254
 	Name		sunshineshield
 	graphic		0x1B74
 	Desc		 Kite Shield
-	Coverage	Hands
 	AR		95
 	VendorSellsFor	273
 	VendorBuysFor	136

--- a/config/multis.cfg
+++ b/config/multis.cfg
@@ -1134,7 +1134,7 @@ Boat 0x17
     static  0x3e44   -6    0    0   // dragon prow
 }
 
-House 0x18
+Boat 0x18
 {
     static  0x2f17   -3    2    3   // cave wall
     static  0x2f16   -2    1    0   // cave wall
@@ -1146,7 +1146,7 @@ House 0x18
     static  0x2f19    2   -1    0   // cave wall
 }
 
-House 0x19
+Boat 0x19
 {
     static  0x12be   -5    4    4   // Yew tree
     static  0x12b6   -4    3    0   // Yew tree
@@ -1181,7 +1181,7 @@ House 0x19
     static  0x12c7    4   -5    4   // Yew tree
 }
 
-House 0x30
+Boat 0x30
 {
     static  0x0044   -5   -5    0   // brick wall
     static  0x0036   -5   -5    5   // brick wall
@@ -1746,7 +1746,7 @@ House 0x30
     static  0x06fd    6    5   25   // tile roof
 }
 
-House 0x31
+Boat 0x31
 {
     static  0x0044   -5   -7    0   // brick wall
     static  0x0036   -5   -7    5   // brick wall
@@ -2538,7 +2538,7 @@ House 0x31
     static  0x06fd    6    8   25   // tile roof
 }
 
-House 0x32
+Boat 0x32
 {
     static  0x009d   -7  -11    0   // log post
     static  0x0093   -7  -11    5   // log post
@@ -3609,7 +3609,7 @@ House 0x32
     static  0x08b9    7    9   26   // wooden banister
 }
 
-House 0x33
+Boat 0x33
 {
     static  0x012a  -11   -7    7   // wooden post
     static  0x012a  -11   -7   27   // wooden post
@@ -5167,7 +5167,7 @@ House 0x33
     static  0x08c6   12    1    1   // wooden banister
 }
 
-House 0x34
+Boat 0x34
 {
     static  0x012a  -13   -9    5   // wooden post
     static  0x012a  -13   -9   25   // wooden post
@@ -7003,7 +7003,7 @@ House 0x34
     static  0x05a4   14    7   45   // thatch roof
 }
 
-House 0x35
+Boat 0x35
 {
     static  0x04ab    0    0    0   // wooden boards
     static  0x001d   -5   -6    0   // stone wall
@@ -7757,7 +7757,7 @@ House 0x35
     static  0x0ba1    6   -3    3   // metal signpost
 }
 
-House 0x36
+Boat 0x36
 {
     static  0x04b8    0    0    0   // wooden boards
     static  0x001d   -6   -7    0   // stone wall
@@ -8495,7 +8495,7 @@ House 0x36
     static  0x26e6    6    2   23   // hay roof
 }
 
-House 0x37
+Boat 0x37
 {
     static  0x0517    0    0    0   // cobblestones
     static  0x0027  -11   -7   88   // stone wall
@@ -10429,7 +10429,7 @@ House 0x37
     static  0x0516   11    2    0   // cobblestones
 }
 
-House 0x38
+Boat 0x38
 {
     static  0x04b7    0    0    0   // wooden boards
     static  0x001d   -5   -5    0   // stone wall
@@ -11007,7 +11007,7 @@ House 0x38
     static  0x28d4    6    1   62   // wood slat roofing
 }
 
-House 0x39
+Boat 0x39
 {
     static  0x0030  -11   -2   48   // stone wall
     static  0x0027  -11   -2   40   // stone wall
@@ -12140,7 +12140,7 @@ House 0x39
     static  0x0887   12    3   20   // wooden rail
 }
 
-House 0x3a
+Boat 0x3a
 {
     static  0x04a9    0    0    0   // wooden boards
     static  0x0a22   -9    5   13   // lantern
@@ -12996,7 +12996,7 @@ House 0x3a
     static  0x06fd    9   -1   40   // tile roof
 }
 
-House 0x3b
+Boat 0x3b
 {
     static  0x04aa    0    0    0   // wooden boards
     static  0x001d  -11   -7    0   // stone wall
@@ -14434,7 +14434,7 @@ House 0x3b
     static  0x06fd   10    2   39   // tile roof
 }
 
-House 0x3c
+Boat 0x3c
 {
     static  0x0111  -11    0   71   // marble wall
     static  0x0111  -11    0   68   // marble wall
@@ -15938,7 +15938,7 @@ House 0x3c
     static  0x0110   12    6   65   // marble wall
 }
 
-House 0x3d
+Boat 0x3d
 {
     static  0x012a   -8   -8    0   // wooden post
     static  0x012a   -8   -8   20   // wooden post
@@ -16903,7 +16903,7 @@ House 0x3d
     static  0x2c75    8    0   57   // slate roof
 }
 
-House 0x3e
+Boat 0x3e
 {
     static  0x0066   -9   -9    0   // stone wall
     static  0x0027   -9   -9    7   // stone wall
@@ -18007,7 +18007,7 @@ House 0x3e
     static  0x0024    8    8    7   // stone wall
 }
 
-House 0x3f
+Boat 0x3f
 {
     static  0x04ab    0    0    0   // wooden boards
     static  0x00cc   -5   -5    0   // stone post
@@ -18626,7 +18626,7 @@ House 0x3f
     static  0x00d2    5    3    0   // stone buttress
 }
 
-House 0x40
+Boat 0x40
 {
     static  0x012a   -8   -7   26   // wooden post
     static  0x012a   -8   -7    6   // wooden post
@@ -19657,7 +19657,7 @@ House 0x40
     static  0x06fd    8    6   46   // tile roof
 }
 
-House 0x64
+Multi 0x64
 {
     static  0x04ac    0    0    7   // wooden boards
     dynamic 0x06a5    0    3    7   // wooden door
@@ -19808,7 +19808,7 @@ House 0x64
     static  0x05b4    4    4   27   // tile roof
 }
 
-House 0x65
+Multi 0x65
 {
     static  0x04ac    0    0    7   // wooden boards
     dynamic 0x06a5    0    3    7   // wooden door
@@ -19959,7 +19959,7 @@ House 0x65
     static  0x05b4    4    4   27   // tile roof
 }
 
-House 0x66
+Multi 0x66
 {
     static  0x04ac    0    0    7   // wooden boards
     dynamic 0x06a5    0    3    7   // wooden door
@@ -20110,7 +20110,7 @@ House 0x66
     static  0x05c3    4    4   27   // wooden shingles
 }
 
-House 0x67
+Multi 0x67
 {
     static  0x04ac    0    0    7   // wooden boards
     dynamic 0x06a5    0    3    7   // wooden door
@@ -20261,7 +20261,7 @@ House 0x67
     static  0x05c3    4    4   27   // wooden shingles
 }
 
-House 0x68
+Multi 0x68
 {
     static  0x04ac    0    0    7   // wooden boards
     dynamic 0x06a5    0    3    7   // wooden door
@@ -20411,7 +20411,7 @@ House 0x68
     static  0x05c3    4    4   27   // wooden shingles
 }
 
-House 0x69
+Multi 0x69
 {
     static  0x04ac    0    0    7   // wooden boards
     dynamic 0x06a5    0    3    7   // wooden door
@@ -20561,7 +20561,7 @@ House 0x69
     static  0x05c3    4    4   27   // wooden shingles
 }
 
-House 0x6a
+Multi 0x6a
 {
     static  0x04ac    0    0    7   // wooden boards
     dynamic 0x06a5    0    3    7   // wooden door
@@ -20705,7 +20705,7 @@ House 0x6a
     static  0x05c3    4    4   27   // wooden shingles
 }
 
-House 0x6b
+Multi 0x6b
 {
     static  0x04ac    0    0    7   // wooden boards
     dynamic 0x06a5    0    3    7   // wooden door
@@ -20849,7 +20849,7 @@ House 0x6b
     static  0x05c3    4    4   27   // wooden shingles
 }
 
-House 0x6c
+Multi 0x6c
 {
     static  0x04ac    0    0    7   // wooden boards
     dynamic 0x06a5    0    3    7   // wooden door
@@ -20999,7 +20999,7 @@ House 0x6c
     static  0x05c3    4    4   27   // wooden shingles
 }
 
-House 0x6d
+Multi 0x6d
 {
     static  0x04ac    0    0    7   // wooden boards
     dynamic 0x06a5    0    3    7   // wooden door
@@ -21149,7 +21149,7 @@ House 0x6d
     static  0x05c3    4    4   27   // wooden shingles
 }
 
-House 0x6e
+Multi 0x6e
 {
     static  0x04ac    0    0    7   // wooden boards
     dynamic 0x06a5    0    3    7   // wooden door
@@ -21299,7 +21299,7 @@ House 0x6e
     static  0x05a4    4    4   27   // thatch roof
 }
 
-House 0x6f
+Multi 0x6f
 {
     static  0x04ac    0    0    7   // wooden boards
     dynamic 0x06a5    0    3    7   // wooden door
@@ -21449,7 +21449,7 @@ House 0x6f
     static  0x05a4    4    4   27   // thatch roof
 }
 
-House 0x70
+Multi 0x70
 {
     dynamic 0x0e43    0   -2    0   // wooden chest
     static  0x0606    0    0   26   // tent roof
@@ -21529,7 +21529,7 @@ House 0x70
     static  0x0604    4    4   20   // tent roof
 }
 
-House 0x71
+Multi 0x71
 {
     dynamic 0x0e43    0   -2    0   // wooden chest
     static  0x0606    0    0   26   // tent roof
@@ -21609,7 +21609,7 @@ House 0x71
     static  0x0604    4    4   20   // tent roof
 }
 
-House 0x72
+Multi 0x72
 {
     dynamic 0x0e43    0   -2    0   // wooden chest
     static  0x061e    0    0   26   // tent roof
@@ -21689,7 +21689,7 @@ House 0x72
     static  0x061c    4    4   20   // tent roof
 }
 
-House 0x73
+Multi 0x73
 {
     dynamic 0x0e43    0   -2    0   // wooden chest
     static  0x061e    0    0   26   // tent roof
@@ -21769,7 +21769,7 @@ House 0x73
     static  0x061c    4    4   20   // tent roof
 }
 
-House 0x74
+Multi 0x74
 {
     static  0x04aa    0    0    7   // wooden boards
     dynamic 0x06a5   -1    6    7   // wooden door
@@ -22298,7 +22298,7 @@ House 0x74
     static  0x0596    7    7   31   // slate roof
 }
 
-House 0x75
+Multi 0x75
 {
     static  0x04aa    0    0    7   // wooden boards
     dynamic 0x06a5   -1    6    7   // wooden door
@@ -22827,7 +22827,7 @@ House 0x75
     static  0x0596    7    7   31   // slate roof
 }
 
-House 0x76
+Multi 0x76
 {
     static  0x0136    0    0    7   // plaster wall
     dynamic 0x06a5   -3    6    7   // wooden door
@@ -23481,7 +23481,7 @@ House 0x76
     static  0x05cf    7    7   47   // wooden shingles
 }
 
-House 0x77
+Multi 0x77
 {
     static  0x0136    0    0    7   // plaster wall
     dynamic 0x06a5   -3    6    7   // wooden door
@@ -24135,7 +24135,7 @@ House 0x77
     static  0x05cf    7    7   47   // wooden shingles
 }
 
-House 0x78
+Multi 0x78
 {
     static  0x0203    0    0    7   // plaster wall
     dynamic 0x06a5   -3    6    7   // wooden door
@@ -24786,7 +24786,7 @@ House 0x78
     static  0x05cf    7    7   47   // wooden shingles
 }
 
-House 0x79
+Multi 0x79
 {
     static  0x0203    0    0    7   // plaster wall
     dynamic 0x06a5   -3    6    7   // wooden door
@@ -25437,7 +25437,7 @@ House 0x79
     static  0x05cf    7    7   47   // wooden shingles
 }
 
-House 0x7a
+Multi 0x7a
 {
     static  0x0521    0    0    6   // stone pavers
     dynamic 0x0675    0    6    6   // metal door
@@ -26906,7 +26906,7 @@ House 0x7a
     static  0x01e9   11    6   72   // stone wall
 }
 
-House 0x7b
+Multi 0x7b
 {
     static  0x0521    0    0    6   // stone pavers
     dynamic 0x0675    0    6    6   // metal door
@@ -28375,7 +28375,7 @@ House 0x7b
     static  0x01e9   11    6   72   // stone wall
 }
 
-House 0x7c
+Multi 0x7c
 {
     static  0x0521    0    0    6   // stone pavers
     dynamic 0x0675    0   10    6   // metal door
@@ -30629,7 +30629,7 @@ House 0x7c
     static  0x01e8   12   12   49   // stone wall
 }
 
-House 0x7d
+Multi 0x7d
 {
     static  0x0521    0    0    6   // stone pavers
     dynamic 0x0675    0   10    6   // metal door
@@ -32883,7 +32883,7 @@ House 0x7d
     static  0x01e8   12   12   49   // stone wall
 }
 
-House 0x7e
+Multi 0x7e
 {
     dynamic 0x0675    0   15    6   // metal door
     dynamic 0x0677    1   15    6   // metal door
@@ -36347,7 +36347,7 @@ House 0x7e
     static  0x08c0  -12  -12   26   // wooden banister
 }
 
-House 0x7f
+Multi 0x7f
 {
     dynamic 0x0675    0   15    6   // metal door
     dynamic 0x0677    1   15    6   // metal door
@@ -39811,7 +39811,7 @@ House 0x7f
     static  0x08c0  -12  -12   26   // wooden banister
 }
 
-House 0x87
+Multi 0x87
 {
     static  0x04aa    0    0    0   // wooden boards
     static  0x05c3    0    0   26   // wooden shingles
@@ -40331,7 +40331,7 @@ House 0x87
     static  0x05d0    8   -6   20   // wooden shingles
 }
 
-House 0x8c
+Multi 0x8c
 {
     static  0x04aa    0    0    7   // wooden boards
     static  0x05c3    0    0   33   // wooden shingles
@@ -40851,7 +40851,7 @@ House 0x8c
     static  0x05d0    8   -6   27   // wooden shingles
 }
 
-House 0x8d
+Multi 0x8d
 {
     static  0x04aa    0    0    7   // wooden boards
     static  0x05c3    0    0   33   // wooden shingles
@@ -41371,7 +41371,7 @@ House 0x8d
     static  0x05d0    8   -6   27   // wooden shingles
 }
 
-House 0x96
+Multi 0x96
 {
     static  0x00fa    0    0    4   // marble wall
     static  0x050e    0    0    4   // white marble
@@ -42016,7 +42016,7 @@ House 0x96
     static  0x0110   -7   -6   44   // marble wall
 }
 
-House 0x98
+Multi 0x98
 {
     static  0x04fd    0    0    6   // flagstones
     static  0x04fc    0    0   26   // flagstones
@@ -42313,7 +42313,7 @@ House 0x98
     static  0x01da    4    3   49   // stone pillar
 }
 
-House 0x9a
+Multi 0x9a
 {
     static  0x04b5    0    0    8   // wooden boards
     static  0x0092    0    0   29   // log wall
@@ -42642,7 +42642,7 @@ House 0x9a
     static  0x0b9c    4    7    9   // metal signpost
 }
 
-House 0x9c
+Multi 0x9c
 {
     static  0x0528    0    0    6   // sandstone floor
     static  0x0528    0    0   26   // sandstone floor
@@ -42951,7 +42951,7 @@ House 0x9c
     static  0x016b   -5   -4   29   // sandstone post
 }
 
-House 0x9e
+Multi 0x9e
 {
     static  0x052b    0    0    5   // sandstone floor
     static  0x04c9    0    0   25   // wooden planks
@@ -43409,7 +43409,7 @@ House 0x9e
     static  0x05a6   -4    6   49   // thatch roof
 }
 
-House 0xa0
+Multi 0xa0
 {
     static  0x049c    0    0    7   // grey slate tile
     static  0x049c    0    0   27   // grey slate tile
@@ -43614,7 +43614,7 @@ House 0xa0
     static  0x05c3    3    4   49   // wooden shingles
 }
 
-House 0xa2
+Multi 0xa2
 {
     static  0x050d    0    0    4   // marble floor
     static  0x050d    0    0   24   // marble floor
@@ -43827,7 +43827,7 @@ House 0xa2
     static  0x0ba2    3    4    5   // metal signpost
 }
 
-House 0x1f4
+Multi 0x1f4
 {
     static  0x136b    1    2   -1   // rock
     static  0x1655   -2   -1   -1   // catapult
@@ -44030,7 +44030,7 @@ House 0x1f4
     static  0x02e1   -6   -4   12   // wood pole
 }
 
-House 0x1f5
+Multi 0x1f5
 {
     static  0x1655   -2   -2   -1   // catapult
     static  0x1655   -2   -1   -1   // catapult
@@ -44260,7 +44260,7 @@ House 0x1f5
     static  0x02e6   -6    4   12   // tent wall
 }
 
-House 0x1f6
+Multi 0x1f6
 {
     static  0x164e   -2    1   -1   // catapult
     static  0x136b    1    2   -1   // rock
@@ -44476,7 +44476,7 @@ House 0x1f6
     static  0x02e6   -6    4   12   // tent wall
 }
 
-House 0x3e8
+Multi 0x3e8
 {
     dynamic 0x1b4e    0    0    0   // treasure
     dynamic 0x1b50    1   -1    0   // treasure
@@ -44488,7 +44488,7 @@ House 0x3e8
     dynamic 0x1b4b   -1    1    0   // treasure
 }
 
-House 0x3e9
+Multi 0x3e9
 {
     dynamic 0x1b43    0    0    0   // treasure
     dynamic 0x1b48    1   -1    0   // treasure
@@ -44502,7 +44502,7 @@ House 0x3e9
     dynamic 0x1b45    2   -1    0   // treasure
 }
 
-House 0x3ea
+Multi 0x3ea
 {
     dynamic 0x1b67    0    0    0   // treasure
     dynamic 0x1b61    1    0    0   // treasure
@@ -44519,7 +44519,7 @@ House 0x3ea
     dynamic 0x1b65   -1    0    0   // treasure
 }
 
-House 0x3eb
+Multi 0x3eb
 {
     dynamic 0x1b5d    0    0    0   // treasure
     dynamic 0x1b59    1   -1    0   // treasure
@@ -44534,7 +44534,7 @@ House 0x3eb
     dynamic 0x1b5b    2    0    0   // treasure
 }
 
-House 0x7d0
+Multi 0x7d0
 {
     static  0x019c    0    0    0   // wood supports
     static  0x019c   -1   -1    0   // wood supports
@@ -44547,7 +44547,7 @@ House 0x7d0
     static  0x019c    1    1    0   // wood supports
 }
 
-House 0x7d1
+Multi 0x7d1
 {
     static  0x019c    0    0    0   // wood supports
     static  0x019c   -1   -1    0   // wood supports
@@ -44560,7 +44560,7 @@ House 0x7d1
     static  0x019c    1    1    0   // wood supports
 }
 
-House 0x7d2
+Multi 0x7d2
 {
     static  0x019c    0    0    0   // wood supports
     static  0x019c   -1   -1    0   // wood supports
@@ -44573,7 +44573,7 @@ House 0x7d2
     static  0x019c    1    1    0   // wood supports
 }
 
-House 0x7d3
+Multi 0x7d3
 {
     static  0x019c    0    0    0   // wood supports
     static  0x019c   -1   -1    0   // wood supports
@@ -44586,7 +44586,7 @@ House 0x7d3
     static  0x019c    1    1    0   // wood supports
 }
 
-House 0x7d4
+Multi 0x7d4
 {
     static  0x019c    0    0    0   // wood supports
     static  0x019c   -1   -1    0   // wood supports
@@ -44599,7 +44599,7 @@ House 0x7d4
     static  0x019c    1    1    0   // wood supports
 }
 
-House 0x7d5
+Multi 0x7d5
 {
     static  0x019c    0    0    0   // wood supports
     static  0x019c   -1   -1    0   // wood supports
@@ -44612,7 +44612,7 @@ House 0x7d5
     static  0x019c    1    1    0   // wood supports
 }
 
-House 0x7d6
+Multi 0x7d6
 {
     static  0x019c    0    0    0   // wood supports
     static  0x019c   -1   -1    0   // wood supports
@@ -44625,7 +44625,7 @@ House 0x7d6
     static  0x019c    1    1    0   // wood supports
 }
 
-House 0x7d7
+Multi 0x7d7
 {
     static  0x019c    0    0    0   // wood supports
     static  0x019c   -1   -1    0   // wood supports
@@ -44638,7 +44638,7 @@ House 0x7d7
     static  0x019c    1    1    0   // wood supports
 }
 
-House 0xbb8
+Multi 0xbb8
 {
     static  0x0b5d    0    0    0   // chair
     dynamic 0x04c6    0    0    1   // wooden planks
@@ -44851,7 +44851,7 @@ House 0xbb8
     static  0x05a4    3   -5   19   // thatch roof
 }
 
-House 0xfa0
+Multi 0xfa0
 {
     dynamic 0x0073    0    0    0   // battlement
     static  0x0f14    0    0    2   // ruby
@@ -44869,7 +44869,7 @@ House 0xfa0
     static  0x1ed5    0    1    1   // target
 }
 
-House 0xfa1
+Multi 0xfa1
 {
     dynamic 0x0073    0    0    0   // battlement
     static  0x0f17    0    0    1   // amethyst
@@ -44887,7 +44887,7 @@ House 0xfa1
     static  0x1ed6    1    0    1   // target
 }
 
-House 0xfa2
+Multi 0xfa2
 {
     dynamic 0x0073    0    0    0   // battlement
     dynamic 0x37f5    0    0    1   // field of blades
@@ -44904,7 +44904,7 @@ House 0xfa2
     dynamic 0x0076   -1    0    0   // battlement
 }
 
-House 0xfa3
+Multi 0xfa3
 {
     dynamic 0x21a4    0    0    0   // no draw
     static  0x1877    0    0    1   // silver wire
@@ -44972,7 +44972,7 @@ House 0xfa3
     dynamic 0x01e3    3   -3    0   // stone arch
 }
 
-House 0xfa4
+Multi 0xfa4
 {
     dynamic 0x21a4    0    0    0   // no draw
     static  0x049c    0    0    0   // grey slate tile
@@ -45087,7 +45087,7 @@ House 0xfa4
     dynamic 0x01ea    3    3    3   // stone wall
 }
 
-House 0xfa5
+Multi 0xfa5
 {
     dynamic 0x049c    0    0    0   // grey slate tile
     static  0x049c    0   -1    0   // grey slate tile
@@ -45235,7 +45235,7 @@ House 0xfa5
     dynamic 0x01dc    3   -3    9   // stone arch
 }
 
-House 0xfa6
+Multi 0xfa6
 {
     dynamic 0x049c    0    0    0   // grey slate tile
     static  0x049c    0   -1    0   // grey slate tile
@@ -45385,7 +45385,7 @@ House 0xfa6
     dynamic 0x01d2   -3   -3   20   // stone post
 }
 
-House 0xfa7
+Multi 0xfa7
 {
     dynamic 0x21a4    0    0    0   // no draw
     static  0x049c    0    0   40   // grey slate tile
@@ -45556,7 +45556,7 @@ House 0xfa7
     dynamic 0x01eb   -3   -3   40   // stone wall
 }
 
-House 0xfa8
+Multi 0xfa8
 {
     dynamic 0x21a4    0    0    0   // no draw
     static  0x049c    0    0   40   // grey slate tile
@@ -45764,7 +45764,7 @@ House 0xfa8
     dynamic 0x01da   -3   -3   43   // stone pillar
 }
 
-House 0xfa9
+Multi 0xfa9
 {
     static  0x16a2    0    0    0   // catapult
     static  0x0015    0    0    7   // wooden wall
@@ -45807,7 +45807,7 @@ House 0xfa9
     static  0x0864   -2    0   30   // wooden fence
 }
 
-House 0xfaa
+Multi 0xfaa
 {
     dynamic 0x0061    0    0    0   // stone wall
     dynamic 0x0104    0    0   11   // marble wall
@@ -45847,7 +45847,7 @@ House 0xfaa
     dynamic 0x0062   -1   -1   36   // stone wall
 }
 
-House 0xfab
+Multi 0xfab
 {
     dynamic 0x10ad    0    0    0   // hanging pole
     dynamic 0x10ad    0    0    3   // hanging pole
@@ -45881,7 +45881,7 @@ House 0xfab
     dynamic 0x10ad    0    3   12   // hanging pole
 }
 
-House 0xfac
+Multi 0xfac
 {
     dynamic 0x0104    0    0    0   // marble wall
     dynamic 0x0113   -1    0    0   // marble arch
@@ -45907,7 +45907,7 @@ House 0xfac
     static  0x3818    0    1   33   // energy
 }
 
-House 0x1388
+Multi 0x1388
 {
     static  0x31f5    0    0    0   // dirt
     static  0x31f5   -1   -1    0   // dirt
@@ -48926,7 +48926,7 @@ House 0x1388
     static  0x00dd  -25   13   21   // stone wall
 }
 
-House 0x13ec
+Multi 0x13ec
 {
     static  0x0065    3    3    0   // stone wall
     static  0x0066   -3   -3    0   // stone wall
@@ -48990,7 +48990,7 @@ House 0x13ec
     static  0x31f4    3    3    7   // dirt
 }
 
-House 0x13ed
+Multi 0x13ed
 {
     static  0x0065    3    4    0   // stone wall
     static  0x0066   -3   -3    0   // stone wall
@@ -49062,7 +49062,7 @@ House 0x13ed
     static  0x31f4    3    4    7   // dirt
 }
 
-House 0x13ee
+Multi 0x13ee
 {
     static  0x0065    3    4    0   // stone wall
     static  0x0066   -3   -4    0   // stone wall
@@ -49142,7 +49142,7 @@ House 0x13ee
     static  0x31f4    3    4    7   // dirt
 }
 
-House 0x13ef
+Multi 0x13ef
 {
     static  0x0065    3    5    0   // stone wall
     static  0x0066   -3   -4    0   // stone wall
@@ -49230,7 +49230,7 @@ House 0x13ef
     static  0x31f4    3    5    7   // dirt
 }
 
-House 0x13f0
+Multi 0x13f0
 {
     static  0x0065    3    5    0   // stone wall
     static  0x0066   -3   -5    0   // stone wall
@@ -49326,7 +49326,7 @@ House 0x13f0
     static  0x31f4    3    5    7   // dirt
 }
 
-House 0x13f1
+Multi 0x13f1
 {
     static  0x0065    3    6    0   // stone wall
     static  0x0066   -3   -5    0   // stone wall
@@ -49430,7 +49430,7 @@ House 0x13f1
     static  0x31f4    3    6    7   // dirt
 }
 
-House 0x13f8
+Multi 0x13f8
 {
     static  0x0065    4    3    0   // stone wall
     static  0x0066   -3   -3    0   // stone wall
@@ -49502,7 +49502,7 @@ House 0x13f8
     static  0x31f4    4    3    7   // dirt
 }
 
-House 0x13f9
+Multi 0x13f9
 {
     static  0x0065    4    4    0   // stone wall
     static  0x0066   -3   -3    0   // stone wall
@@ -49583,7 +49583,7 @@ House 0x13f9
     static  0x31f4    4    4    7   // dirt
 }
 
-House 0x13fa
+Multi 0x13fa
 {
     static  0x0065    4    4    0   // stone wall
     static  0x0066   -3   -4    0   // stone wall
@@ -49673,7 +49673,7 @@ House 0x13fa
     static  0x31f4    4    4    7   // dirt
 }
 
-House 0x13fb
+Multi 0x13fb
 {
     static  0x0065    4    5    0   // stone wall
     static  0x0066   -3   -4    0   // stone wall
@@ -49772,7 +49772,7 @@ House 0x13fb
     static  0x31f4    4    5    7   // dirt
 }
 
-House 0x13fc
+Multi 0x13fc
 {
     static  0x0065    4    5    0   // stone wall
     static  0x0066   -3   -5    0   // stone wall
@@ -49880,7 +49880,7 @@ House 0x13fc
     static  0x31f4    4    5    7   // dirt
 }
 
-House 0x13fd
+Multi 0x13fd
 {
     static  0x0065    4    6    0   // stone wall
     static  0x0066   -3   -5    0   // stone wall
@@ -49997,7 +49997,7 @@ House 0x13fd
     static  0x31f4    4    6    7   // dirt
 }
 
-House 0x13fe
+Multi 0x13fe
 {
     static  0x0065    4    6    0   // stone wall
     static  0x0066   -3   -6    0   // stone wall
@@ -50123,7 +50123,7 @@ House 0x13fe
     static  0x31f4    4    6    7   // dirt
 }
 
-House 0x1404
+Multi 0x1404
 {
     static  0x0065    4    3    0   // stone wall
     static  0x0066   -4   -3    0   // stone wall
@@ -50203,7 +50203,7 @@ House 0x1404
     static  0x31f4    4    3    7   // dirt
 }
 
-House 0x1405
+Multi 0x1405
 {
     static  0x0065    4    4    0   // stone wall
     static  0x0066   -4   -3    0   // stone wall
@@ -50293,7 +50293,7 @@ House 0x1405
     static  0x31f4    4    4    7   // dirt
 }
 
-House 0x1406
+Multi 0x1406
 {
     static  0x0065    4    4    0   // stone wall
     static  0x0066   -4   -4    0   // stone wall
@@ -50393,7 +50393,7 @@ House 0x1406
     static  0x31f4    4    4    7   // dirt
 }
 
-House 0x1407
+Multi 0x1407
 {
     static  0x0065    4    5    0   // stone wall
     static  0x0066   -4   -4    0   // stone wall
@@ -50503,7 +50503,7 @@ House 0x1407
     static  0x31f4    4    5    7   // dirt
 }
 
-House 0x1408
+Multi 0x1408
 {
     static  0x0065    4    5    0   // stone wall
     static  0x0066   -4   -5    0   // stone wall
@@ -50623,7 +50623,7 @@ House 0x1408
     static  0x31f4    4    5    7   // dirt
 }
 
-House 0x1409
+Multi 0x1409
 {
     static  0x0065    4    6    0   // stone wall
     static  0x0066   -4   -5    0   // stone wall
@@ -50753,7 +50753,7 @@ House 0x1409
     static  0x31f4    4    6    7   // dirt
 }
 
-House 0x140a
+Multi 0x140a
 {
     static  0x0065    4    6    0   // stone wall
     static  0x0066   -4   -6    0   // stone wall
@@ -50893,7 +50893,7 @@ House 0x140a
     static  0x31f4    4    6    7   // dirt
 }
 
-House 0x140b
+Multi 0x140b
 {
     static  0x0065    4    7    0   // stone wall
     static  0x0066   -4   -6    0   // stone wall
@@ -51043,7 +51043,7 @@ House 0x140b
     static  0x31f4    4    7    7   // dirt
 }
 
-House 0x1410
+Multi 0x1410
 {
     static  0x0065    5    3    0   // stone wall
     static  0x0066   -4   -3    0   // stone wall
@@ -51131,7 +51131,7 @@ House 0x1410
     static  0x31f4    5    3    7   // dirt
 }
 
-House 0x1411
+Multi 0x1411
 {
     static  0x0065    5    4    0   // stone wall
     static  0x0066   -4   -3    0   // stone wall
@@ -51230,7 +51230,7 @@ House 0x1411
     static  0x31f4    5    4    7   // dirt
 }
 
-House 0x1412
+Multi 0x1412
 {
     static  0x0065    5    4    0   // stone wall
     static  0x0066   -4   -4    0   // stone wall
@@ -51340,7 +51340,7 @@ House 0x1412
     static  0x31f4    5    4    7   // dirt
 }
 
-House 0x1413
+Multi 0x1413
 {
     static  0x0065    5    5    0   // stone wall
     static  0x0066   -4   -4    0   // stone wall
@@ -51461,7 +51461,7 @@ House 0x1413
     static  0x31f4    5    5    7   // dirt
 }
 
-House 0x1414
+Multi 0x1414
 {
     static  0x0065    5    5    0   // stone wall
     static  0x0066   -4   -5    0   // stone wall
@@ -51593,7 +51593,7 @@ House 0x1414
     static  0x31f4    5    5    7   // dirt
 }
 
-House 0x1415
+Multi 0x1415
 {
     static  0x0065    5    6    0   // stone wall
     static  0x0066   -4   -5    0   // stone wall
@@ -51736,7 +51736,7 @@ House 0x1415
     static  0x31f4    5    6    7   // dirt
 }
 
-House 0x1416
+Multi 0x1416
 {
     static  0x0065    5    6    0   // stone wall
     static  0x0066   -4   -6    0   // stone wall
@@ -51890,7 +51890,7 @@ House 0x1416
     static  0x31f4    5    6    7   // dirt
 }
 
-House 0x1417
+Multi 0x1417
 {
     static  0x0065    5    7    0   // stone wall
     static  0x0066   -4   -6    0   // stone wall
@@ -52055,7 +52055,7 @@ House 0x1417
     static  0x31f4    5    7    7   // dirt
 }
 
-House 0x1418
+Multi 0x1418
 {
     static  0x0065    5    7    0   // stone wall
     static  0x0066   -4   -7    0   // stone wall
@@ -52231,7 +52231,7 @@ House 0x1418
     static  0x31f4    5    7    7   // dirt
 }
 
-House 0x141c
+Multi 0x141c
 {
     static  0x0065    5    3    0   // stone wall
     static  0x0066   -5   -3    0   // stone wall
@@ -52327,7 +52327,7 @@ House 0x141c
     static  0x31f4    5    3    7   // dirt
 }
 
-House 0x141d
+Multi 0x141d
 {
     static  0x0065    5    4    0   // stone wall
     static  0x0066   -5   -3    0   // stone wall
@@ -52435,7 +52435,7 @@ House 0x141d
     static  0x31f4    5    4    7   // dirt
 }
 
-House 0x141e
+Multi 0x141e
 {
     static  0x0065    5    4    0   // stone wall
     static  0x0066   -5   -4    0   // stone wall
@@ -52555,7 +52555,7 @@ House 0x141e
     static  0x31f4    5    4    7   // dirt
 }
 
-House 0x141f
+Multi 0x141f
 {
     static  0x0065    5    5    0   // stone wall
     static  0x0066   -5   -4    0   // stone wall
@@ -52687,7 +52687,7 @@ House 0x141f
     static  0x31f4    5    5    7   // dirt
 }
 
-House 0x1420
+Multi 0x1420
 {
     static  0x0065    5    5    0   // stone wall
     static  0x0066   -5   -5    0   // stone wall
@@ -52831,7 +52831,7 @@ House 0x1420
     static  0x31f4    5    5    7   // dirt
 }
 
-House 0x1421
+Multi 0x1421
 {
     static  0x0065    5    6    0   // stone wall
     static  0x0066   -5   -5    0   // stone wall
@@ -52987,7 +52987,7 @@ House 0x1421
     static  0x31f4    5    6    7   // dirt
 }
 
-House 0x1422
+Multi 0x1422
 {
     static  0x0065    5    6    0   // stone wall
     static  0x0066   -5   -6    0   // stone wall
@@ -53155,7 +53155,7 @@ House 0x1422
     static  0x31f4    5    6    7   // dirt
 }
 
-House 0x1423
+Multi 0x1423
 {
     static  0x0065    5    7    0   // stone wall
     static  0x0066   -5   -6    0   // stone wall
@@ -53335,7 +53335,7 @@ House 0x1423
     static  0x31f4    5    7    7   // dirt
 }
 
-House 0x1424
+Multi 0x1424
 {
     static  0x0065    5    7    0   // stone wall
     static  0x0066   -5   -7    0   // stone wall
@@ -53527,7 +53527,7 @@ House 0x1424
     static  0x31f4    5    7    7   // dirt
 }
 
-House 0x1425
+Multi 0x1425
 {
     static  0x0065    5    8    0   // stone wall
     static  0x0066   -5   -7    0   // stone wall
@@ -53731,7 +53731,7 @@ House 0x1425
     static  0x31f4    5    8    7   // dirt
 }
 
-House 0x1428
+Multi 0x1428
 {
     static  0x0065    6    3    0   // stone wall
     static  0x0066   -5   -3    0   // stone wall
@@ -53835,7 +53835,7 @@ House 0x1428
     static  0x31f4    6    3    7   // dirt
 }
 
-House 0x1429
+Multi 0x1429
 {
     static  0x0065    6    4    0   // stone wall
     static  0x0066   -5   -3    0   // stone wall
@@ -53952,7 +53952,7 @@ House 0x1429
     static  0x31f4    6    4    7   // dirt
 }
 
-House 0x142a
+Multi 0x142a
 {
     static  0x0065    6    4    0   // stone wall
     static  0x0066   -5   -4    0   // stone wall
@@ -54082,7 +54082,7 @@ House 0x142a
     static  0x31f4    6    4    7   // dirt
 }
 
-House 0x142b
+Multi 0x142b
 {
     static  0x0065    6    5    0   // stone wall
     static  0x0066   -5   -4    0   // stone wall
@@ -54225,7 +54225,7 @@ House 0x142b
     static  0x31f4    6    5    7   // dirt
 }
 
-House 0x142c
+Multi 0x142c
 {
     static  0x0065    6    5    0   // stone wall
     static  0x0066   -5   -5    0   // stone wall
@@ -54381,7 +54381,7 @@ House 0x142c
     static  0x31f4    6    5    7   // dirt
 }
 
-House 0x142d
+Multi 0x142d
 {
     static  0x0065    6    6    0   // stone wall
     static  0x0066   -5   -5    0   // stone wall
@@ -54550,7 +54550,7 @@ House 0x142d
     static  0x31f4    6    6    7   // dirt
 }
 
-House 0x142e
+Multi 0x142e
 {
     static  0x0065    6    6    0   // stone wall
     static  0x0066   -5   -6    0   // stone wall
@@ -54732,7 +54732,7 @@ House 0x142e
     static  0x31f4    6    6    7   // dirt
 }
 
-House 0x142f
+Multi 0x142f
 {
     static  0x0065    6    7    0   // stone wall
     static  0x0066   -5   -6    0   // stone wall
@@ -54927,7 +54927,7 @@ House 0x142f
     static  0x31f4    6    7    7   // dirt
 }
 
-House 0x1430
+Multi 0x1430
 {
     static  0x0065    6    7    0   // stone wall
     static  0x0066   -5   -7    0   // stone wall
@@ -55135,7 +55135,7 @@ House 0x1430
     static  0x31f4    6    7    7   // dirt
 }
 
-House 0x1431
+Multi 0x1431
 {
     static  0x0065    6    8    0   // stone wall
     static  0x0066   -5   -7    0   // stone wall
@@ -55356,7 +55356,7 @@ House 0x1431
     static  0x31f4    6    8    7   // dirt
 }
 
-House 0x1432
+Multi 0x1432
 {
     static  0x0065    6    8    0   // stone wall
     static  0x0066   -5   -8    0   // stone wall
@@ -55590,7 +55590,7 @@ House 0x1432
     static  0x31f4    6    8    7   // dirt
 }
 
-House 0x1435
+Multi 0x1435
 {
     static  0x0065    6    4    0   // stone wall
     static  0x0066   -6   -3    0   // stone wall
@@ -55716,7 +55716,7 @@ House 0x1435
     static  0x31f4    6    4    7   // dirt
 }
 
-House 0x1436
+Multi 0x1436
 {
     static  0x0065    6    4    0   // stone wall
     static  0x0066   -6   -4    0   // stone wall
@@ -55856,7 +55856,7 @@ House 0x1436
     static  0x31f4    6    4    7   // dirt
 }
 
-House 0x1437
+Multi 0x1437
 {
     static  0x0065    6    5    0   // stone wall
     static  0x0066   -6   -4    0   // stone wall
@@ -56010,7 +56010,7 @@ House 0x1437
     static  0x31f4    6    5    7   // dirt
 }
 
-House 0x1438
+Multi 0x1438
 {
     static  0x0065    6    5    0   // stone wall
     static  0x0066   -6   -5    0   // stone wall
@@ -56178,7 +56178,7 @@ House 0x1438
     static  0x31f4    6    5    7   // dirt
 }
 
-House 0x1439
+Multi 0x1439
 {
     static  0x0065    6    6    0   // stone wall
     static  0x0066   -6   -5    0   // stone wall
@@ -56360,7 +56360,7 @@ House 0x1439
     static  0x31f4    6    6    7   // dirt
 }
 
-House 0x143a
+Multi 0x143a
 {
     static  0x0065    6    6    0   // stone wall
     static  0x0066   -6   -6    0   // stone wall
@@ -56556,7 +56556,7 @@ House 0x143a
     static  0x31f4    6    6    7   // dirt
 }
 
-House 0x143b
+Multi 0x143b
 {
     static  0x0065    6    7    0   // stone wall
     static  0x0066   -6   -6    0   // stone wall
@@ -56766,7 +56766,7 @@ House 0x143b
     static  0x31f4    6    7    7   // dirt
 }
 
-House 0x143c
+Multi 0x143c
 {
     static  0x0065    6    7    0   // stone wall
     static  0x0066   -6   -7    0   // stone wall
@@ -56990,7 +56990,7 @@ House 0x143c
     static  0x31f4    6    7    7   // dirt
 }
 
-House 0x143d
+Multi 0x143d
 {
     static  0x0065    6    8    0   // stone wall
     static  0x0066   -6   -7    0   // stone wall
@@ -57228,7 +57228,7 @@ House 0x143d
     static  0x31f4    6    8    7   // dirt
 }
 
-House 0x143e
+Multi 0x143e
 {
     static  0x0065    6    8    0   // stone wall
     static  0x0066   -6   -8    0   // stone wall
@@ -57480,7 +57480,7 @@ House 0x143e
     static  0x31f4    6    8    7   // dirt
 }
 
-House 0x143f
+Multi 0x143f
 {
     static  0x0065    6    9    0   // stone wall
     static  0x0066   -6   -8    0   // stone wall
@@ -57746,7 +57746,7 @@ House 0x143f
     static  0x31f4    6    9    7   // dirt
 }
 
-House 0x1442
+Multi 0x1442
 {
     static  0x0065    7    4    0   // stone wall
     static  0x0066   -6   -4    0   // stone wall
@@ -57896,7 +57896,7 @@ House 0x1442
     static  0x31f4    7    4    7   // dirt
 }
 
-House 0x1443
+Multi 0x1443
 {
     static  0x0065    7    5    0   // stone wall
     static  0x0066   -6   -4    0   // stone wall
@@ -58061,7 +58061,7 @@ House 0x1443
     static  0x31f4    7    5    7   // dirt
 }
 
-House 0x1444
+Multi 0x1444
 {
     static  0x0065    7    5    0   // stone wall
     static  0x0066   -6   -5    0   // stone wall
@@ -58241,7 +58241,7 @@ House 0x1444
     static  0x31f4    7    5    7   // dirt
 }
 
-House 0x1445
+Multi 0x1445
 {
     static  0x0065    7    6    0   // stone wall
     static  0x0066   -6   -5    0   // stone wall
@@ -58436,7 +58436,7 @@ House 0x1445
     static  0x31f4    7    6    7   // dirt
 }
 
-House 0x1446
+Multi 0x1446
 {
     static  0x0065    7    6    0   // stone wall
     static  0x0066   -6   -6    0   // stone wall
@@ -58646,7 +58646,7 @@ House 0x1446
     static  0x31f4    7    6    7   // dirt
 }
 
-House 0x1447
+Multi 0x1447
 {
     static  0x0065    7    7    0   // stone wall
     static  0x0066   -6   -6    0   // stone wall
@@ -58871,7 +58871,7 @@ House 0x1447
     static  0x31f4    7    7    7   // dirt
 }
 
-House 0x1448
+Multi 0x1448
 {
     static  0x0065    7    7    0   // stone wall
     static  0x0066   -6   -7    0   // stone wall
@@ -59111,7 +59111,7 @@ House 0x1448
     static  0x31f4    7    7    7   // dirt
 }
 
-House 0x1449
+Multi 0x1449
 {
     static  0x0065    7    8    0   // stone wall
     static  0x0066   -6   -7    0   // stone wall
@@ -59366,7 +59366,7 @@ House 0x1449
     static  0x31f4    7    8    7   // dirt
 }
 
-House 0x144a
+Multi 0x144a
 {
     static  0x0065    7    8    0   // stone wall
     static  0x0066   -6   -8    0   // stone wall
@@ -59636,7 +59636,7 @@ House 0x144a
     static  0x31f4    7    8    7   // dirt
 }
 
-House 0x144b
+Multi 0x144b
 {
     static  0x0065    7    9    0   // stone wall
     static  0x0066   -6   -8    0   // stone wall
@@ -59921,7 +59921,7 @@ House 0x144b
     static  0x31f4    7    9    7   // dirt
 }
 
-House 0x144f
+Multi 0x144f
 {
     static  0x0065    7    5    0   // stone wall
     static  0x0066   -7   -4    0   // stone wall
@@ -60097,7 +60097,7 @@ House 0x144f
     static  0x31f4    7    5    7   // dirt
 }
 
-House 0x1450
+Multi 0x1450
 {
     static  0x0065    7    5    0   // stone wall
     static  0x0066   -7   -5    0   // stone wall
@@ -60289,7 +60289,7 @@ House 0x1450
     static  0x31f4    7    5    7   // dirt
 }
 
-House 0x1451
+Multi 0x1451
 {
     static  0x0065    7    6    0   // stone wall
     static  0x0066   -7   -5    0   // stone wall
@@ -60497,7 +60497,7 @@ House 0x1451
     static  0x31f4    7    6    7   // dirt
 }
 
-House 0x1452
+Multi 0x1452
 {
     static  0x0065    7    6    0   // stone wall
     static  0x0066   -7   -6    0   // stone wall
@@ -60721,7 +60721,7 @@ House 0x1452
     static  0x31f4    7    6    7   // dirt
 }
 
-House 0x1453
+Multi 0x1453
 {
     static  0x0065    7    7    0   // stone wall
     static  0x0066   -7   -6    0   // stone wall
@@ -60961,7 +60961,7 @@ House 0x1453
     static  0x31f4    7    7    7   // dirt
 }
 
-House 0x1454
+Multi 0x1454
 {
     static  0x0065    7    7    0   // stone wall
     static  0x0066   -7   -7    0   // stone wall
@@ -61217,7 +61217,7 @@ House 0x1454
     static  0x31f4    7    7    7   // dirt
 }
 
-House 0x1455
+Multi 0x1455
 {
     static  0x0065    7    8    0   // stone wall
     static  0x0066   -7   -7    0   // stone wall
@@ -61489,7 +61489,7 @@ House 0x1455
     static  0x31f4    7    8    7   // dirt
 }
 
-House 0x1456
+Multi 0x1456
 {
     static  0x0065    7    8    0   // stone wall
     static  0x0066   -7   -8    0   // stone wall
@@ -61777,7 +61777,7 @@ House 0x1456
     static  0x31f4    7    8    7   // dirt
 }
 
-House 0x1457
+Multi 0x1457
 {
     static  0x0065    7    9    0   // stone wall
     static  0x0066   -7   -8    0   // stone wall
@@ -62081,7 +62081,7 @@ House 0x1457
     static  0x31f4    7    9    7   // dirt
 }
 
-House 0x145c
+Multi 0x145c
 {
     static  0x0065    8    5    0   // stone wall
     static  0x0066   -7   -5    0   // stone wall
@@ -62285,7 +62285,7 @@ House 0x145c
     static  0x31f4    8    5    7   // dirt
 }
 
-House 0x145d
+Multi 0x145d
 {
     static  0x0065    8    6    0   // stone wall
     static  0x0066   -7   -5    0   // stone wall
@@ -62506,7 +62506,7 @@ House 0x145d
     static  0x31f4    8    6    7   // dirt
 }
 
-House 0x145e
+Multi 0x145e
 {
     static  0x0065    8    6    0   // stone wall
     static  0x0066   -7   -6    0   // stone wall
@@ -62744,7 +62744,7 @@ House 0x145e
     static  0x31f4    8    6    7   // dirt
 }
 
-House 0x145f
+Multi 0x145f
 {
     static  0x0065    8    7    0   // stone wall
     static  0x0066   -7   -6    0   // stone wall
@@ -62999,7 +62999,7 @@ House 0x145f
     static  0x31f4    8    7    7   // dirt
 }
 
-House 0x1460
+Multi 0x1460
 {
     static  0x0065    8    7    0   // stone wall
     static  0x0066   -7   -7    0   // stone wall
@@ -63271,7 +63271,7 @@ House 0x1460
     static  0x31f4    8    7    7   // dirt
 }
 
-House 0x1461
+Multi 0x1461
 {
     static  0x0065    8    8    0   // stone wall
     static  0x0066   -7   -7    0   // stone wall
@@ -63560,7 +63560,7 @@ House 0x1461
     static  0x31f4    8    8    7   // dirt
 }
 
-House 0x1462
+Multi 0x1462
 {
     static  0x0065    8    8    0   // stone wall
     static  0x0066   -7   -8    0   // stone wall
@@ -63866,7 +63866,7 @@ House 0x1462
     static  0x31f4    8    8    7   // dirt
 }
 
-House 0x1463
+Multi 0x1463
 {
     static  0x0065    8    9    0   // stone wall
     static  0x0066   -7   -8    0   // stone wall
@@ -64189,7 +64189,7 @@ House 0x1463
     static  0x31f4    8    9    7   // dirt
 }
 
-House 0x1469
+Multi 0x1469
 {
     static  0x0065    8    6    0   // stone wall
     static  0x0066   -8   -5    0   // stone wall
@@ -64423,7 +64423,7 @@ House 0x1469
     static  0x31f4    8    6    7   // dirt
 }
 
-House 0x146a
+Multi 0x146a
 {
     static  0x0065    8    6    0   // stone wall
     static  0x0066   -8   -6    0   // stone wall
@@ -64675,7 +64675,7 @@ House 0x146a
     static  0x31f4    8    6    7   // dirt
 }
 
-House 0x146b
+Multi 0x146b
 {
     static  0x0065    8    7    0   // stone wall
     static  0x0066   -8   -6    0   // stone wall
@@ -64945,7 +64945,7 @@ House 0x146b
     static  0x31f4    8    7    7   // dirt
 }
 
-House 0x146c
+Multi 0x146c
 {
     static  0x0065    8    7    0   // stone wall
     static  0x0066   -8   -7    0   // stone wall
@@ -65233,7 +65233,7 @@ House 0x146c
     static  0x31f4    8    7    7   // dirt
 }
 
-House 0x146d
+Multi 0x146d
 {
     static  0x0065    8    8    0   // stone wall
     static  0x0066   -8   -7    0   // stone wall
@@ -65539,7 +65539,7 @@ House 0x146d
     static  0x31f4    8    8    7   // dirt
 }
 
-House 0x146e
+Multi 0x146e
 {
     static  0x0065    8    8    0   // stone wall
     static  0x0066   -8   -8    0   // stone wall
@@ -65863,7 +65863,7 @@ House 0x146e
     static  0x31f4    8    8    7   // dirt
 }
 
-House 0x146f
+Multi 0x146f
 {
     static  0x0065    8    9    0   // stone wall
     static  0x0066   -8   -8    0   // stone wall
@@ -66205,7 +66205,7 @@ House 0x146f
     static  0x31f4    8    9    7   // dirt
 }
 
-House 0x1476
+Multi 0x1476
 {
     static  0x0065    9    6    0   // stone wall
     static  0x0066   -8   -6    0   // stone wall
@@ -66471,7 +66471,7 @@ House 0x1476
     static  0x31f4    9    6    7   // dirt
 }
 
-House 0x1477
+Multi 0x1477
 {
     static  0x0065    9    7    0   // stone wall
     static  0x0066   -8   -6    0   // stone wall
@@ -66756,7 +66756,7 @@ House 0x1477
     static  0x31f4    9    7    7   // dirt
 }
 
-House 0x1478
+Multi 0x1478
 {
     static  0x0065    9    7    0   // stone wall
     static  0x0066   -8   -7    0   // stone wall
@@ -67060,7 +67060,7 @@ House 0x1478
     static  0x31f4    9    7    7   // dirt
 }
 
-House 0x1479
+Multi 0x1479
 {
     static  0x0065    9    8    0   // stone wall
     static  0x0066   -8   -7    0   // stone wall
@@ -67383,7 +67383,7 @@ House 0x1479
     static  0x31f4    9    8    7   // dirt
 }
 
-House 0x147a
+Multi 0x147a
 {
     static  0x0065    9    8    0   // stone wall
     static  0x0066   -8   -8    0   // stone wall
@@ -67725,7 +67725,7 @@ House 0x147a
     static  0x31f4    9    8    7   // dirt
 }
 
-House 0x147b
+Multi 0x147b
 {
     static  0x0065    9    9    0   // stone wall
     static  0x0066   -8   -8    0   // stone wall
@@ -68086,7 +68086,7 @@ House 0x147b
     static  0x31f4    9    9    7   // dirt
 }
 
-House 0x1d4c
+Multi 0x1d4c
 {
     static  0x0821   -1   -1    0   // iron fence
     static  0x0821   -1    0    0   // iron fence
@@ -68114,7 +68114,7 @@ House 0x1d4c
     static  0x0e7c    4    4    0   // metal chest
 }
 
-Stairs 0x1db0
+Multi 0x1db0
 {
     static  0x0739    0    0    0   // wooden stairs
     static  0x0738    0   -1    0   // wood
@@ -68128,7 +68128,7 @@ Stairs 0x1db0
     static  0x0739    0   -3   15   // wooden stairs
 }
 
-Stairs 0x1db1
+Multi 0x1db1
 {
     static  0x073c    0    0    0   // wooden stairs
     static  0x0738    1    0    0   // wood
@@ -68142,7 +68142,7 @@ Stairs 0x1db1
     static  0x073c    3    0   15   // wooden stairs
 }
 
-Stairs 0x1db2
+Multi 0x1db2
 {
     static  0x073b    0    0    0   // wooden stairs
     static  0x0738    0    1    0   // wood
@@ -68156,7 +68156,7 @@ Stairs 0x1db2
     static  0x073b    0    3   15   // wooden stairs
 }
 
-Stairs 0x1db3
+Multi 0x1db3
 {
     static  0x073a    0    0    0   // wooden stairs
     static  0x0738   -1    0    0   // wood
@@ -68170,7 +68170,7 @@ Stairs 0x1db3
     static  0x073a   -3    0   15   // wooden stairs
 }
 
-Stairs 0x1db4
+Multi 0x1db4
 {
     static  0x07a4    0    0    0   // stone stairs
     static  0x07a3    0   -1    0   // stone
@@ -68184,7 +68184,7 @@ Stairs 0x1db4
     static  0x07a4    0   -3   15   // stone stairs
 }
 
-Stairs 0x1db5
+Multi 0x1db5
 {
     static  0x07a7    0    0    0   // stone stairs
     static  0x07a3    1    0    0   // stone
@@ -68198,7 +68198,7 @@ Stairs 0x1db5
     static  0x07a7    3    0   15   // stone stairs
 }
 
-Stairs 0x1db6
+Multi 0x1db6
 {
     static  0x07a6    0    0    0   // stone stairs
     static  0x07a3    0    1    0   // stone
@@ -68212,7 +68212,7 @@ Stairs 0x1db6
     static  0x07a6    0    3   15   // stone stairs
 }
 
-Stairs 0x1db7
+Multi 0x1db7
 {
     static  0x07a5    0    0    0   // stone stairs
     static  0x07a3   -1    0    0   // stone
@@ -68226,7 +68226,7 @@ Stairs 0x1db7
     static  0x07a5   -3    0   15   // stone stairs
 }
 
-Stairs 0x1db8
+Multi 0x1db8
 {
     static  0x0789    0    0    0   // stone stairs
     static  0x0788    0   -1    0   // stone
@@ -68240,7 +68240,7 @@ Stairs 0x1db8
     static  0x0789    0   -3   15   // stone stairs
 }
 
-Stairs 0x1db9
+Multi 0x1db9
 {
     static  0x078c    0    0    0   // stone stairs
     static  0x0788    1    0    0   // stone
@@ -68254,7 +68254,7 @@ Stairs 0x1db9
     static  0x078c    3    0   15   // stone stairs
 }
 
-Stairs 0x1dba
+Multi 0x1dba
 {
     static  0x078b    0    0    0   // stone stairs
     static  0x0788    0    1    0   // stone
@@ -68268,7 +68268,7 @@ Stairs 0x1dba
     static  0x078b    0    3   15   // stone stairs
 }
 
-Stairs 0x1dbb
+Multi 0x1dbb
 {
     static  0x078a    0    0    0   // stone stairs
     static  0x0788   -1    0    0   // stone
@@ -68282,7 +68282,7 @@ Stairs 0x1dbb
     static  0x078a   -3    0   15   // stone stairs
 }
 
-Stairs 0x1dbc
+Multi 0x1dbc
 {
     static  0x0722    0    0    0   // wooden stairs
     static  0x0721    0   -1    0   // wood
@@ -68296,7 +68296,7 @@ Stairs 0x1dbc
     static  0x0722    0   -3   15   // wooden stairs
 }
 
-Stairs 0x1dbd
+Multi 0x1dbd
 {
     static  0x0725    0    0    0   // wooden stairs
     static  0x0721    1    0    0   // wood
@@ -68310,7 +68310,7 @@ Stairs 0x1dbd
     static  0x0725    3    0   15   // wooden stairs
 }
 
-Stairs 0x1dbe
+Multi 0x1dbe
 {
     static  0x0724    0    0    0   // wooden stairs
     static  0x0721    0    1    0   // wood
@@ -68324,7 +68324,7 @@ Stairs 0x1dbe
     static  0x0724    0    3   15   // wooden stairs
 }
 
-Stairs 0x1dbf
+Multi 0x1dbf
 {
     static  0x0723    0    0    0   // wooden stairs
     static  0x0721   -1    0    0   // wood
@@ -68338,7 +68338,7 @@ Stairs 0x1dbf
     static  0x0723   -3    0   15   // wooden stairs
 }
 
-Stairs 0x1dc0
+Multi 0x1dc0
 {
     static  0x071f    0    0    0   // stone stairs
     static  0x071e    0   -1    0   // stone
@@ -68352,7 +68352,7 @@ Stairs 0x1dc0
     static  0x071f    0   -3   15   // stone stairs
 }
 
-Stairs 0x1dc1
+Multi 0x1dc1
 {
     static  0x0749    0    0    0   // stone stairs
     static  0x071e    1    0    0   // stone
@@ -68366,7 +68366,7 @@ Stairs 0x1dc1
     static  0x0749    3    0   15   // stone stairs
 }
 
-Stairs 0x1dc2
+Multi 0x1dc2
 {
     static  0x0737    0    0    0   // stone stairs
     static  0x071e    0    1    0   // stone
@@ -68380,7 +68380,7 @@ Stairs 0x1dc2
     static  0x0737    0    3   15   // stone stairs
 }
 
-Stairs 0x1dc3
+Multi 0x1dc3
 {
     static  0x0736    0    0    0   // stone stairs
     static  0x071e   -1    0    0   // stone
@@ -68394,7 +68394,7 @@ Stairs 0x1dc3
     static  0x0736   -3    0   15   // stone stairs
 }
 
-Stairs 0x1dc4
+Multi 0x1dc4
 {
     static  0x070a    0    0    0   // marble stairs
     static  0x0709    0   -1    0   // marble
@@ -68408,7 +68408,7 @@ Stairs 0x1dc4
     static  0x070a    0   -3   15   // marble stairs
 }
 
-Stairs 0x1dc5
+Multi 0x1dc5
 {
     static  0x070d    0    0    0   // marble stairs
     static  0x0709    1    0    0   // marble
@@ -68422,7 +68422,7 @@ Stairs 0x1dc5
     static  0x070d    3    0   15   // marble stairs
 }
 
-Stairs 0x1dc6
+Multi 0x1dc6
 {
     static  0x070c    0    0    0   // marble stairs
     static  0x0709    0    1    0   // marble
@@ -68436,7 +68436,7 @@ Stairs 0x1dc6
     static  0x070c    0    3   15   // marble stairs
 }
 
-Stairs 0x1dc7
+Multi 0x1dc7
 {
     static  0x070b    0    0    0   // marble stairs
     static  0x0709   -1    0    0   // marble
@@ -68450,7 +68450,7 @@ Stairs 0x1dc7
     static  0x070b   -3    0   15   // marble stairs
 }
 
-Stairs 0x1dc8
+Multi 0x1dc8
 {
     static  0x03ef    0    0    0   // stone stairs
     static  0x03ee    0   -1    0   // stone stairs
@@ -68464,7 +68464,7 @@ Stairs 0x1dc8
     static  0x03ef    0   -3   15   // stone stairs
 }
 
-Stairs 0x1dc9
+Multi 0x1dc9
 {
     static  0x03f2    0    0    0   // stone stairs
     static  0x03ee    1    0    0   // stone stairs
@@ -68478,7 +68478,7 @@ Stairs 0x1dc9
     static  0x03f2    3    0   15   // stone stairs
 }
 
-Stairs 0x1dca
+Multi 0x1dca
 {
     static  0x03f1    0    0    0   // stone stairs
     static  0x03ee    0    1    0   // stone stairs
@@ -68492,7 +68492,7 @@ Stairs 0x1dca
     static  0x03f1    0    3   15   // stone stairs
 }
 
-Stairs 0x1dcb
+Multi 0x1dcb
 {
     static  0x03f0    0    0    0   // stone stairs
     static  0x03ee   -1    0    0   // stone stairs
@@ -68506,7 +68506,7 @@ Stairs 0x1dcb
     static  0x03f0   -3    0   15   // stone stairs
 }
 
-Stairs 0x1dcc
+Multi 0x1dcc
 {
     static  0x076d    0    0    0   // sandstone stairs
     static  0x076c    0   -1    0   // sandstone
@@ -68520,7 +68520,7 @@ Stairs 0x1dcc
     static  0x076d    0   -3   15   // sandstone stairs
 }
 
-Stairs 0x1dcd
+Multi 0x1dcd
 {
     static  0x0770    0    0    0   // sandstone stairs
     static  0x076c    1    0    0   // sandstone
@@ -68534,7 +68534,7 @@ Stairs 0x1dcd
     static  0x0770    3    0   15   // sandstone stairs
 }
 
-Stairs 0x1dce
+Multi 0x1dce
 {
     static  0x076f    0    0    0   // sandstone stairs
     static  0x076c    0    1    0   // sandstone
@@ -68548,7 +68548,7 @@ Stairs 0x1dce
     static  0x076f    0    3   15   // sandstone stairs
 }
 
-Stairs 0x1dcf
+Multi 0x1dcf
 {
     static  0x076e    0    0    0   // sandstone stairs
     static  0x076c   -1    0    0   // sandstone
@@ -68562,7 +68562,7 @@ Stairs 0x1dcf
     static  0x076e   -3    0   15   // sandstone stairs
 }
 
-Stairs 0x1dd0
+Multi 0x1dd0
 {
     static  0x0751    0    0    0   // stone stairs
     static  0x0750    0   -1    0   // stone
@@ -68576,7 +68576,7 @@ Stairs 0x1dd0
     static  0x0751    0   -3   15   // stone stairs
 }
 
-Stairs 0x1dd1
+Multi 0x1dd1
 {
     static  0x0754    0    0    0   // stone stairs
     static  0x0750    1    0    0   // stone
@@ -68590,7 +68590,7 @@ Stairs 0x1dd1
     static  0x0754    3    0   15   // stone stairs
 }
 
-Stairs 0x1dd2
+Multi 0x1dd2
 {
     static  0x0753    0    0    0   // stone stairs
     static  0x0750    0    1    0   // stone
@@ -68604,7 +68604,7 @@ Stairs 0x1dd2
     static  0x0753    0    3   15   // stone stairs
 }
 
-Stairs 0x1dd3
+Multi 0x1dd3
 {
     static  0x0752    0    0    0   // stone stairs
     static  0x0750   -1    0    0   // stone
@@ -68618,7 +68618,7 @@ Stairs 0x1dd3
     static  0x0752   -3    0   15   // stone stairs
 }
 
-Stairs 0x1dd4
+Multi 0x1dd4
 {
     static  0x07bb    0    0    0   // carpeted stair
     static  0x07ba    0   -1    0   // carpeted rostrum
@@ -68632,7 +68632,7 @@ Stairs 0x1dd4
     static  0x07bb    0   -3   15   // carpeted stair
 }
 
-Stairs 0x1dd7
+Multi 0x1dd7
 {
     static  0x07bc    0    0    0   // carpeted stair
     static  0x07ba   -1    0    0   // carpeted rostrum

--- a/config/tiles.cfg
+++ b/config/tiles.cfg
@@ -183195,11 +183195,13 @@ tile 0x3ec3
 {
     Desc tiller
     UoFlags 0x00004000
-    Layer 1
+    Layer 25
+    AnimID 0
     Height 3
     Weight 255
     OverFlight 0
     Movable 1
+    Equippable 1
     DescPrependA 1
 }
 
@@ -183304,12 +183306,14 @@ tile 0x3ecb
 {
     Desc mast
     UoFlags 0x00024040
-    Layer 5
+    Layer 25
+    AnimID 0
     Height 3
     Weight 255
     BlockSight 1
     OverFlight 0
     Blocking 1
+    Equippable 1
     DescPrependA 1
 }
 
@@ -183331,11 +183335,13 @@ tile 0x3ecd
 {
     Desc spar
     UoFlags 0x00024004
-    Layer 6
+    Layer 25
+    AnimID 0
     Height 3
     Weight 255
     OverFlight 0
     Movable 1
+    Equippable 1
     DescPrependA 1
 }
 
@@ -183343,10 +183349,13 @@ tile 0x3ece
 {
     Desc spar
     UoFlags 0x00024004
+    Layer 25
+    AnimID 0
     Height 3
     Weight 255
     OverFlight 0
     Movable 1
+    Equippable 1
     DescPrependA 1
 }
 
@@ -183354,11 +183363,13 @@ tile 0x3ecf
 {
     Desc spar
     UoFlags 0x00024004
-    Layer 7
+    Layer 25
+    AnimID 0
     Height 3
     Weight 255
     OverFlight 0
     Movable 1
+    Equippable 1
     DescPrependA 1
 }
 
@@ -183366,11 +183377,14 @@ tile 0x3ed0
 {
     Desc mast
     UoFlags 0x04024040
+    Layer 25
+    AnimID 0
     Height 3
     Weight 255
     BlockSight 1
     OverFlight 0
     Blocking 1
+    Equippable 1
     DescPrependA 1
 }
 
@@ -183378,10 +183392,13 @@ tile 0x3ed1
 {
     Desc spar
     UoFlags 0x00024004
+    Layer 25
+    AnimID 0
     Height 3
     Weight 255
     OverFlight 0
     Movable 1
+    Equippable 1
     DescPrependA 1
 }
 
@@ -183389,10 +183406,13 @@ tile 0x3ed2
 {
     Desc spar
     UoFlags 0x04024004
+    Layer 25
+    AnimID 0
     Height 3
     Weight 255
     OverFlight 0
     Movable 1
+    Equippable 1
     DescPrependA 1
 }
 
@@ -183400,6 +183420,8 @@ tile 0x3ed3
 {
     Desc gang plank
     UoFlags 0x00004600
+    Layer 25
+    AnimID 0
     Height 3
     Weight 255
     MoveLand 1
@@ -183408,6 +183430,7 @@ tile 0x3ed3
     AllowDropOn 1
     Gradual 1
     Movable 1
+    Equippable 1
     DescPrependA 1
 }
 
@@ -183415,6 +183438,8 @@ tile 0x3ed4
 {
     Desc gang plank
     UoFlags 0x00004600
+    Layer 25
+    AnimID 0
     Height 3
     Weight 255
     MoveLand 1
@@ -183423,6 +183448,7 @@ tile 0x3ed4
     AllowDropOn 1
     Gradual 1
     Movable 1
+    Equippable 1
     DescPrependA 1
 }
 
@@ -183430,6 +183456,8 @@ tile 0x3ed5
 {
     Desc gang plank
     UoFlags 0x00004600
+    Layer 25
+    AnimID 0
     Height 3
     Weight 255
     MoveLand 1
@@ -183438,6 +183466,7 @@ tile 0x3ed5
     AllowDropOn 1
     Gradual 1
     Movable 1
+    Equippable 1
     DescPrependA 1
 }
 
@@ -183445,50 +183474,65 @@ tile 0x3ed6
 {
     Desc MissingName
     UoFlags 0x04000000
+    Layer 25
+    AnimID 0
     Height 0
     Weight 0
     OverFlight 0
     Movable 1
+    Equippable 1
 }
 
 tile 0x3ed7
 {
     Desc MissingName
     UoFlags 0x00000000
+    Layer 25
+    AnimID 0
     Height 0
     Weight 0
     OverFlight 0
     Movable 1
+    Equippable 1
 }
 
 tile 0x3ed8
 {
     Desc curtains
     UoFlags 0x04000000
+    Layer 25
+    AnimID 0
     Height 0
     Weight 0
     OverFlight 0
     Movable 1
+    Equippable 1
 }
 
 tile 0x3ed9
 {
     Desc curtains
     UoFlags 0x00000000
+    Layer 25
+    AnimID 0
     Height 0
     Weight 0
     OverFlight 0
     Movable 1
+    Equippable 1
 }
 
 tile 0x3eda
 {
     Desc curtains
     UoFlags 0x00000000
+    Layer 25
+    AnimID 0
     Height 0
     Weight 0
     OverFlight 0
     Movable 1
+    Equippable 1
 }
 
 tile 0x3edb
@@ -184540,11 +184584,13 @@ tile 0x3f3a
 {
     Desc MissingName
     UoFlags 0x00000000
-    Layer 7
+    Layer 25
+    AnimID 0
     Height 0
     Weight 255
     OverFlight 0
     Movable 1
+    Equippable 1
 }
 
 tile 0x3f3b
@@ -185119,14 +185165,12 @@ tile 0x3f6f
 {
     Desc ballista
     UoFlags 0x00000040
-    Layer 25
-    AnimID 9
+    Layer 1
     Height 20
     Weight 5
     BlockSight 1
     OverFlight 0
     Blocking 1
-    Equippable 1
 }
 
 tile 0x3f70

--- a/pkg/opt/areas/EnterAreaDelay.src
+++ b/pkg/opt/areas/EnterAreaDelay.src
@@ -38,6 +38,13 @@ var regionname := GetRegionName(who);
 // Resolve area policy mask ONCE and reuse the result for all bit checks.
 var mask := CInt(ResolvePolicyAtLocation(who.x, who.y, who.realm));
 
+// No Damage Zone - checked before Safe Area since that block returns early
+// on match, which would otherwise skip this if both were ever set together.
+if (HasPolicy(mask, AREA_POLICY_NO_DAMAGE_ZONE))
+	SendSysMessage(who, "This is a NO DAMAGE zone.", 3, 1001);
+	SetNoDamageZoneProperties(who);
+endif
+
 // Safe area, no more messages atm
 if (HasPolicy(mask, AREA_POLICY_SAFE_AREA))
 	SendSysMessage(who, "This is a SAFE area.", 3, 1001);

--- a/pkg/opt/areas/LeaveArea.src
+++ b/pkg/opt/areas/LeaveArea.src
@@ -48,5 +48,10 @@ program LeaveArea(who)
 		RemoveNOPK(who);
 	endif
 
+	// No Damage Zone, remove flag
+	if (GetObjProperty(who, "InNoDamageZone"))
+		RemoveNoDamageZoneProperties(who);
+	endif
+
 endprogram
 

--- a/pkg/opt/areas/areas.cfg
+++ b/pkg/opt/areas/areas.cfg
@@ -15,465 +15,262 @@
 Areas britannia
 {
 	//Dungeon Entrances
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 556 599 1608 1655 id=blightedgroveentrance Blighted Grove Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1432 1471 1216 1251 id=brigandstrongholdentrance Brigand Stronghold Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2492 2507 1916 1923 id=coveteousentrance Coveteous Entrance
-	// Contains: - | Inside: Ice Isle, Britannia, Whole World | Partially overlaps: -
-	Area 4100 4123 428 451 id=deceitentrance Deceit Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1292 1359 1044 1099 id=despiseentrance Despise Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1164 1183 2632 2647 id=destardentrance Destard Entrance
-	// Contains: - | Inside: Serpents Hold, Serpents Hold Isle, Britannia, Whole World | Partially overlaps: -
-	Area 2920 2927 3404 3411 id=firedungeonentrance Fire Dungeon Entrance
-	// Contains: - | Inside: Nujel'm, Britannia, Whole World | Partially overlaps: -
-	Area 3776 3795 1088 1107 id=gemstonecaveentrance Gemstone Cave Entrance
-	// Contains: - | Inside: Fire Island, Britannia, Whole World | Partially overlaps: -
-	Area 4716 4727 3808 3827 id=hythlothentrance Hythloth Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1900 2003 76 87 id=icedungeonentrance Ice Dungeon Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1012 1023 1424 1443 id=orccaveentrance Orc Cave Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1712 1723 2992 3003 id=paintedcavesentrance Painted Caves Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1620 1635 3316 3327 id=rangerdungeonentrance Ranger Dungeon Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1712 1751 1056 1079 id=sanctuaryentrance Sanctuary Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 504 523 1556 1567 id=shameentrance Shame Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2616 2643 36 63 id=solenhiveentrance Solen Hive Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1104 1191 2576 2619 id=terathankeepentrance Terathan Keep Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1348 1463 884 1007 id=windentrance Wind Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1376 1427 848 883 id=windentrance2 Wind Entrance
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1984 2063 212 291 id=wrongentrance Wrong Entrance
+	Area 556 599 1608 1655 id=blightedgroveentrance cat=entrance Blighted Grove Entrance
+	Area 1432 1471 1216 1251 id=brigandstrongholdentrance cat=entrance Brigand Stronghold Entrance
+	Area 2492 2507 1916 1923 id=coveteousentrance cat=entrance Coveteous Entrance
+	Area 4100 4123 428 451 id=deceitentrance cat=entrance Deceit Entrance
+	Area 1292 1359 1044 1099 id=despiseentrance cat=entrance Despise Entrance
+	Area 1164 1183 2632 2647 id=destardentrance cat=entrance Destard Entrance
+	Area 2920 2927 3404 3411 id=firedungeonentrance cat=entrance Fire Dungeon Entrance
+	Area 3776 3795 1088 1107 id=gemstonecaveentrance cat=entrance Gemstone Cave Entrance
+	Area 4716 4727 3808 3827 id=hythlothentrance cat=entrance Hythloth Entrance
+	Area 1900 2003 76 87 id=icedungeonentrance cat=entrance Ice Dungeon Entrance
+	Area 1012 1023 1424 1443 id=orccaveentrance cat=entrance Orc Cave Entrance
+	Area 1712 1723 2992 3003 id=paintedcavesentrance cat=entrance Painted Caves Entrance
+	Area 1620 1635 3316 3327 id=rangerdungeonentrance cat=entrance Ranger Dungeon Entrance
+	Area 1712 1751 1056 1079 id=sanctuaryentrance cat=entrance Sanctuary Entrance
+	Area 504 523 1556 1567 id=shameentrance cat=entrance Shame Entrance
+	Area 2616 2643 36 63 id=solenhiveentrance cat=entrance Solen Hive Entrance
+	Area 1104 1191 2576 2619 id=terathankeepentrance cat=entrance Terathan Keep Entrance
+	Area 1348 1463 884 1007 id=windentrance cat=entrance Wind Entrance
+	Area 1376 1427 848 883 id=windentrance2 cat=entrance Wind Entrance
+	Area 1984 2063 212 291 id=wrongentrance cat=entrance Wrong Entrance
 
 	//Britannia Shrines
-	// Contains: - | Inside: Fire Island, Britannia, Whole World | Partially overlaps: -
-	Area 4268 4279 3692 3703 id=shrineofhumility Shrine of Humility
-	// Contains: - | Inside: Valor Island, Britannia, Whole World | Partially overlaps: -
-	Area 2484 2499 3924 3939 id=shrineofvalor Shrine of Valor
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1716 1735 3520 3535 id=shrineofhonor Shrine of Honor
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1588 1603 2484 2499 id=shrineofspirituality Shrine of Spirituality
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1292 1307 624 643 id=shrineofjustice Shrine of Justice
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1456 1463 840 847 id=shrineofchaos Shrine of Chaos
-	// Contains: - | Inside: Desert of Compassion, Britannia, Whole World | Partially overlaps: -
-	Area 1852 1867 864 883 id=shrineofcompassion Shrine of Compassion
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 3344 3367 276 299 id=shrineofsacrifice Shrine of Sacrifice
-	// Contains: - | Inside: Ice Isle, Britannia, Whole World | Partially overlaps: -
-	Area 4200 4235 548 591 id=shrineofhonesty Shrine of Honesty
+	Area 4268 4279 3692 3703 id=shrineofhumility cat=shrine Shrine of Humility
+	Area 2484 2499 3924 3939 id=shrineofvalor cat=shrine Shrine of Valor
+	Area 1716 1735 3520 3535 id=shrineofhonor cat=shrine Shrine of Honor
+	Area 1588 1603 2484 2499 id=shrineofspirituality cat=shrine Shrine of Spirituality
+	Area 1292 1307 624 643 id=shrineofjustice cat=shrine Shrine of Justice
+	Area 1456 1463 840 847 id=shrineofchaos cat=shrine Shrine of Chaos
+	Area 1852 1867 864 883 id=shrineofcompassion cat=shrine Shrine of Compassion
+	Area 3344 3367 276 299 id=shrineofsacrifice cat=shrine Shrine of Sacrifice
+	Area 4200 4235 548 591 id=shrineofhonesty cat=shrine Shrine of Honesty
 
 	//Britannia Graveyards
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1336 1391 1440 1511 id=britaingraveyard Britain Graveyard
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2724 2787 836 899 id=vespergraveyard Vesper Graveyard
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2420 2459 1076 1123 id=covegraveyard Cove Graveyard
-	// Contains: - | Inside: Moonglow Island, Britannia, Whole World | Partially overlaps: -
-	Area 4524 4559 1292 1339 id=moonglowgraveyard Moonglow Graveyard
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 708 739 1100 1139 id=yewgraveyard Yew Graveyard
-	// Contains: - | Inside: Jhelom, Britannia, Whole World | Partially overlaps: -
-	Area 1272 1299 3712 3751 id=jhelomgraveyard Jhelom Graveyard
-	// Contains: - | Inside: Nujel'm, Britannia, Whole World | Partially overlaps: -
-	Area 3500 3555 1120 1163 id=nujelmgraveyard Nujel'm Graveyard
+	Area 1336 1391 1440 1511 id=britaingraveyard cat=graveyard Britain Graveyard
+	Area 2724 2787 836 899 id=vespergraveyard cat=graveyard Vesper Graveyard
+	Area 2420 2459 1076 1123 id=covegraveyard cat=graveyard Cove Graveyard
+	Area 4524 4559 1292 1339 id=moonglowgraveyard cat=graveyard Moonglow Graveyard
+	Area 708 739 1100 1139 id=yewgraveyard cat=graveyard Yew Graveyard
+	Area 1272 1299 3712 3751 id=jhelomgraveyard cat=graveyard Jhelom Graveyard
+	Area 3500 3555 1120 1163 id=nujelmgraveyard cat=graveyard Nujel'm Graveyard
 
 	//Small Points of Interest
-	// Contains: - | Inside: Jhelom, Britannia, Whole World | Partially overlaps: -
-	Area 1376 1423 3728 3759 id=jhelomarena Jhelom Arena
-	// Contains: - | Inside: Arcane Isle, Britannia, Whole World | Partially overlaps: -
-	Area 2480 2507 3564 3603 id=zeddicuszorandersaltar Zeddicus Zorander's Altar
-	// Contains: - | Inside: Terathan Keep, Whole World | Partially overlaps: -
-	Area 5120 5171 1744 1791 id=starroom Star Room
-	// Contains: - | Inside: Moonglow Island, Britannia, Whole World | Partially overlaps: -
-	Area 4472 4551 1340 1411 id=moonglowzoo Moonglow Zoo
-
+	Area 1376 1423 3728 3759 id=jhelomarena cat=poi Jhelom Arena
+	Area 2480 2507 3564 3603 id=zeddicuszorandersaltar cat=poi Zeddicus Zorander's Altar
+	Area 5120 5171 1744 1791 id=starroom cat=poi Star Room
+	Area 4472 4551 1340 1411 id=moonglowzoo cat=poi Moonglow Zoo
 
 	//Britannia Cities
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5892 6019 1420 1531 id=occlomine Occlo Mine
-	// Contains: - | Inside: Occlo Isle, Britannia, Whole World | Partially overlaps: -
-	Area 3588 3751 2460 2731 id=occlo Occlo
-	// Contains: - | Inside: Magincia Isle, Britannia, Whole World | Partially overlaps: -
-	Area 3652 3811 2048 2299 id=magincia Magincia
-	// Contains: - | Inside: Buccaneer's Den Isle, Britannia, Whole World | Partially overlaps: -
-	Area 2620 2787 2068 2267 id=buccaneersden Buccaneer's Den
-	// Contains: Fire Dungeon Entrance | Inside: Serpents Hold Isle, Britannia, Whole World | Partially overlaps: -
-	Area 2868 3079 3324 3575 id=serpentshold Serpents Hold
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1792 2167 2632 2927 id=trinsic Trinsic
-	// Contains: - | Inside: North Jhelom Island, Britannia, Whole World | Partially overlaps: -
-	Area 1100 1203 3564 3703 id=northjhelomfarmlands North Jhelom Farmlands
-	// Contains: Jhelom Graveyard, Jhelom Arena | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1232 1519 3596 3923 id=jhelom Jhelom
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1372 1531 3948 4051 id=southjhelomisland South Jhelom Island
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 512 695 2048 2299 id=skarabrae Skara Brae
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 696 911 2056 2423 id=skarabraefarmlands Skara Brae Farmlands
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6912 7167 256 511 id=elventown Elven Town
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1408 1711 1500 1795 id=britain Britain
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1288 1407 1700 1839 id=britainfarmlands Britain Farmlands
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1084 1287 1540 1903 id=britainouterfarmlands Britain Outer Farmlands
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1500 1543 1404 1499 id=lordblackthornescastle Lord Blackthornes Castle
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1288 1407 1556 1699 id=lordbritishcastle Lord British Castle
-	// Contains: Gemstone Cave Entrance, Nujel'm Graveyard | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 3480 3827 1032 1427 id=nujelm Nujel'm
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 540 707 772 927 id=empathabbey Empath Abbey
-	// Contains: - | Inside: Lost Lands, Whole World | Partially overlaps: -
-	Area 5128 5315 3928 4087 id=delucia Delucia
-	// Contains: - | Inside: Lost Lands, Whole World | Partially overlaps: -
-	Area 5632 5843 3092 3319 id=papau Papau
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2204 2295 1112 1243 id=cove Cove
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2388 2539 348 603 id=minoc Minoc
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2540 2627 552 603 id=minocfarmlands Minoc Farmlands
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2464 2623 604 687 id=minocfarmlands2 Minoc Farmlands
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2540 2635 372 551 id=minocisle Minoc Isle
-	// Contains: - | Inside: Moonglow Island, Britannia, Whole World | Partially overlaps: -
-	Area 4380 4735 792 1235 id=moonglow Moonglow
-	// Contains: - | Inside: Moonglow Island, Britannia, Whole World | Partially overlaps: -
-	Area 4248 4379 876 1103 id=moonglowkeep Moonglow Keep
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5128 5375 256 511 id=randorin Randorin
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2820 2935 636 799 id=vesper Vesper
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2936 2987 684 799 id=vesper2 Vesper
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2988 3035 748 799 id=vesper3 Vesper
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2820 3055 800 1015 id=vesper4 Vesper
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2936 3007 600 655 id=vesperoutbuildings Vesper Outbuildings
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2716 2819 928 1015 id=vesperoutbuildings2 Vesper Outbuildings
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 500 599 928 1051 id=yew Yew
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 192 411 700 927 id=yewisland Yew Island
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 412 539 772 927 id=yewfarmlands Yew Farmlands
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 232 499 928 1255 id=yewfarmlands2 Yew Farmlands
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 500 599 1052 1255 id=yewfarmlands3 Yew Farmlands
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 600 707 928 1255 id=yewfarmlands4 Yew Farmlands
+	Area 5892 6019 1420 1531 id=occlomine cat=city Occlo Mine
+	Area 3588 3751 2460 2731 id=occlo cat=city Occlo
+	Area 3652 3811 2048 2299 id=magincia cat=city Magincia
+	Area 2620 2787 2068 2267 id=buccaneersden cat=city Buccaneer's Den
+	Area 2868 3079 3324 3575 id=serpentshold cat=city Serpents Hold
+	Area 1792 2167 2632 2927 id=trinsic cat=city Trinsic
+	Area 1100 1203 3564 3703 id=northjhelomfarmlands cat=city North Jhelom Farmlands
+	Area 1232 1519 3596 3923 id=jhelom cat=city Jhelom
+	Area 1372 1531 3948 4051 id=southjhelomisland cat=city South Jhelom Island
+	Area 512 695 2048 2299 id=skarabrae cat=city Skara Brae
+	Area 696 911 2056 2423 id=skarabraefarmlands cat=city Skara Brae Farmlands
+	Area 6912 7167 256 511 id=elventown cat=city Elven Town
+	Area 1408 1711 1500 1795 id=britain cat=city Britain
+	Area 1288 1407 1700 1839 id=britainfarmlands cat=city Britain Farmlands
+	Area 1084 1287 1540 1903 id=britainouterfarmlands cat=city Britain Outer Farmlands
+	Area 1500 1543 1404 1499 id=lordblackthornescastle cat=city Lord Blackthornes Castle
+	Area 1288 1407 1556 1699 id=lordbritishcastle cat=city Lord British Castle
+	Area 3480 3827 1032 1427 id=nujelm cat=city Nujel'm
+	Area 540 707 772 927 id=empathabbey cat=city Empath Abbey
+	Area 5128 5315 3928 4087 id=delucia cat=city Delucia
+	Area 5632 5843 3092 3319 id=papau cat=city Papau
+	Area 2204 2295 1112 1243 id=cove cat=city Cove
+	Area 2388 2539 348 603 id=minoc cat=city Minoc
+	Area 2540 2627 552 603 id=minocfarmlands cat=city Minoc Farmlands
+	Area 2464 2623 604 687 id=minocfarmlands2 cat=city Minoc Farmlands
+	Area 2540 2635 372 551 id=minocisle cat=city Minoc Isle
+	Area 4380 4735 792 1235 id=moonglow cat=city Moonglow
+	Area 4248 4379 876 1103 id=moonglowkeep cat=city Moonglow Keep
+	Area 5128 5375 256 511 id=randorin cat=city Randorin
+	Area 2820 2935 636 799 id=vesper cat=city Vesper
+	Area 2936 2987 684 799 id=vesper2 cat=city Vesper
+	Area 2988 3035 748 799 id=vesper3 cat=city Vesper
+	Area 2820 3055 800 1015 id=vesper4 cat=city Vesper
+	Area 2936 3007 600 655 id=vesperoutbuildings cat=city Vesper Outbuildings
+	Area 2716 2819 928 1015 id=vesperoutbuildings2 cat=city Vesper Outbuildings
+	Area 500 599 928 1051 id=yew cat=city Yew
+	Area 192 411 700 927 id=yewisland cat=city Yew Island
+	Area 412 539 772 927 id=yewfarmlands cat=city Yew Farmlands
+	Area 232 499 928 1255 id=yewfarmlands2 cat=city Yew Farmlands
+	Area 500 599 1052 1255 id=yewfarmlands3 cat=city Yew Farmlands
+	Area 600 707 928 1255 id=yewfarmlands4 cat=city Yew Farmlands
 
 	//Britannia Dungeons
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5632 5947 1760 2047 id=solenhive Solen Hive
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5920 6027 1572 1695 id=paintedcaves Painted Caves
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5380 5503 1848 1951 id=coveteouslevel Coveteous Level 1
-	// Contains: - | Inside: Coveteous Level 2, Whole World | Partially overlaps: -
-	Area 5380 5399 1952 1963 id=coveteouslevel2 Coveteous Level 1
-	// Contains: Coveteous Level 1 | Inside: Whole World | Partially overlaps: -
-	Area 5380 5623 1952 2039 id=coveteouslevel3 Coveteous Level 2
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5536 5627 1824 1927 id=coveteouslevel4 Coveteous Level 3
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5500 5555 1800 1819 id=coveteouslevel5 Coveteous Level 4
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5400 5483 1792 1835 id=coveteouslake Coveteous Lake
-	// Contains: Star Room | Inside: Whole World | Partially overlaps: -
-	Area 5120 5375 1532 1795 id=terathankeep Terathan Keep
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1028 1255 2156 2303 id=britainmaze Britain Maze
-	// Contains: - | Inside: Mining Caves, Whole World | Partially overlaps: -
-	Area 5128 5163 1944 2019 id=orccavelevel Orc Cave Level 1
-	// Contains: - | Inside: Mining Caves, Whole World | Partially overlaps: -
-	Area 5128 5171 1864 1919 id=orccavelevel2 Orc Cave Level 2
-	// Contains: Orc Cave Level 1, Orc Cave Level 2 | Inside: Whole World | Partially overlaps: -
-	Area 5120 5371 1796 2063 id=miningcaves Mining Caves
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5292 5375 1284 1391 id=khaldunlevel Khaldun Level 1
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5376 5627 1284 1407 id=khaldunlevel2 Khaldun Level 2
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5376 5519 1408 1507 id=khaldunlevel3 Khaldun Level 2
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5880 6027 1280 1415 id=rangerdungeon Ranger Dungeon
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6028 6051 1280 1335 id=rangerdungeon2 Ranger Dungeon
-	// Contains: - | Inside: Fire Island, Britannia, Whole World | Partially overlaps: -
-	Area 4560 4635 3548 3631 id=firetemple Fire Temple
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5900 6003 12 115 id=hythlothlevel Hythloth Level 1
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5900 6003 132 243 id=hythlothlevel2 Hythloth Level 2
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6020 6131 140 235 id=hythlothlevel3 Hythloth Level 3
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6044 6123 24 107 id=hythlothlevel4 Hythloth Level 4
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5564 5599 620 643 id=despisegateway Despise Gateway
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5380 5515 516 639 id=despiselevel Despise Level 1
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5380 5531 644 771 id=despiselevel2 Despise Level 2
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5380 5627 772 1023 id=despiselevel3 Despise Level 3
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5120 5379 772 1031 id=destard Destard
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5776 5883 512 639 id=wronglevel Wrong Level 1
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5644 5735 512 579 id=wronglevel2 Wrong Level 2
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5784 5723 620 667 id=wronglevel3 Wrong Level 3
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5664 5871 788 1011 id=wronglevel4 Wrong Level 4
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5380 5627 380 507 id=newbiesdungeon Newbies Dungeon
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5380 5627 260 379 id=randorindungeon Randorin Dungeon
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5380 5503 0 131 id=shamelevel Shame Level 1
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5504 5635 0 131 id=shamelevel2 Shame Level 2
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5380 5627 132 255 id=shamelevel3 Shame Level 3
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5636 5891 0 127 id=shamelevel4 Shame Level 4
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5656 5699 380 431 id=zuluentrance Zulu Entrance 1
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5732 5771 316 371 id=zuluentrance2 Zulu Entrance 2
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5716 5771 424 463 id=zuluentrance3 Zulu Entrance 3
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5812 5863 416 479 id=zuluentrance4 Zulu Entrance 4
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5900 6003 268 371 id=zuludungeon Zulu Dungeon 1
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5900 6003 396 495 id=zuludungeon2 Zulu Dungeon 2
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6024 6131 268 371 id=zuludungeon3 Zulu Dungeon 3
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6024 6131 396 499 id=zuludungeon4 Zulu Dungeon 4
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5124 5231 1284 1387 id=zuludungeon5 Zulu Dungeon 5
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5124 5371 1412 1515 id=zuludungeon6 Zulu Dungeon 6
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6068 6139 1276 1335 id=colorwars Color Wars
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6032 6131 1336 1407 id=colorwars2 Color Wars
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6024 6127 1424 1511 id=britainsewers Britain Sewers
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2100 2211 3880 4019 id=evilspellbookisland Evil Spellbook Island
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5664 5891 128 259 id=icedungeon Ice Dungeon
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5652 5711 300 339 id=icedungeonlevel Ice Dungeon Level 2
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5800 5863 320 387 id=icedungeonfort Ice Dungeon Fort
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5120 5235 520 643 id=deceitlevel Deceit Level 1
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5272 5355 520 643 id=deceitlevel2 Deceit Level 2
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5120 5235 644 771 id=deceitlevel3 Deceit Level 3
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5236 5355 644 771 id=deceitlevel4 Deceit Level 4
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5616 5627 1424 1443 id=firedungeon Fire Dungeon
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5628 5879 1280 1523 id=firedungeon2 Fire Dungeon
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6632 6699 72 199 id=firedungeonmine Fire Dungeon Mine
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6200 6571 320 671 id=scourgeoutlands Scourge Outlands
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6432 6563 824 983 id=blightedgrove Blighted Grove
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6456 6615 0 259 id=gemstonecave Gemstone Cave
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5120 5371 0 251 id=wind Wind
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6240 6319 852 915 id=brigandstronghold Brigand Stronghold
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 932 1027 680 839 id=shadowlordsstronghold Shadowlords Stronghold
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6144 6399 0 255 id=sanctuary Sanctuary
+	Area 5632 5947 1760 2047 id=solenhive cat=dungeon Solen Hive
+	Area 5920 6027 1572 1695 id=paintedcaves cat=dungeon Painted Caves
+	Area 5380 5503 1848 1951 id=coveteouslevel cat=dungeon Coveteous Level 1
+	Area 5380 5399 1952 1963 id=coveteouslevel2 cat=dungeon Coveteous Level 1
+	Area 5380 5623 1952 2039 id=coveteouslevel3 cat=dungeon Coveteous Level 2
+	Area 5536 5627 1824 1927 id=coveteouslevel4 cat=dungeon Coveteous Level 3
+	Area 5500 5555 1800 1819 id=coveteouslevel5 cat=dungeon Coveteous Level 4
+	Area 5400 5483 1792 1835 id=coveteouslake cat=dungeon Coveteous Lake
+	Area 5120 5375 1532 1795 id=terathankeep cat=dungeon Terathan Keep
+	Area 1028 1255 2156 2303 id=britainmaze cat=dungeon Britain Maze
+	Area 5128 5163 1944 2019 id=orccavelevel cat=dungeon Orc Cave Level 1
+	Area 5128 5171 1864 1919 id=orccavelevel2 cat=dungeon Orc Cave Level 2
+	Area 5120 5371 1796 2063 id=miningcaves cat=dungeon Mining Caves
+	Area 5292 5375 1284 1391 id=khaldunlevel cat=dungeon Khaldun Level 1
+	Area 5376 5627 1284 1407 id=khaldunlevel2 cat=dungeon Khaldun Level 2
+	Area 5376 5519 1408 1507 id=khaldunlevel3 cat=dungeon Khaldun Level 2
+	Area 5880 6027 1280 1415 id=rangerdungeon cat=dungeon Ranger Dungeon
+	Area 6028 6051 1280 1335 id=rangerdungeon2 cat=dungeon Ranger Dungeon
+	Area 4560 4635 3548 3631 id=firetemple cat=dungeon Fire Temple
+	Area 5900 6003 12 115 id=hythlothlevel cat=dungeon Hythloth Level 1
+	Area 5900 6003 132 243 id=hythlothlevel2 cat=dungeon Hythloth Level 2
+	Area 6020 6131 140 235 id=hythlothlevel3 cat=dungeon Hythloth Level 3
+	Area 6044 6123 24 107 id=hythlothlevel4 cat=dungeon Hythloth Level 4
+	Area 5564 5599 620 643 id=despisegateway cat=dungeon Despise Gateway
+	Area 5380 5515 516 639 id=despiselevel cat=dungeon Despise Level 1
+	Area 5380 5531 644 771 id=despiselevel2 cat=dungeon Despise Level 2
+	Area 5380 5627 772 1023 id=despiselevel3 cat=dungeon Despise Level 3
+	Area 5120 5379 772 1031 id=destard cat=dungeon Destard
+	Area 5776 5883 512 639 id=wronglevel cat=dungeon Wrong Level 1
+	Area 5644 5735 512 579 id=wronglevel2 cat=dungeon Wrong Level 2
+	Area 5784 5723 620 667 id=wronglevel3 cat=dungeon Wrong Level 3
+	Area 5664 5871 788 1011 id=wronglevel4 cat=dungeon Wrong Level 4
+	Area 5380 5627 380 507 id=newbiesdungeon cat=dungeon Newbies Dungeon
+	Area 5380 5627 260 379 id=randorindungeon cat=dungeon Randorin Dungeon
+	Area 5380 5503 0 131 id=shamelevel cat=dungeon Shame Level 1
+	Area 5504 5635 0 131 id=shamelevel2 cat=dungeon Shame Level 2
+	Area 5380 5627 132 255 id=shamelevel3 cat=dungeon Shame Level 3
+	Area 5636 5891 0 127 id=shamelevel4 cat=dungeon Shame Level 4
+	Area 5656 5699 380 431 id=zuluentrance cat=dungeon Zulu Entrance 1
+	Area 5732 5771 316 371 id=zuluentrance2 cat=dungeon Zulu Entrance 2
+	Area 5716 5771 424 463 id=zuluentrance3 cat=dungeon Zulu Entrance 3
+	Area 5812 5863 416 479 id=zuluentrance4 cat=dungeon Zulu Entrance 4
+	Area 5900 6003 268 371 id=zuludungeon cat=dungeon Zulu Dungeon 1
+	Area 5900 6003 396 495 id=zuludungeon2 cat=dungeon Zulu Dungeon 2
+	Area 6024 6131 268 371 id=zuludungeon3 cat=dungeon Zulu Dungeon 3
+	Area 6024 6131 396 499 id=zuludungeon4 cat=dungeon Zulu Dungeon 4
+	Area 5124 5231 1284 1387 id=zuludungeon5 cat=dungeon Zulu Dungeon 5
+	Area 5124 5371 1412 1515 id=zuludungeon6 cat=dungeon Zulu Dungeon 6
+	Area 6068 6139 1276 1335 id=colorwars cat=dungeon Color Wars
+	Area 6032 6131 1336 1407 id=colorwars2 cat=dungeon Color Wars
+	Area 6024 6127 1424 1511 id=britainsewers cat=dungeon Britain Sewers
+	Area 2100 2211 3880 4019 id=evilspellbookisland cat=dungeon Evil Spellbook Island
+	Area 5664 5891 128 259 id=icedungeon cat=dungeon Ice Dungeon
+	Area 5652 5711 300 339 id=icedungeonlevel cat=dungeon Ice Dungeon Level 2
+	Area 5800 5863 320 387 id=icedungeonfort cat=dungeon Ice Dungeon Fort
+	Area 5120 5235 520 643 id=deceitlevel cat=dungeon Deceit Level 1
+	Area 5272 5355 520 643 id=deceitlevel2 cat=dungeon Deceit Level 2
+	Area 5120 5235 644 771 id=deceitlevel3 cat=dungeon Deceit Level 3
+	Area 5236 5355 644 771 id=deceitlevel4 cat=dungeon Deceit Level 4
+	Area 5616 5627 1424 1443 id=firedungeon cat=dungeon Fire Dungeon
+	Area 5628 5879 1280 1523 id=firedungeon2 cat=dungeon Fire Dungeon
+	Area 6632 6699 72 199 id=firedungeonmine cat=dungeon Fire Dungeon Mine
+	Area 6200 6571 320 671 id=scourgeoutlands cat=dungeon Scourge Outlands
+	Area 6432 6563 824 983 id=blightedgrove cat=dungeon Blighted Grove
+	Area 6456 6615 0 259 id=gemstonecave cat=dungeon Gemstone Cave
+	Area 5120 5371 0 251 id=wind cat=dungeon Wind
+	Area 6240 6319 852 915 id=brigandstronghold cat=dungeon Brigand Stronghold
+	Area 932 1027 680 839 id=shadowlordsstronghold cat=dungeon Shadowlords Stronghold
+	Area 6144 6399 0 255 id=sanctuary cat=dungeon Sanctuary
 
 	//Britannia Points of Interest
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 616 655 1472 1503 id=orcfort Orc Fort
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1404 1431 2092 2115 id=britaincrossroads Britain Crossroads
-	// Contains: Shrine of Valor | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2376 2551 3868 4051 id=valorisland Valor Island
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2300 2411 3368 3547 id=ruinsisland Ruins Island
-	// Contains: Zeddicus Zorander's Altar | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2432 2559 3532 3667 id=arcaneisle Arcane Isle
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1028 1135 3080 3227 id=destardisle Destard Isle
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1080 1271 2768 3055 id=destardswamp Destard Swamp
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1648 1703 2440 2503 id=trinsiccrossroads Trinsic Crossroads
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1796 2127 2236 2463 id=bogofdesolation Bog of Desolation
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6740 6783 68 151 id=unusedbasement Unused Basement
-	// Contains: Shrine of Compassion | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1816 2035 804 887 id=desertofcompassion Desert of Compassion
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1816 1947 888 975 id=desertofcompassion2 Desert of Compassion
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1948 1999 888 919 id=desertofcompassion3 Desert of Compassion
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1948 1971 920 955 id=desertofcompassion4 Desert of Compassion
-	// Contains: - | Inside: Green Acres 1, Whole World | Partially overlaps: -
-	Area 6080 6143 592 643 id=racestartingroom Race Starting Room
-	// Contains: - | Inside: Green Acres 1, Whole World | Partially overlaps: -
-	Area 5912 6143 908 999 id=housedisplayarea House Display Area
-	// Contains: - | Inside: Green Acres 2, Whole World | Partially overlaps: -
-	Area 5752 5875 1092 1239 id=developerskeep Developers Keep
-	// Contains: - | Inside: Green Acres 1, Whole World | Partially overlaps: -
-	Area 6040 6103 1092 1239 id=developershouse Developers House
-	// Contains: - | Inside: Whole World | Partially overlaps: Green Acres 1, Green Acres 2
-	Area 5876 6039 1092 1239 id=developerscastle Developers Castle
-	// Contains: - | Inside: Green Acres 4, Whole World | Partially overlaps: -
-	Area 5436 5483 1572 1627 id=weddingchapel Wedding Chapel
-	// Contains: - | Inside: Green Acres 4, Whole World | Partially overlaps: -
-	Area 5488 5547 1632 1695 id=zulusarena Zulu's Arena
-	// Contains: - | Inside: Green Acres 1, Whole World | Partially overlaps: -
-	Area 5996 6055 696 755 id=greyroom Grey Room
-	// Contains: - | Inside: Green Acres 2, Whole World | Partially overlaps: -
-	Area 5376 5471 1044 1127 id=staffhome Staff Home
-	// Contains: - | Inside: Green Acres 1, Whole World | Partially overlaps: -
-	Area 6008 6091 828 907 id=vendormarket Vendor Market 1
-	// Contains: - | Inside: Green Acres 1, Whole World | Partially overlaps: -
-	Area 5912 5987 828 907 id=vendormarket2 Vendor Market 2
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5132 5203 1172 1207 id=hairshop Hair Shop
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5268 5315 1156 1195 id=jail Jail
-	// Contains: Hythloth Entrance, Shrine of Humility, Fire Temple | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 4100 4863 3068 3987 id=fireisland Fire Island
-	// Contains: North Jhelom Farmlands | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 1040 1231 3356 3711 id=northjhelomisland North Jhelom Island
-	// Contains: Moonglow Graveyard, Moonglow, Moonglow Keep, Moonglow Zoo | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 4240 4747 780 1531 id=moonglowisland Moonglow Island
-	// Contains: Deceit Entrance, Shrine of Honesty | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 3848 4307 164 771 id=iceisle Ice Isle
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2304 2631 784 955 id=coveteousmountains Coveteous Mountains
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2200 2219 1244 1275 id=covemine Cove Mine
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2136 2227 1308 1427 id=coveorcfort Cove Orc Fort
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 3332 3371 536 603 id=vesperoutlands Vesper Outlands
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2576 2591 1108 1131 id=ruinedaltar Ruined Altar
-	// Contains: Occlo | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 3332 3815 2352 2931 id=occloisle Occlo Isle
-	// Contains: Magincia | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 3520 3819 2012 2307 id=maginciaisle Magincia Isle
-	// Contains: Buccaneer's Den | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2568 2999 1928 2371 id=buccaneersdenisle Buccaneer's Den Isle
-	// Contains: Fire Dungeon Entrance, Serpents Hold | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 2760 3079 3324 3643 id=serpentsholdisle Serpents Hold Isle
-	// Contains: - | Inside: Britannia, Whole World | Partially overlaps: -
-	Area 424 511 2004 2131 id=skarabraeisle Skara Brae Isle
+	Area 616 655 1472 1503 id=orcfort cat=poi Orc Fort
+	Area 1404 1431 2092 2115 id=britaincrossroads cat=poi Britain Crossroads
+	Area 2376 2551 3868 4051 id=valorisland cat=poi Valor Island
+	Area 2300 2411 3368 3547 id=ruinsisland cat=poi Ruins Island
+	Area 2432 2559 3532 3667 id=arcaneisle cat=poi Arcane Isle
+	Area 1028 1135 3080 3227 id=destardisle cat=poi Destard Isle
+	Area 1080 1271 2768 3055 id=destardswamp cat=poi Destard Swamp
+	Area 1648 1703 2440 2503 id=trinsiccrossroads cat=poi Trinsic Crossroads
+	Area 1796 2127 2236 2463 id=bogofdesolation cat=poi Bog of Desolation
+	Area 6740 6783 68 151 id=unusedbasement cat=poi Unused Basement
+	Area 1816 2035 804 887 id=desertofcompassion cat=poi Desert of Compassion
+	Area 1816 1947 888 975 id=desertofcompassion2 cat=poi Desert of Compassion
+	Area 1948 1999 888 919 id=desertofcompassion3 cat=poi Desert of Compassion
+	Area 1948 1971 920 955 id=desertofcompassion4 cat=poi Desert of Compassion
+	Area 6080 6143 592 643 id=racestartingroom cat=poi Race Starting Room
+	Area 5912 6143 908 999 id=housedisplayarea cat=poi House Display Area
+	Area 5752 5875 1092 1239 id=developerskeep cat=poi Developers Keep
+	Area 6040 6103 1092 1239 id=developershouse cat=poi Developers House
+	Area 5876 6039 1092 1239 id=developerscastle cat=poi Developers Castle
+	Area 5436 5483 1572 1627 id=weddingchapel cat=poi Wedding Chapel
+	Area 5488 5547 1632 1695 id=zulusarena cat=poi Zulu's Arena
+	Area 5996 6055 696 755 id=greyroom cat=poi Grey Room
+	Area 5376 5471 1044 1127 id=staffhome cat=poi Staff Home
+	Area 6008 6091 828 907 id=vendormarket cat=poi Vendor Market 1
+	Area 5912 5987 828 907 id=vendormarket2 cat=poi Vendor Market 2
+	Area 5132 5203 1172 1207 id=hairshop cat=poi Hair Shop
+	Area 5268 5315 1156 1195 id=jail cat=poi Jail
+	Area 4100 4863 3068 3987 id=fireisland cat=poi Fire Island
+	Area 1040 1231 3356 3711 id=northjhelomisland cat=poi North Jhelom Island
+	Area 4240 4747 780 1531 id=moonglowisland cat=poi Moonglow Island
+	Area 3848 4307 164 771 id=iceisle cat=poi Ice Isle
+	Area 2304 2631 784 955 id=coveteousmountains cat=poi Coveteous Mountains
+	Area 2200 2219 1244 1275 id=covemine cat=poi Cove Mine
+	Area 2136 2227 1308 1427 id=coveorcfort cat=poi Cove Orc Fort
+	Area 3332 3371 536 603 id=vesperoutlands cat=poi Vesper Outlands
+	Area 2576 2591 1108 1131 id=ruinedaltar cat=poi Ruined Altar
+	Area 3332 3815 2352 2931 id=occloisle cat=poi Occlo Isle
+	Area 3520 3819 2012 2307 id=maginciaisle cat=poi Magincia Isle
+	Area 2568 2999 1928 2371 id=buccaneersdenisle cat=poi Buccaneer's Den Isle
+	Area 2760 3079 3324 3643 id=serpentsholdisle cat=poi Serpents Hold Isle
+	Area 424 511 2004 2131 id=skarabraeisle cat=poi Skara Brae Isle
 
-
-	//Large Areas
-	// Contains: Race Starting Room, House Display Area, Developers House, Grey Room, Vendor Market 1, Vendor Market 2 | Inside: Whole World | Partially overlaps: Developers Castle
-	Area 5912 6143 512 1267 id=greenacres Green Acres 1
-	// Contains: Developers Keep, Staff Home | Inside: Whole World | Partially overlaps: Developers Castle
-	Area 5376 5911 1044 1267 id=greenacres2 Green Acres 2
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 6052 6143 1536 1723 id=greenacres3 Green Acres 3
-	// Contains: Wedding Chapel, Zulu's Arena | Inside: Whole World | Partially overlaps: -
-	Area 5432 5891 1536 1747 id=greenacres4 Green Acres 4
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5892 6143 1724 1747 id=greenacres5 Green Acres 5
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5432 5619 1748 1775 id=greenacres6 Green Acres 6
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5960 6143 1748 2295 id=greenacres7 Green Acres 7
-	// Contains: - | Inside: Whole World | Partially overlaps: -
-	Area 5124 5959 2064 2295 id=greenacres8 Green Acres 8
-	// Contains: Delucia, Papau | Inside: - | Partially overlaps: Whole World
-	Area 5120 6143 2300 4095 id=lostlands Lost Lands
-	// Contains: Blighted Grove Entrance, Brigand Stronghold Entrance, Coveteous Entrance, Deceit Entrance, Despise Entrance, Destard Entrance, Fire Dungeon Entrance, Gemstone Cave Entrance, Hythloth Entrance, Ice Dungeon Entrance, Orc Cave Entrance, Painted Caves Entrance, Ranger Dungeon Entrance, Sanctuary Entrance, Shame Entrance, Solen Hive Entrance, Terathan Keep Entrance, Wind Entrance, Wind Entrance, Wrong Entrance, Shrine of Humility, Shrine of Valor, Shrine of Honor, Shrine of Spirituality, Shrine of Justice, Shrine of Chaos, Shrine of Compassion, Shrine of Sacrifice, Shrine of Honesty, Britain Graveyard, Vesper Graveyard, Cove Graveyard, Moonglow Graveyard, Yew Graveyard, Jhelom Graveyard, Nujel'm Graveyard, Occlo, Magincia, Buccaneer's Den, Serpents Hold, Trinsic, North Jhelom Farmlands, Jhelom, South Jhelom Island, Skara Brae, Skara Brae Farmlands, Britain, Britain Farmlands, Britain Outer Farmlands, Lord Blackthornes Castle, Lord British Castle, Nujel'm, Empath Abbey, Cove, Minoc, Minoc Farmlands, Minoc Farmlands, Minoc Isle, Moonglow, Moonglow Keep, Vesper, Vesper, Vesper, Vesper, Vesper Outbuildings, Vesper Outbuildings, Yew, Yew Island, Yew Farmlands, Yew Farmlands, Yew Farmlands, Yew Farmlands, Britain Maze, Fire Temple, Evil Spellbook Island, Shadowlords Stronghold, Jhelom Arena, Orc Fort, Britain Crossroads, Valor Island, Ruins Island, Arcane Isle, Destard Isle, Destard Swamp, Trinsic Crossroads, Bog of Desolation, Desert of Compassion, Desert of Compassion, Desert of Compassion, Desert of Compassion, Fire Island, North Jhelom Island, Moonglow Island, Ice Isle, Coveteous Mountains, Moonglow Zoo, Cove Mine, Cove Orc Fort, Vesper Outlands, Ruined Altar, Occlo Isle, Magincia Isle, Buccaneer's Den Isle, Serpents Hold Isle, Skara Brae Isle, Zeddicus Zorander's Altar | Inside: Whole World | Partially overlaps: -
-	Area 0 5119 0 4095 id=britannia Britannia
-	// Contains: Blighted Grove Entrance, Brigand Stronghold Entrance, Coveteous Entrance, Deceit Entrance, Despise Entrance, Destard Entrance, Fire Dungeon Entrance, Gemstone Cave Entrance, Hythloth Entrance, Ice Dungeon Entrance, Orc Cave Entrance, Painted Caves Entrance, Ranger Dungeon Entrance, Sanctuary Entrance, Shame Entrance, Solen Hive Entrance, Terathan Keep Entrance, Wind Entrance, Wind Entrance, Wrong Entrance, Shrine of Humility, Shrine of Valor, Shrine of Honor, Shrine of Spirituality, Shrine of Justice, Shrine of Chaos, Shrine of Compassion, Shrine of Sacrifice, Shrine of Honesty, Britain Graveyard, Vesper Graveyard, Cove Graveyard, Moonglow Graveyard, Yew Graveyard, Jhelom Graveyard, Nujel'm Graveyard, Occlo Mine, Occlo, Magincia, Buccaneer's Den, Serpents Hold, Trinsic, North Jhelom Farmlands, Jhelom, South Jhelom Island, Skara Brae, Skara Brae Farmlands, Elven Town, Britain, Britain Farmlands, Britain Outer Farmlands, Lord Blackthornes Castle, Lord British Castle, Nujel'm, Empath Abbey, Delucia, Papau, Cove, Minoc, Minoc Farmlands, Minoc Farmlands, Minoc Isle, Moonglow, Moonglow Keep, Randorin, Vesper, Vesper, Vesper, Vesper, Vesper Outbuildings, Vesper Outbuildings, Yew, Yew Island, Yew Farmlands, Yew Farmlands, Yew Farmlands, Yew Farmlands, Solen Hive, Painted Caves, Coveteous Level 1, Coveteous Level 1, Coveteous Level 2, Coveteous Level 3, Coveteous Level 4, Coveteous Lake, Terathan Keep, Britain Maze, Mining Caves, Orc Cave Level 1, Orc Cave Level 2, Khaldun Level 1, Khaldun Level 2, Khaldun Level 2, Ranger Dungeon, Ranger Dungeon, Fire Temple, Hythloth Level 1, Hythloth Level 2, Hythloth Level 3, Hythloth Level 4, Despise Gateway, Despise Level 1, Despise Level 2, Despise Level 3, Destard, Wrong Level 1, Wrong Level 2, Wrong Level 3, Wrong Level 4, Newbies Dungeon, Randorin Dungeon, Shame Level 1, Shame Level 2, Shame Level 3, Shame Level 4, Zulu Entrance 1, Zulu Entrance 2, Zulu Entrance 3, Zulu Entrance 4, Zulu Dungeon 1, Zulu Dungeon 2, Zulu Dungeon 3, Zulu Dungeon 4, Zulu Dungeon 5, Zulu Dungeon 6, Color Wars, Color Wars, Britain Sewers, Evil Spellbook Island, Ice Dungeon, Ice Dungeon Level 2, Ice Dungeon Fort, Deceit Level 1, Deceit Level 2, Deceit Level 3, Deceit Level 4, Fire Dungeon, Fire Dungeon, Fire Dungeon Mine, Scourge Outlands, Blighted Grove, Gemstone Cave, Wind, Brigand Stronghold, Shadowlords Stronghold, Sanctuary, Jhelom Arena, Orc Fort, Britain Crossroads, Valor Island, Ruins Island, Arcane Isle, Destard Isle, Destard Swamp, Trinsic Crossroads, Bog of Desolation, Unused Basement, Desert of Compassion, Desert of Compassion, Desert of Compassion, Desert of Compassion, Race Starting Room, House Display Area, Developers Keep, Developers House, Developers Castle, Wedding Chapel, Zulu's Arena, Grey Room, Staff Home, Vendor Market 1, Vendor Market 2, Hair Shop, Jail, Fire Island, Star Room, North Jhelom Island, Moonglow Island, Ice Isle, Coveteous Mountains, Moonglow Zoo, Cove Mine, Cove Orc Fort, Vesper Outlands, Ruined Altar, Occlo Isle, Magincia Isle, Buccaneer's Den Isle, Serpents Hold Isle, Skara Brae Isle, Zeddicus Zorander's Altar, Green Acres 1, Green Acres 2, Green Acres 3, Green Acres 4, Green Acres 5, Green Acres 6, Green Acres 7, Green Acres 8, Britannia | Inside: - | Partially overlaps: Lost Lands
-	Area 0 7167 0 4095 id=feluccawholeworld Felucca Whole World
+	//World Areas
+	Area 5912 6143 512 1267 id=greenacres cat=world Green Acres 1
+	Area 5376 5911 1044 1267 id=greenacres2 cat=world Green Acres 2
+	Area 6052 6143 1536 1723 id=greenacres3 cat=world Green Acres 3
+	Area 5432 5891 1536 1747 id=greenacres4 cat=world Green Acres 4
+	Area 5892 6143 1724 1747 id=greenacres5 cat=world Green Acres 5
+	Area 5432 5619 1748 1775 id=greenacres6 cat=world Green Acres 6
+	Area 5960 6143 1748 2295 id=greenacres7 cat=world Green Acres 7
+	Area 5124 5959 2064 2295 id=greenacres8 cat=world Green Acres 8
+	Area 5120 6143 2300 4095 id=lostlands cat=dungeon Lost Lands
+	Area 0 5119 0 4095 id=zuluterritory cat=world Zulu Territory
+	Area 5120 7167 0 4095 id=zuludungeonterritory cat=world Zulu Dungeon Territory
+	Area 0 7167 0 4095 id=feluccawholeworld cat=world Felucca Whole World
 }
 
 //Britannia_alt
 Areas britannia_alt
 {
 	//Whole Map Areas
-	Area	0 5121 0 4095 id=trammel Trammel
-	Area	5122 7167 0 4095 id=trammeldungeonarea Trammel Dungeon Area
-	Area 0 7167 0 4095 id=trammelwholeworld Trammel Whole World
+	Area	0 5121 0 4095 id=trammel cat=world Trammel
+	Area	5122 7167 0 4095 id=trammeldungeonarea cat=world Trammel Dungeon Area
+	Area 0 7167 0 4095 id=trammelwholeworld cat=world Trammel Whole World
 }
 
 //ilshenar
 Areas ilshenar
 {
-	Area	2226 2301 1522 1597 id=virtuesroom Virtues Room
-	Area	752 926 556 728 id=verlorreg Ver Lor Reg
-	Area	0 2303 0 1599 id=ilshenar Ilshenar
+	Area	2226 2301 1522 1597 id=virtuesroom cat=poi Virtues Room
+	Area	752 926 556 728 id=verlorreg cat=poi Ver Lor Reg
+	Area	0 2303 0 1599 id=ilshenar cat=world Ilshenar
 }
 
 //malas
 Areas malas
 {
-	Area	872 1107 420 652 id=luna Luna
-	Area	1931 2137 1224 1438 id=umbra Umbra
-	Area	0 200 0 712 id=tokunodungeons Tokuno Dungeons
-	Area	511 2559 0 2047 id=malas Malas
+	Area	872 1107 420 652 id=luna cat=city Luna
+	Area	1931 2137 1224 1438 id=umbra cat=city Umbra
+	Area	0 200 0 712 id=tokunodungeons cat=dungeon Tokuno Dungeons
+	Area	511 2559 0 2047 id=malas cat=world Malas
 }
 
 //tokuno
 Areas tokuno
 {
-	Area	620 863 1160 1375 id=zento Zento
-	Area	0 1447 0 1447 id=tokuno Tokuno
+	Area	620 863 1160 1375 id=zento cat=city Zento
+	Area	0 1447 0 1447 id=tokuno cat=world Tokuno
 }
 
 //termur
 Areas termur
 {
-	Area	256 1279 2750 4095 id=termur Ter Mur
+	Area	256 1279 2750 4095 id=termur cat=world Ter Mur
 }
 
 
@@ -508,98 +305,61 @@ Areas termur
 # //	Area	5120	5375	0		255 	Wind
 # //	Area	5120	5375	1536	1791 	Terathan Temple
 	
-# 	// Inside: Justice Hall, Britannia
 # 	Area	588  	675  	796  	899  	Empath Abbey
-# 	// Inside: Britannia | Partially overlaps: Britain
 # 	Area	1296 	1411 	1560 	1699 	Lord British's Castle
-# 	// Inside: Britannia
 # 	Area	1500 	1545 	1400 	1490 	Blackthorn Castle
-# 	// Inside: Britannia | Partially overlaps: Lord British's Castle
 # 	Area	1376 	1715 	1536 	1795 	Britain
-# 	// Contains: Fighting Pit | Inside: Britannia
 # 	Area	1020 	1531 	3340 	4055 	Jhelom
-# 	// Inside: Britannia
 # 	Area	3644 	3839 	2040 	2283 	Magincia
-# 	// Inside: Britannia
 # 	Area	2384 	2547 	364  	627  	Minoc
-# 	// Inside: Britannia
 # 	Area	2548 	2635 	464  	551  	Minoc Isle
-# 	// Inside: Britannia
 # 	Area	4368 	4495 	1020 	1235 	Moonglow
-# 	// Inside: Britannia
 # 	Area	3484 	3819 	1064 	1399 	Nujel'm
-# 	// Contains: Arena | Inside: Dungeons 3
 # 	Area	5488 	5547 	1632 	1695 	Arena Lounge
 # 	// -
 # 	Area	6024 	6075 	844  	891  	Vendor Market 1
 # 	// -
 # 	Area	5920 	5967 	844  	891  	Vendor Market 2
-# 	// Inside: Dungeons 2
 # 	Area	5892 	6019 	1420 	1527 	Ocllo Mine
-# 	// Inside: Britannia
 # 	Area	3332 	3815 	2348 	2927 	Ocllo
-# 	// Inside: Britannia
 # 	Area	2204 	2295 	1112 	1243 	Cove
-# 	// Inside: Britannia
 # 	Area	1792 	2103 	2632 	2899 	Trinsic
-# 	// Inside: Britannia
 # 	Area	2820 	3051 	632  	1015 	Vesper
-# 	// Inside: Dungeons 1
 # 	Area	5630 	5887 	512  	1023 	Wrong
-# 	// Inside: Britannia | Partially overlaps: Justice Hall
 # 	Area	496  	587  	948  	1027 	Yew
-# 	// Inside: Britannia
 # 	Area	532  	695  	2108 	2271 	Skara Brae
-# 	// Inside: Britannia
 # 	Area	2864 	3071 	3332 	3583 	Serpent's Hold
-# 	// Inside: Britannia
 # 	Area	2592 	2783 	2080 	2271 	Buccaneer's Den
-# 	// Partially overlaps: Whole World
 # 	Area	6912 	7167 	256  	511  	Elven Town
 # 	// -
 # 	Area	5128 	5211 	1160 	1215 	Hair Shop
-# 	// Inside: Dungeons 3
 # 	Area	5130 	5153 	1761 	1775 	Star Room
-# 	// Inside: Dungeons 3 | Partially overlaps: Mini Caves
 # 	Area	5120 	5375 	1792 	2047 	Underground Caves
-# 	// Inside: Britannia
 # 	Area	1469 	1488 	747  	758  	PvP stone area
 # 	// -
 # 	Area	5268 	5315 	1156 	1195 	Jail
 # 	// -
 # 	Area	6144 	6398 	0    	254  	Raided Town
-# 	// Partially overlaps: Underground Caves, Dungeons 3
 # 	Area	5121 	5368 	1810 	2061 	Mini Caves
-# 	// Partially overlaps: Dungeons 3
 # 	Area	5633 	5947 	1762 	2047 	Solen Hive
 # 	// -
 # 	Area	6456 	6707 	12   	247  	Gemstone Cave
-# 	// Inside: Arena Lounge, Dungeons 3
 # 	Area	5494 	5541 	1641 	1688 	Arena
 # 	// -
 # 	Area	6013 	6039 	713  	739  	Gate Room
 # 	// -
 # 	Area	6097 	6123 	607  	625  	Race Room
-# 	// Inside: Britannia
 # 	Area	2365 	2564 	3855 	4052 	Evil Spellbook Island
-# 	// Inside: Britannia
 # 	Area	2418 	2573 	3534 	3671 	T2A Island
-# 	// Inside: Dungeons 3
 # 	Area	5443 	5475 	1581 	1621 	Wedding Chapel
 # 	// -
 # 	Area	5427 	5440 	1082 	1094 	Staff Room
-# 	// Inside: Dungeons 2 | Partially overlaps: Capture the Flag 2
 # 	Area	6030 	6136 	1333 	1412 	Capture the Flag 1
-# 	// Inside: Dungeons 2 | Partially overlaps: Capture the Flag 1
 # 	Area	6052 	6142 	1280 	1347 	Capture the Flag 2
-# 	// Inside: Britannia
 # 	Area	930  	1025 	681  	836  	Yew Underground
-# 	// Inside: Britannia
 # 	Area	1030 	1257 	2158 	2306 	Brit Maze
 # 	// Area	5380	5631	260		387		Newbie Dungeon
-# 	// Contains: Randorin Arena
 # 	Area	5128 	5375 	256  	511  	Randorin
-# 	// Partially overlaps: Dungeons 4
 # 	Area	5376 	5631 	256  	511  	No-PvP Dungeon
 # 	// -
 # 	Area	5912 	6143 	908  	1067 	Exhibit Area
@@ -612,29 +372,18 @@ Areas termur
 # 	//Area	5392	5631	1536	1775 	Green Acres 5
 # 	//Area	5120	5631	2048	2203 	Green Acres 6
 # 	//Area	5632	6142	1536	2203 	Green Acres 7
-# 	// Contains: Wrong
 # 	Area	5120 	5903 	512  	1043 	Dungeons 1
-# 	// Contains: Ocllo Mine, Capture the Flag 1, Capture the Flag 2
 # 	Area	5120 	6143 	1268 	1531 	Dungeons 2
-# 	// Contains: Arena Lounge, Star Room, Underground Caves, Arena, Wedding Chapel | Partially overlaps: Mini Caves, Solen Hive
 # 	Area	5120 	5635 	1532 	2047 	Dungeons 3
-# 	// Partially overlaps: No-PvP Dungeon
 # 	Area	5628 	6143 	256  	511  	Dungeons 4
 # 	// -
 # 	Area	5120 	6143 	0    	255  	Dungeons 5
-# 	// Inside: Britannia
 # 	Area	4248	4343	876		1019	Moonglow Keep
-# 	// Contains: Britain, Empath Abbey, Lord British's Castle, Blackthorn Castle, Jhelom, Magincia, Minoc, Minoc Isle, Moonglow, Nujel'm, Ocllo, Cove, Trinsic, Vesper, Yew, Skara Brae, Serpent's Hold, Buccaneer's Den, PvP Stone Area, Evil Spellbook Island, T2A Island, Yew Underground, Brit Maze, Justice Hall, Fighting Pit
 # 	Area	0    	5119 	0    	4094 	Britannia
-# 	// Inside: Lost Lands
 # 	Area	5632 	5843 	3092 	3319 	Papua
-# 	// Inside: Lost Lands
 # 	Area	5128 	5315 	3928 	4087 	Delucia
-# 	// Contains: Papua, Delucia
 # 	Area	5120 	6142 	2303 	4094 	Lost Lands
-# 	// Contains: all areas | Partially overlaps: Elven Town
 # 	Area	0    	7167 	0    	4094 	Whole World
-# 	// Contains: Empath Abbey | Inside: Britannia | Partially overlaps: Yew
 # 	Area	185  	690  	400  	955  	Justice Hall
 # }
 
@@ -642,10 +391,8 @@ Areas termur
 # Areas 2
 # {
 # 	// Jelhom Fighting Pit
-# 	// Inside: Jhelom, Britannia
 # 	Area	1376 	1423 	3728 	3759 	Fighting Pit
 
 # 	// RPer town Arena
-# 	// Inside: Randorin
 # 	Area	5270 	5291 	450  	461  	Randorin Arena
 # }

--- a/pkg/opt/areas/callguards.src
+++ b/pkg/opt/areas/callguards.src
@@ -54,8 +54,8 @@ function LookAround( who )
 			endif
 							
 			elem := FindConfigElem( npc_cfg, mobile.npctemplate );
-			if( !elem.guardignore && !GetObjProperty(mobile,"guardignore") and !wfh)					
-				if( IsInGuardedArea(mobile) && (mobile.script != "tamed" || crimMaster) )
+			if( !elem.guardignore && !GetObjProperty(mobile,"guardignore") and !wfh)
+				if( IsInGuardedArea(mobile) && !IsInNoDamageZone(mobile) && (mobile.script != "tamed" || crimMaster) )
 					set_critical(1);
 					guard := CreateNpcFromTemplate( "guard", mobile.x, mobile.y, mobile.z, 0, who.realm );
 					if( guard )
@@ -69,7 +69,7 @@ function LookAround( who )
 			endif
 		elseif( !mobile.cmdlevel )
 			if( mobile.criminal || mobile.murderer )
-				if( IsInGuardedArea(mobile))
+				if( IsInGuardedArea(mobile) && !IsInNoDamageZone(mobile) )
 					set_critical(1);
 					guard := CreateNpcFromTemplate( "guard", mobile.x, mobile.y, mobile.z, 0, mobile.realm );
 					if( guard )

--- a/pkg/opt/areas/include/areafunctions.inc
+++ b/pkg/opt/areas/include/areafunctions.inc
@@ -1,6 +1,8 @@
 use uo;
 use polsys;
 
+include ":housing:utility";
+
 ///////////////////////////////////////////////////////////////////////////////////////
 // Toadstool
 //
@@ -78,4 +80,110 @@ endfunction
 
 function RemoveNOPK(who)
 	EraseObjProperty(who, "NOPKAREA");
+endfunction
+
+///////////////////////////////////////////////////////////////////////////////////////
+// Omega
+//
+// SetNoDamageZoneProperties()/RemoveNoDamageZoneProperties() - No Damage Zone doesn't
+// grant invul like Safe Area does. Combat is blocked from ever starting (packethook,
+// Fight(), damage-calc backstops), so there's nothing for invul to protect against -
+// this property just flags "who is currently standing in one" for those hot-path checks.
+//
+///////////////////////////////////////////////////////////////////////////////////////
+function SetNoDamageZoneProperties(who)
+	if (who.cmdlevel)
+		return 0;
+	endif
+	SetObjProperty(who, "InNoDamageZone", 1);
+endfunction
+
+function RemoveNoDamageZoneProperties(who)
+	EraseObjProperty(who, "InNoDamageZone");
+endfunction
+
+///////////////////////////////////////////////////////////////////////////////////////
+// Omega
+//
+// StoreDonatorMountForNoDamageZone() - Same net effect as manually using a mount
+// stone (see pkg/opt/vanityshop/mountstone.src StoreMount()), but driven off the
+// live mount NPC directly rather than the rider+stone-item pair that command
+// expects, since our callers (Fight(), tamed.src, dismount.inc) only ever have the
+// mount mobile in hand.
+//
+///////////////////////////////////////////////////////////////////////////////////////
+function StoreDonatorMountForNoDamageZone(mount)
+	if (!mount)
+		return 0;
+	endif
+
+	var stone_serial := GetObjProperty(mount, "DMountStoneSerial");
+	var stone := SystemFindObjectBySerial(stone_serial);
+	if (!stone)
+		return 0;
+	endif
+
+	PlayStationaryEffectEX(mount.x, mount.y, mount.z, mount.realm, 0x3728, 0xa, 0xa, mount.color, 4);
+	MoveObjectToLocation(mount, 5288, 1176, 0, "britannia", MOVEOBJECT_FORCELOCATION);
+
+	SetObjProperty(stone, "MountHP", mount.hp);
+	SetObjProperty(stone, "MountMana", mount.mana);
+	SetObjProperty(stone, "MountStamina", mount.stamina);
+	SetObjProperty(stone, "petname", mount.name);
+	SetObjProperty(stone, "MountStored", 1);
+	SetObjProperty(mount, "guardkill", 1);
+	ApplyRawDamage(mount, CInt(GetHP(mount) + 3));
+
+	var rider_serial := CInt(GetObjProperty(mount, "master"));
+	var rider := SystemFindObjectBySerial(rider_serial);
+	if (rider)
+		EraseObjProperty(rider, "DonatorMounted");
+	endif
+
+	return 1;
+endfunction
+
+///////////////////////////////////////////////////////////////////////////////////////
+// Omega
+//
+// ConfiscateTamedPetForNoDamageZone() - Shared confiscation helper for a tamed pet
+// ordered to attack a defender inside a No Damage Zone from outside it: donator
+// mounts get stored to their stone (non-destructive, recoverable normally);
+// everything else gets ticketed to its master the same way
+// ConfiscatePetForRestrictedRelease() (scripts/ai/tamed.src) already does for
+// NOPK/Guarded/Safe release restrictions, then removed via KillConfiscatedPet().
+// Called from scripts/ai/combat/fight.inc's Fight() and tamed.src's own Fight().
+//
+// Deliberately NOT triggered just by a pet being present/released/dismounted in
+// the zone - zoo owners need to be able to walk pets in and .release/GoWild them
+// to populate the exhibit. Once released they can't target or attack anyone
+// (blocked the same way everything else in the zone is), so they're harmless
+// left alone; only an explicit outside-in attack order gets punished.
+//
+///////////////////////////////////////////////////////////////////////////////////////
+function ConfiscateTamedPetForNoDamageZone(pet)
+	if (!pet)
+		return 0;
+	endif
+
+	if (GetObjProperty(pet, "DonatorMount"))
+		return StoreDonatorMountForNoDamageZone(pet);
+	endif
+
+	var master_serial := CInt(GetObjProperty(pet, "master"));
+	var master := SystemFindObjectBySerial(master_serial);
+	if (!master)
+		master := SystemFindObjectBySerial(master_serial, SYSFIND_SEARCH_OFFLINE_MOBILES);
+	endif
+
+	if (master)
+		var ticket := CreateItemInBackpack(master, CONFISCATION_TICKET_OBJTYPE, 1);
+		if (ticket)
+			PopulateConfiscatedPetTicket(ticket, master.serial, pet);
+			SendSysMessage(master, "Your pet " + pet.name + " has been confiscated (No Damage Zone).", 3, 2595);
+		endif
+	endif
+
+	KillConfiscatedPet(pet);
+	return 1;
 endfunction

--- a/pkg/opt/areas/include/areapolicy.inc
+++ b/pkg/opt/areas/include/areapolicy.inc
@@ -22,6 +22,7 @@ const AREA_POLICY_NO_LOOTING := 64;
 const AREA_POLICY_SAFE_AREA := 128;
 const AREA_POLICY_NO_PK := 256;
 const AREA_POLICY_RP_AREA := 512;
+const AREA_POLICY_NO_DAMAGE_ZONE := 1024;
 
 // World-catchall area ids whose masks are OR-merged into every location's
 // policy so that setting a flag on e.g. "feluccawholeworld" makes it apply to
@@ -47,9 +48,22 @@ function ParseAreaLine(area_line, area_index := 0)
 		return error{"errortext":="Missing id= in area definition: " + CStr(area_line)};
 	endif
 
+	// Optional cat=<category> token right after id=, used only to group areas
+	// for display in the .areas admin gump. Absent on any line, it defaults to
+	// "other" and has no effect on policy resolution (file order still wins).
+	var category := "other";
+	var name_start := 6;
+	if(parts.size() >= 6)
+		var cat_token := ParseAreaCatToken(parts[6]);
+		if(cat_token)
+			category := cat_token;
+			name_start := 7;
+		endif
+	endif
+
 	var name := "";
 	var i;
-	for(i := 6; i <= parts.size(); i := i + 1)
+	for(i := name_start; i <= parts.size(); i := i + 1)
 		if(name)
 			name := name + " ";
 		endif
@@ -66,6 +80,7 @@ function ParseAreaLine(area_line, area_index := 0)
 	info.+min_y := CInt(parts[3]);
 	info.+max_y := CInt(parts[4]);
 	info.+area_id := area_id;
+	info.+category := category;
 	info.+name := name;
 	info.+area_index := CInt(area_index);
 	return info;
@@ -83,6 +98,20 @@ function ParseAreaIdToken(token)
 
 	var raw_id := SubStr(raw, 4, Len(raw));
 	return NormalizeAreaId(raw_id);
+endfunction
+
+
+function ParseAreaCatToken(token)
+	var raw := CStr(token);
+	if(Len(raw) < 5)
+		return "";
+	endif
+	if(Lower(SubStr(raw, 1, 4)) != "cat=")
+		return "";
+	endif
+
+	var raw_cat := SubStr(raw, 5, Len(raw));
+	return NormalizeAreaId(raw_cat);
 endfunction
 
 

--- a/pkg/opt/areas/textcmd/admin/areas.src
+++ b/pkg/opt/areas/textcmd/admin/areas.src
@@ -22,6 +22,7 @@ include "include/constants/propids";
 
 var areas_cfg := 0;
 var areas := {};
+var display_order := {};
 var AREA_POLICY_EDITOR_REALM := "";
 
 var guarded := {};
@@ -34,13 +35,25 @@ var nolooting := {};
 var safearea := {};
 var nopk := {};
 var rparea := {};
+var nodamagezone := {};
 
-const AREAS_PER_PAGE := 11;
+const AREAS_PER_PAGE := 15;
+const ROW_HEIGHT := 25;
 const BTN_PREV_PAGE := 90001;
 const BTN_NEXT_PAGE := 90002;
 const BTN_SAVE_CONFIG := 90003;
 const BTN_CANCEL_CONFIG := 90004;
+const BTN_SHOW_INFO := 90005;
+const BTN_GOTO_PAGE := 90006;
+const BTN_CLOSE_INFO := 90007;
+const TXT_ID_PAGE_JUMP := 95000;
 var FACET_REALM_OPTIONS := {"britannia", "britannia_alt", "ilshenar", "malas", "tokuno", "termur"};
+
+// Display-only grouping for the admin gump. This never touches areas.cfg's
+// file order, which is what ResolveAreaKeyAtLocation()/ResolveAreaMatchAtLocation()
+// in areapolicy.inc walk (first bounding-box match wins) - reordering that would
+// change which policy applies at overlapping coordinates server-wide.
+var CATEGORY_ORDER := {"world", "city", "dungeon", "poi", "graveyard", "shrine", "entrance"};
 
 set_script_option(SCRIPTOPT_NO_RUNAWAY,1);
 
@@ -89,6 +102,7 @@ Program areas(who, text)
 
 	LoadAreaFlagArrays();
 	EnsureAreaFlagArrays();
+	display_order := BuildCategoryDisplayOrder();
 
 	var totalpages := CInt(((areas.size() - 1) / AREAS_PER_PAGE)) + 1;
 	if (totalpages < 1)
@@ -127,6 +141,18 @@ Program areas(who, text)
 			if (page > 1)
 				page := page - 1;
 			endif
+			continue;
+		elseif (btn == BTN_SHOW_INFO)
+			ShowAreaInfoGump(who);
+			continue;
+		elseif (btn == BTN_GOTO_PAGE)
+			var requested := CInt(GFExtractData(result, TXT_ID_PAGE_JUMP));
+			if (requested < 1)
+				requested := 1;
+			elseif (requested > totalpages)
+				requested := totalpages;
+			endif
+			page := requested;
 			continue;
 		elseif (btn > 1 and btn < 7)
 			SendSysMessage(who, "These options are not yet supported.");
@@ -181,102 +207,244 @@ endfunction
 
 ////////////////////////////////////////////////////////////////////////////////////
 //
+// BuildCategoryDisplayOrder() - Groups areas[] by their cat= tag for gump
+// display, in CATEGORY_ORDER order. Returns an array of original areas[]
+// indices - areas.cfg itself is never reordered, so policy-resolution
+// precedence (first bounding-box match wins) is unaffected.
+//
+////////////////////////////////////////////////////////////////////////////////////
+function BuildCategoryDisplayOrder()
+	var buckets := dictionary;
+	var i;
+	for(i := 1; i <= areas.size(); i := i + 1)
+		var area_info := ParseAreaLine(areas[i], i);
+		var cat := "other";
+		if(area_info != error && area_info.category)
+			cat := area_info.category;
+		endif
+		if(!buckets.Exists(cat))
+			buckets[cat] := array{};
+		endif
+		buckets[cat].append(i);
+	endfor
+
+	var order := array{};
+	var cat_name;
+	foreach cat_name in CATEGORY_ORDER
+		if(buckets.Exists(cat_name))
+			var cat_bucket := buckets[cat_name];
+			AppendSortedBucket(order, cat_bucket, cat_name);
+		endif
+	endforeach
+
+	// Anything not in CATEGORY_ORDER (shouldn't happen now that every areas.cfg
+	// line is tagged, but stay defensive for future untagged additions) goes
+	// last, alphabetical like everything else.
+	var bucket_keys := buckets.Keys();
+	var leftover_cat;
+	foreach leftover_cat in bucket_keys
+		if(!(leftover_cat in CATEGORY_ORDER))
+			var leftover_bucket := buckets[leftover_cat];
+			AppendSortedBucket(order, leftover_bucket, leftover_cat);
+		endif
+	endforeach
+
+	return order;
+endfunction
+
+////////////////////////////////////////////////////////////////////////////////////
+//
+// AppendSortedBucket() - Sorts one category's original-index bucket and appends
+// it to order[]. World gets the fixed Whole World / Zulu Territory / Zulu
+// Dungeon Territory / Green Acres sequence (regions.cfg's own display order);
+// everything else (and anything left in World after that) sorts alphabetically
+// by area name. Uses the "sortkey|||payload" + .sort() idiom already used in
+// omegacache.inc, since eScript's struct-based sort doesn't work reliably.
+//
+////////////////////////////////////////////////////////////////////////////////////
+function AppendSortedBucket(byref order, bucket, cat_name)
+	var sort_pairs := array{};
+	var idx;
+	foreach idx in bucket
+		var sort_key := BuildAreaSortKey(idx, cat_name);
+		sort_pairs.append(sort_key + "|||" + CStr(idx));
+	endforeach
+	sort_pairs.sort();
+
+	var pair;
+	foreach pair in sort_pairs
+		var sep := Find(pair, "|||", 1);
+		order.append(CInt(pair[sep + 3, Len(pair)]));
+	endforeach
+	return 1;
+endfunction
+
+////////////////////////////////////////////////////////////////////////////////////
+//
+// BuildAreaSortKey() - Sort key for one area within its category display
+// bucket. World gets a manual rank prefix (0-4) so Whole World / Zulu
+// Territory / Zulu Dungeon Territory / Green Acres always lead in that order,
+// then falls back to alphabetical - same as every other category.
+//
+////////////////////////////////////////////////////////////////////////////////////
+function BuildAreaSortKey(idx, cat_name)
+	var area := areas[idx];
+	var name := Lower(GetAreaName(area));
+
+	if(cat_name != "world")
+		return name;
+	endif
+
+	var area_info := ParseAreaLine(area, idx);
+	var area_id := "";
+	if(area_info != error)
+		area_id := CStr(area_info.area_id);
+	endif
+
+	var rank := 4;
+	if(Len(area_id) >= 10 && Lower(SubStr(area_id, Len(area_id) - 9, 10)) == "wholeworld")
+		rank := 0;
+	elseif(area_id == "zuluterritory")
+		rank := 1;
+	elseif(area_id == "zuludungeonterritory")
+		rank := 2;
+	elseif(Len(area_id) >= 10 && Lower(SubStr(area_id, 1, 10)) == "greenacres")
+		rank := 3;
+	endif
+
+	return CStr(rank) + "_" + name;
+endfunction
+
+////////////////////////////////////////////////////////////////////////////////////
+//
 // BuildAreasPageGump() - Draws a single page of the areas gump.
 //
 ////////////////////////////////////////////////////////////////////////////////////
 function BuildAreasPageGump(page, totalpages)
-	var gump := GFCreateGump(20, 20, 860, 520);
+	var gump := GFCreateGump(20, 20, 860, 590);
 
 	// The main gump screen
-	GFResizePic(gump, 20, 20, 9250, 860, 525);
+	GFResizePic(gump, 20, 20, 9250, 860, 595);
 
-	// The area background gumps
-	GFResizePic(gump, 35, 220, 9200, 830, 285);
-	GFResizePic(gump, 35, 180, 9200, 830, 40);
+	// Header bar - full width, like the column-header bar below it, instead of
+	// the old narrow title box. Facet on the left, title centered, both green.
+	GFResizePic(gump, 35, 35, 9200, 830, 40);
+	GFTextLine(gump, 50, 48, 67, "Facet: " + CStr(AREA_POLICY_EDITOR_REALM));
+	GFTextMid(gump, 35, 48, 830, 67, "AREA SET-UP");
 
-	// Title text
-	GFResizePic(gump, 175, 35, 9200, 100, 20);
-	GFTextLine(gump, 180, 35, 67, "AREA SET-UP");
-	GFTextLine(gump, 300, 35, 1000, "Facet: " + CStr(AREA_POLICY_EDITOR_REALM));
-
-	// Action buttons
-	GFAddButton(gump, 60, 78, 4005, 4006, GF_CLOSE_BTN, BTN_SAVE_CONFIG);
-	GFTextLine(gump, 110, 82, 57, "Save Areas Config");
-	GFAddButton(gump, 60, 118, 4005, 4006, GF_CLOSE_BTN, BTN_CANCEL_CONFIG);
-	GFTextLine(gump, 110, 122, 57, "Cancel");
-
-	// HTML gump
-	GFHTMLArea(gump, 405, 35, 390, 140, GetHelpString(), 1, 1);
-
-	// Names for all the options
-	GFTextLine(gump, 96, 185, 900, "Area");
-	GFTextLine(gump, 95, 200, 900, "Name");
-
-	GFTextLine(gump, 190, 185, 900, "Guarded");
-	GFTextLine(gump, 195, 200, 900, "Area");
-
-	GFTextLine(gump, 260, 185, 900, "Disabled");
-	GFTextLine(gump, 255, 200, 900, "Recall To");
-
-	GFTextLine(gump, 330, 185, 900, "Disabled");
-	GFTextLine(gump, 320, 200, 900, "Recall From");
-
-	GFTextLine(gump, 400, 185, 900, "Disabled");
-	GFTextLine(gump, 400, 200, 900, "Marking");
-
-	GFTextLine(gump, 467, 185, 900, "Disabled");
-	GFTextLine(gump, 475, 200, 900, "Magic");
-
-	GFTextLine(gump, 535, 185, 900, "Forbidden");
-	GFTextLine(gump, 545, 200, 900, "Area");
-
-	GFTextLine(gump, 610, 185, 900, "Disabled");
-	GFTextLine(gump, 612, 200, 900, "Looting");
-
-	GFTextLine(gump, 685, 185, 900, "Safe");
-	GFTextLine(gump, 685, 200, 900, "Area");
-
-	GFTextLine(gump, 760, 185, 900, "No-PK");
-	GFTextLine(gump, 760, 200, 900, "Area");
-
-	GFTextLine(gump, 830, 185, 900, "RP");
-	GFTextLine(gump, 830, 200, 900, "Area");
-
-	// Block of text that displays current area info
-	var y := 230;
-	var start_idx := ((page - 1) * AREAS_PER_PAGE) + 1;
-	var end_idx := start_idx + AREAS_PER_PAGE - 1;
-	if (end_idx > areas.size())
-		end_idx := areas.size();
-	endif
-
-	var i;
-	for (i := start_idx; i <= end_idx; i := i + 1)
-		var retval := i * 10;
-		var area := areas[i];
-
-		GFTextLine(gump, 35, y, 0, GetAreaName(area));
-		GFCheckBox(gump, 200, y, 9026, 9027, guarded[i], retval + 1);
-		GFCheckBox(gump, 270, y, 9026, 9027, norecallto[i], retval + 2);
-		GFCheckBox(gump, 340, y, 9026, 9027, norecallfrom[i], retval + 3);
-		GFCheckBox(gump, 410, y, 9026, 9027, disabledmarking[i], retval + 4);
-		GFCheckBox(gump, 480, y, 9026, 9027, disablemagic[i], retval + 5);
-		GFCheckBox(gump, 550, y, 9026, 9027, forbiddenarea[i], retval + 6);
-		GFCheckBox(gump, 620, y, 9026, 9027, nolooting[i], retval + 7);
-		GFCheckBox(gump, 690, y, 9026, 9027, safearea[i], retval + 8);
-		GFCheckBox(gump, 760, y, 9026, 9027, nopk[i], retval + 9);
-		GFCheckBox(gump, 830, y, 9026, 9027, rparea[i], retval + 10);
-		y := y + 25;
+	// Action buttons - evenly spaced across the header width instead of a
+	// fixed left-hugging row. The explanation box moved to its own popup gump
+	// (Area Info button).
+	var action_labels := {"Save Areas Config", "Cancel", "Area Info / Help"};
+	var action_btns := {BTN_SAVE_CONFIG, BTN_CANCEL_CONFIG, BTN_SHOW_INFO};
+	var action_icon_w := 30;
+	var action_slot_w := CInt(830 / 3);
+	var a;
+	for(a := 1; a <= 3; a := a + 1)
+		var slot_center := 35 + ((a - 1) * action_slot_w) + CInt(action_slot_w / 2);
+		var label_w := GFTextWidth(CStr(action_labels[a]));
+		var cluster_x := slot_center - CInt((action_icon_w + 6 + label_w) / 2);
+		GFAddButton(gump, cluster_x, 85, 4005, 4006, GF_CLOSE_BTN, CInt(action_btns[a]));
+		GFTextLine(gump, cluster_x + action_icon_w + 6, 89, 57, CStr(action_labels[a]));
 	endfor
 
-	if (page > 1)
-		GFAddButton(gump, 35, 506, 4014, 4015, 1, BTN_PREV_PAGE);
-	endif
-	if (page < totalpages)
-		GFAddButton(gump, 765, 506, 4005, 4006, 1, BTN_NEXT_PAGE);
+	// The area background gumps. Header bar is 50 tall (not 40) so the 3rd
+	// line of the Recall To/From columns has room to render fully instead of
+	// spilling into the list panel below it.
+	GFResizePic(gump, 35, 180, 9200, 830, (AREAS_PER_PAGE * ROW_HEIGHT) + 15);
+	GFResizePic(gump, 35, 125, 9200, 830, 50);
+
+	// Names for all the options. Recall To/From are 3 lines instead of 2 so
+	// the columns can sit closer together - frees up room for No Damage Zone
+	// (placeholder column, not wired to a policy flag yet).
+	GFTextLine(gump, 96, 130, 900, "Area");
+	GFTextLine(gump, 95, 145, 900, "Name");
+
+	GFTextLine(gump, 195, 130, 900, "Guarded");
+	GFTextLine(gump, 200, 145, 900, "Area");
+
+	GFTextLine(gump, 253, 128, 900, "Disabled");
+	GFTextLine(gump, 255, 140, 900, "Recall");
+	GFTextLine(gump, 263, 152, 900, "To");
+
+	GFTextLine(gump, 311, 128, 900, "Disabled");
+	GFTextLine(gump, 313, 140, 900, "Recall");
+	GFTextLine(gump, 316, 152, 900, "From");
+
+	GFTextLine(gump, 369, 130, 900, "Disabled");
+	GFTextLine(gump, 369, 145, 900, "Marking");
+
+	GFTextLine(gump, 427, 130, 900, "Disabled");
+	GFTextLine(gump, 432, 145, 900, "Magic");
+
+	GFTextLine(gump, 480, 130, 900, "Forbidden");
+	GFTextLine(gump, 490, 145, 900, "Area");
+
+	GFTextLine(gump, 543, 130, 900, "Disabled");
+	GFTextLine(gump, 545, 145, 900, "Looting");
+
+	GFTextLine(gump, 606, 130, 900, "Safe");
+	GFTextLine(gump, 606, 145, 900, "Area");
+
+	GFTextLine(gump, 669, 130, 900, "No-PK");
+	GFTextLine(gump, 669, 145, 900, "Area");
+
+	GFTextLine(gump, 727, 130, 900, "RP");
+	GFTextLine(gump, 727, 145, 900, "Area");
+
+	GFTextLine(gump, 770, 130, 900, "No Damage");
+	GFTextLine(gump, 780, 145, 900, "Zone");
+
+	// Block of text that displays current area info. Paged over display_order
+	// (World -> Cities -> Dungeons -> POI -> Graveyards -> Shrines -> Dungeon
+	// Entrances) rather than areas[] directly, but retval still encodes the
+	// original areas.cfg index so ApplyPageValues() writes the right flags.
+	// retval uses *100 (not *10) so there's headroom for the 11th (and any
+	// future) column without colliding with the next area's field-1 checkbox.
+	var y := 190;
+	var start_idx := ((page - 1) * AREAS_PER_PAGE) + 1;
+	var end_idx := start_idx + AREAS_PER_PAGE - 1;
+	if (end_idx > display_order.size())
+		end_idx := display_order.size();
 	endif
 
-	GFTextLine(gump, 340, 508, 1000, "Page " + page + " of " + totalpages);
+	var pos;
+	for (pos := start_idx; pos <= end_idx; pos := pos + 1)
+		var orig_i := display_order[pos];
+		var retval := orig_i * 100;
+		var area := areas[orig_i];
+
+		GFTextLine(gump, 35, y, 0, GetAreaName(area));
+		GFCheckBox(gump, 205, y, 9026, 9027, guarded[orig_i], retval + 1);
+		GFCheckBox(gump, 263, y, 9026, 9027, norecallto[orig_i], retval + 2);
+		GFCheckBox(gump, 321, y, 9026, 9027, norecallfrom[orig_i], retval + 3);
+		GFCheckBox(gump, 379, y, 9026, 9027, disabledmarking[orig_i], retval + 4);
+		GFCheckBox(gump, 437, y, 9026, 9027, disablemagic[orig_i], retval + 5);
+		GFCheckBox(gump, 495, y, 9026, 9027, forbiddenarea[orig_i], retval + 6);
+		GFCheckBox(gump, 553, y, 9026, 9027, nolooting[orig_i], retval + 7);
+		GFCheckBox(gump, 611, y, 9026, 9027, safearea[orig_i], retval + 8);
+		GFCheckBox(gump, 669, y, 9026, 9027, nopk[orig_i], retval + 9);
+		GFCheckBox(gump, 727, y, 9026, 9027, rparea[orig_i], retval + 10);
+		GFCheckBox(gump, 785, y, 9026, 9027, nodamagezone[orig_i], retval + 11);
+		y := y + ROW_HEIGHT;
+	endfor
+
+	// Bottom row - Prev flush to the left edge, Next flush to the right edge
+	// (mirroring Prev), page count and the jump-to-page control evenly spaced
+	// in the space between them.
+	if (page > 1)
+		GFAddButton(gump, 35, 576, 4014, 4015, 1, BTN_PREV_PAGE);
+	endif
+	if (page < totalpages)
+		GFAddButton(gump, 835, 576, 4005, 4006, 1, BTN_NEXT_PAGE);
+	endif
+
+	GFTextMid(gump, 222, 578, 200, 1000, "Page " + page + " of " + totalpages);
+
+	GFTextLine(gump, 506, 578, 1000, "Go to:");
+	GFTextEntry(gump, 554, 576, 40, 20, 1000, CStr(page), TXT_ID_PAGE_JUMP, 3);
+	GFAddButton(gump, 602, 576, 4005, 4006, GF_CLOSE_BTN, BTN_GOTO_PAGE);
+	GFTextLine(gump, 628, 578, 57, "Go");
 
 	return gump;
 endfunction
@@ -317,6 +485,9 @@ function EnsureAreaFlagArrays()
 	if (!rparea)
 		rparea := {};
 	endif
+	if (!nodamagezone)
+		nodamagezone := {};
+	endif
 
 	var i;
 	for (i := 1; i <= areas.size(); i := i + 1)
@@ -350,6 +521,9 @@ function EnsureAreaFlagArrays()
 		if (rparea.size() < i)
 			rparea.append(0);
 		endif
+		if (nodamagezone.size() < i)
+			nodamagezone.append(0);
+		endif
 	endfor
 endfunction
 
@@ -369,6 +543,7 @@ function LoadAreaFlagArrays()
 	safearea := {};
 	nopk := {};
 	rparea := {};
+	nodamagezone := {};
 
 	var i;
 	for(i := 1; i <= areas.size(); i := i + 1)
@@ -388,6 +563,7 @@ function LoadAreaFlagArrays()
 		safearea[i] := HasPolicy(mask, AREA_POLICY_SAFE_AREA);
 		nopk[i] := HasPolicy(mask, AREA_POLICY_NO_PK);
 		rparea[i] := HasPolicy(mask, AREA_POLICY_RP_AREA);
+		nodamagezone[i] := HasPolicy(mask, AREA_POLICY_NO_DAMAGE_ZONE);
 	endfor
 endfunction
 
@@ -399,39 +575,44 @@ endfunction
 function ApplyPageValues(data, page)
 	var start_idx := ((page - 1) * AREAS_PER_PAGE) + 1;
 	var end_idx := start_idx + AREAS_PER_PAGE - 1;
-	if (end_idx > areas.size())
-		end_idx := areas.size();
+	if (end_idx > display_order.size())
+		end_idx := display_order.size();
 	endif
 
-	var i;
-	for (i := start_idx; i <= end_idx; i := i + 1)
-		guarded[i] := 0;
-		norecallto[i] := 0;
-		norecallfrom[i] := 0;
-		disabledmarking[i] := 0;
-		disablemagic[i] := 0;
-		forbiddenarea[i] := 0;
-		nolooting[i] := 0;
-		safearea[i] := 0;
-		nopk[i] := 0;
-		rparea[i] := 0;
+	var pos;
+	var orig_i;
+	for (pos := start_idx; pos <= end_idx; pos := pos + 1)
+		orig_i := display_order[pos];
+		guarded[orig_i] := 0;
+		norecallto[orig_i] := 0;
+		norecallfrom[orig_i] := 0;
+		disabledmarking[orig_i] := 0;
+		disablemagic[orig_i] := 0;
+		forbiddenarea[orig_i] := 0;
+		nolooting[orig_i] := 0;
+		safearea[orig_i] := 0;
+		nopk[orig_i] := 0;
+		rparea[orig_i] := 0;
+		nodamagezone[orig_i] := 0;
 	endfor
 
 	var val;
 	foreach val in data
-		for (i := start_idx; i <= end_idx; i := i + 1)
-			var mine := (val - (i * 10));
+		for (pos := start_idx; pos <= end_idx; pos := pos + 1)
+			orig_i := display_order[pos];
+			var mine := (val - (orig_i * 100));
 			case(mine)
-			1: guarded[i] := 1;
-			2: norecallto[i] := 1;
-			3: norecallfrom[i] := 1;
-			4: disabledmarking[i] := 1;
-			5: disablemagic[i] := 1;
-			6: forbiddenarea[i] := 1;
-			7: nolooting[i] := 1;
-			8: safearea[i] := 1;
-			9: nopk[i] := 1;
-			10: rparea[i] := 1;
+			1: guarded[orig_i] := 1;
+			2: norecallto[orig_i] := 1;
+			3: norecallfrom[orig_i] := 1;
+			4: disabledmarking[orig_i] := 1;
+			5: disablemagic[orig_i] := 1;
+			6: forbiddenarea[orig_i] := 1;
+			7: nolooting[orig_i] := 1;
+			8: safearea[orig_i] := 1;
+			9: nopk[orig_i] := 1;
+			10: rparea[orig_i] := 1;
+			11: nodamagezone[orig_i] := 1;
 			endcase
 		endfor
 	endforeach
@@ -489,6 +670,9 @@ function SaveAreaFlagArrays(who)
 		if(rparea[i])
 			mask := mask + AREA_POLICY_RP_AREA;
 		endif
+		if(nodamagezone[i])
+			mask := mask + AREA_POLICY_NO_DAMAGE_ZONE;
+		endif
 
 		Print("[areas.save] area=" + CStr(i) + " id=" + CStr(area_info.area_id) + " mask=" + CStr(mask));
 		SetPolicyMask(AREA_POLICY_EDITOR_REALM, area_info.area_id, mask, updated_by);
@@ -531,6 +715,16 @@ function RefreshOnlineAreaStatus()
 		elseif (had_nopk)
 			RemoveNOPK(character);
 		endif
+
+		var in_nodamage := IsInNoDamageZone(character);
+		var had_nodamage := GetObjProperty(character, "InNoDamageZone");
+		if (in_nodamage)
+			if (!had_nodamage)
+				SetNoDamageZoneProperties(character);
+			endif
+		elseif (had_nodamage)
+			RemoveNoDamageZoneProperties(character);
+		endif
 	endforeach
 endfunction
 ////////////////////////////////////////////////////////////////////////////////////
@@ -551,6 +745,9 @@ function GetAreaName(area)
 	if(parts[5] && Lower(SubStr(CStr(parts[5]), 1, 3)) == "id=")
 		start_index := 6;
 	endif
+	if(parts[start_index] && Lower(SubStr(CStr(parts[start_index]), 1, 4)) == "cat=")
+		start_index := start_index + 1;
+	endif
 
 	var i;
 	for(i := start_index; i <= parts.size(); i := i + 1)
@@ -562,6 +759,25 @@ function GetAreaName(area)
 
 	return areaname;
 
+endfunction
+
+////////////////////////////////////////////////////////////////////////////////////
+//
+// ShowAreaInfoGump() - Popup gump holding the explanation text that used to
+// live in an HTML box on the main gump. Blocks until closed, then the caller
+// redisplays the main gump at whatever page/values it had before.
+//
+////////////////////////////////////////////////////////////////////////////////////
+function ShowAreaInfoGump(who)
+	var gump := GFCreateGump(160, 100, 480, 400);
+
+	GFResizePic(gump, 0, 0, 9250, 480, 400);
+	GFHTMLArea(gump, 20, 20, 440, 330, GetHelpString(), 1, 1);
+	GFAddButton(gump, 205, 360, 4005, 4006, GF_CLOSE_BTN, BTN_CLOSE_INFO);
+	GFTextLine(gump, 235, 364, 57, "Close");
+
+	GFSendGump(who, gump);
+	return 1;
 endfunction
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/pkg/opt/omegacache/omegacache.inc
+++ b/pkg/opt/omegacache/omegacache.inc
@@ -1723,11 +1723,22 @@ endfunction
 function RunOmegaCacheGump(who, access)
 	var df := access.df;
 	// Block multiple gump instances
-	if(CInt(GetObjProperty(who, "#omegacache_open")) > ReadGameClock())
-		SendSysMessage(who, "You already have the Omega Cache open.");
-		return;
+	var open_until := CInt(GetObjProperty(who, "#omegacache_open"));
+	var now := ReadGameClock();
+	if(open_until > now)
+		// ReadGameClock() is uptime-based and resets to 0 on server restart, so a
+		// leftover value from before a restart can read as far in the future
+		// relative to the new (small) clock — which would otherwise wedge this
+		// guard open until real uptime caught back up to the stale value. Any
+		// legitimately-set guard is at most 600s ahead of "now"; anything further
+		// out than that can only be stale, so treat it as expired instead.
+		if(open_until <= now + 600)
+			SendSysMessage(who, "You already have the Omega Cache open.");
+			return;
+		endif
+		EraseObjProperty(who, "#omegacache_open");
 	endif
-	SetObjProperty(who, "#omegacache_open", ReadGameClock() + 600);
+	SetObjProperty(who, "#omegacache_open", now + 600);
 
 	var view := "categories";
 	var category_map := dictionary;

--- a/pkg/packethooks/packethook/packethook.src
+++ b/pkg/packethooks/packethook/packethook.src
@@ -221,6 +221,20 @@ exported Function OnTarget( who, byref Packet )
 	var noPKdef := GetObjProperty(obj, "NOPKAREA");
 	var is_casting := GetObjProperty(who , "#Casting");
 	var target_type := packet.GetInt8(6) != 1;
+
+	// No Damage Zone protects the target regardless of PC/NPC, unlike the
+	// NO-PK/Safe checks below which only guard against attacking players.
+	if(!who.cmdlevel && GetObjProperty(obj, "InNoDamageZone") && (!target_type))
+		SendSysMessage(who, "You can't target anything in a no damage zone!", FONT_NORMAL, 2595 );
+		CancelTarget( who );
+		if(is_casting)
+			EraseObjProperty( who , "#Casting" );
+			SetObjProperty( who, "#TargetRejected", 1 );
+			return CORE_OK;
+		endif
+		return CORE_IGNORE;
+	endif
+
 	if((!who.cmdlevel && obj.isa(POLCLASS_MOBILE) && !obj.isa(POLCLASS_NPC) && obj != who) && (noPKatk || noPKdef) && (!target_type))
 		SendSysMessage(who, "You can't target players in a NO-PK zone!", FONT_NORMAL, 2595 );
 		CancelTarget( who );
@@ -253,6 +267,14 @@ Exported Function checkAttack(who, ByRef packet)
 	var DEFisRPer := GetObjProperty(obj, "IsRPer");
 	var noPKatk := GetObjProperty(who, "NOPKAREA");
 	var noPKdef := GetObjProperty(obj, "NOPKAREA");
+
+	// No Damage Zone protects the target regardless of PC/NPC, unlike the
+	// NO-PK/Safe checks below which only guard against attacking players.
+	if(!who.cmdlevel && GetObjProperty(obj, "InNoDamageZone"))
+		SendSysMessage(who, "You can't attack anything in a no damage zone!", FONT_NORMAL, 2595 );
+		return CORE_IGNORE;
+	endif
+
 	if((!who.cmdlevel && obj.isa(POLCLASS_MOBILE) && !obj.isa(POLCLASS_NPC)) && (noPKatk || noPKdef))
 		SendSysMessage(who, "You can't target players in a NO-PK zone!", FONT_NORMAL, 2595 );
 		return CORE_IGNORE;

--- a/pkg/systems/combat/banishonhit.src
+++ b/pkg/systems/combat/banishonhit.src
@@ -15,6 +15,12 @@ program banishonhit( parms )
 	//var basedamage := parms[5];
 	var rawdamage	:= parms[6];
 
+	// No Damage Zone - see blackrockscript.src for why this bypasses the
+	// normal combat-blocking checks and needs its own guard.
+	if (GetObjProperty(attacker, "InNoDamageZone") || GetObjProperty(defender, "InNoDamageZone"))
+		return;
+	endif
+
 	var summoned := GetObjProperty( attacker , "summoned" );
 	var animated := GetObjProperty( attacker , "animated" );
 	var cursed   := GetObjProperty( armor , "Cursed" );

--- a/pkg/systems/combat/banishscript.src
+++ b/pkg/systems/combat/banishscript.src
@@ -17,7 +17,13 @@ program banishscript(attacker, defender, weapon, armor, basedamage, rawdamage)
 			rawdamage	:= attacker[6];
 			attacker 	:= attacker[1];
 		endif
-		
+
+		// No Damage Zone - see blackrockscript.src for why this bypasses
+		// the normal combat-blocking checks and needs its own guard.
+		if (GetObjProperty(attacker, "InNoDamageZone") || GetObjProperty(defender, "InNoDamageZone"))
+			return;
+		endif
+
         var summoned := GetObjProperty( defender, "summoned" );
         var animated := GetObjProperty( defender, "animated" );
         var cursed := GetObjProperty( weapon , "Cursed" );

--- a/pkg/systems/combat/blackrockscript.src
+++ b/pkg/systems/combat/blackrockscript.src
@@ -18,7 +18,16 @@ program blackrockscript(attacker, defender, weapon, armor, basedamage, rawdamage
 			rawdamage	:= attacker[6];
 			attacker 	:= attacker[1];
 		endif
-		
+
+		// No Damage Zone - the summoned/animated branches below apply a
+		// guaranteed-lethal ApplyTheDamage() unconditionally, bypassing the
+		// InSafeArea checks that only exist in the "else" branch. Bail out
+		// entirely (either side) so this weapon's proc has no effect on
+		// anyone connected to a protected zone.
+		if (GetObjProperty(attacker, "InNoDamageZone") || GetObjProperty(defender, "InNoDamageZone"))
+			return;
+		endif
+
         var targ;
         var cursed := GetObjProperty( weapon , "Cursed" );
         rawdamage := RecalcDmg( attacker , defender , weapon , armor , basedamage );

--- a/pkg/systems/combat/config/itemdesc.cfg
+++ b/pkg/systems/combat/config/itemdesc.cfg
@@ -1805,7 +1805,6 @@ Armor 0x8250
 	Name		ShieldofAlryc
 	graphic		0x1B76
 	Desc		 Glowing Heater Shield
-	Coverage	Hands
 	AR		65
 	VendorSellsFor	127300
 	VendorBuysFor	50000
@@ -3315,7 +3314,6 @@ Armor 0x604c
 	Color		0x512
 	Desc		Shield of Wonders
 	AR		15
-	Coverage	Hands
 	MaxHP		150
 	BlocksCastingIfInHand	0
 	equipscript	::skilladvancerequip
@@ -8753,7 +8751,6 @@ Armor 0x76d0
 	Desc		Shield AR5
 	Graphic		0x1B76
 	AR		5
-	Coverage	Hands
 	maxhp		100
 	equipscript	::skilladvancerequip
 	unequipscript	::skilladvancerunequip
@@ -8767,7 +8764,6 @@ Armor 0x76d1
 	Desc		Shield AR10
 	Graphic		0x1B76
 	AR		10
-	Coverage	Hands
 	maxhp		200
 	equipscript	::skilladvancerequip
 	unequipscript	::skilladvancerunequip
@@ -8781,7 +8777,6 @@ Armor 0x76d2
 	Desc		Shield AR15
 	Graphic		0x1B76
 	AR		15
-	Coverage	Hands
 	maxhp		300
 	equipscript	::skilladvancerequip
 	unequipscript	::skilladvancerunequip
@@ -8795,7 +8790,6 @@ Armor 0x76d3
 	Desc		Shield AR20
 	Graphic		0x1B76
 	AR		20
-	Coverage	Hands
 	maxhp		400
 	equipscript	::skilladvancerequip
 	unequipscript	::skilladvancerunequip
@@ -8809,7 +8803,6 @@ Armor 0x76d4
 	Desc		Shield AR25
 	Graphic		0x1B76
 	AR		25
-	Coverage	Hands
 	maxhp		500
 	equipscript	::skilladvancerequip
 	unequipscript	::skilladvancerunequip
@@ -8868,7 +8861,6 @@ Armor 0x76d8
 	Desc		Shield AR30
 	Graphic		0x1B76
 	AR		30
-	Coverage	Hands
 	maxhp		500
 	equipscript	::skilladvancerequip
 	unequipscript	::skilladvancerunequip
@@ -8882,7 +8874,6 @@ Armor 0x76d9
 	Desc		Shield AR35
 	Graphic		0x1B76
 	AR		35
-	Coverage	Hands
 	maxhp		500
 	equipscript	::skilladvancerequip
 	unequipscript	::skilladvancerunequip
@@ -8896,7 +8887,6 @@ Armor 0x76da
 	Desc		Shield AR40
 	Graphic		0x1B76
 	AR		40
-	Coverage	Hands
 	maxhp		500
 	equipscript	::skilladvancerequip
 	unequipscript	::skilladvancerunequip
@@ -8910,7 +8900,6 @@ Armor 0x76db
 	Desc		Shield AR45
 	Graphic		0x1B76
 	AR		45
-	Coverage	Hands
 	maxhp		500
 	equipscript	::skilladvancerequip
 	unequipscript	::skilladvancerunequip
@@ -8924,7 +8913,6 @@ Armor 0x76dc
 	Desc		Shield AR50
 	Graphic		0x1B76
 	AR		50
-	Coverage	Hands
 	maxhp		500
 	equipscript	::skilladvancerequip
 	unequipscript	::skilladvancerunequip
@@ -8938,7 +8926,6 @@ Armor 0x76df
 	Desc		Shield of Stygian Darkness
 	Graphic		0x1B7B
 	AR		30
-	Coverage	Hands
 	maxhp		500
 	equipscript	::skilladvancerequip
 	unequipscript	::skilladvancerunequip
@@ -8951,8 +8938,9 @@ Armor 0x76dd
 	Name		AnimationShield
 	Desc		Animation's Shield
 	Graphic		0x1086
-	AR		35
-	Coverage	Hands
+	AR			35
+	Coverage	Body
+	Coverage	Legs/feet
 	maxhp		500
 	equipscript	::skilladvancerequip
 	unequipscript	::skilladvancerunequip
@@ -15594,7 +15582,6 @@ Armor 0x9825
 	Name		Shieldofdrakon
 	graphic		0x1B76
 	Desc		 Heater Shield
-	Coverage	Hands
 	AR		60
  	VendorSellsFor 50000
  	VendorBuysFor 20000
@@ -15614,7 +15601,6 @@ Armor 0x9826
 	Name		Shieldofryous
 	graphic		0x1B74
 	Desc		 Kite Shield
-	Coverage	Hands
 	AR		60
  	VendorSellsFor 50000
  	VendorBuysFor 20000
@@ -15634,7 +15620,6 @@ Armor 0x9827
 	Name		Shieldofdarkness
 	graphic		0x1B7B
 	Desc		Metal Shield
-	Coverage	Hands
 	AR		60
  	VendorSellsFor 50000
  	VendorBuysFor 20000
@@ -15654,7 +15639,6 @@ Armor 0x9828
 	Name		ElvenShield
 	graphic		0x1B72
 	Desc		Bronze Shield
-	Coverage	Hands
 	AR		60
  	VendorSellsFor 50000
  	VendorBuysFor 20000
@@ -15674,7 +15658,6 @@ Armor 0x982a
 	Name					NavarBloodyBarrier
 	graphic					0x2B01
 	Desc					Shield
-	Coverage				Hands
 	AR						65
  	VendorSellsFor 			50000
  	VendorBuysFor 			20000
@@ -15760,7 +15743,6 @@ Armor 0x1bc6
  	Name  solidchaos
  	graphic  7107
  	Desc  shield
- 	Coverage Hands
  	AR  30
  	VendorSellsFor 273
  	VendorBuysFor 136

--- a/pkg/systems/combat/include/hitscriptinc.inc
+++ b/pkg/systems/combat/include/hitscriptinc.inc
@@ -62,6 +62,16 @@ function RecalcDmg( attacker, defender, weapon, armor, byref basedamage, piercin
 
 	//Print("In RecalcDmg with basedamage: " + basedamage);
 
+	// No Damage Zone backstop - unlike the NOPK/SafeArea checks below, this
+	// isn't skipped when either side is an NPC. Combat is already blocked
+	// from starting at the packethook/Fight() level; this only matters if
+	// damage reaches here some other way (e.g. flag toggled live mid-fight).
+	if (GetObjProperty(defender, "InNoDamageZone"))
+		attacker.setwarmode(0);
+		defender.setwarmode(0);
+		return;
+	endif
+
 	var noPKatk := GetObjProperty(attacker, "NOPKAREA");
 	var noPKdef := GetObjProperty(defender, "NOPKAREA");
 
@@ -631,6 +641,14 @@ endfunction
 function DealDamage( attacker, defender, weapon, armor, basedamage, rawdamage )
 
 	//Print("In DealDamage with basedamage: " + basedamage);
+
+	// No Damage Zone backstop - see RecalcDmg() above for why this is a
+	// separate, non-_any_npc-excluded check.
+	if (GetObjProperty(defender, "InNoDamageZone"))
+		attacker.setwarmode(0);
+		defender.setwarmode(0);
+		return;
+	endif
 
 	var noPKatk := GetObjProperty(attacker, "NOPKAREA");
 	var noPKdef := GetObjProperty(defender, "NOPKAREA");

--- a/regions/regions.cfg
+++ b/regions/regions.cfg
@@ -1,4 +1,4 @@
-#
+﻿#
 # Region Data
 #
 # This file can be split up into multiple files, if different region
@@ -27,7 +27,7 @@ Region Whole World
     Range 0 0 7167 4095
     Realm britannia
     MIDI 27
-    Type POI
+    Type World
     Area 1835008
     EnterText You have entered Whole World.
     LeaveText You have left Whole World.
@@ -40,7 +40,7 @@ Region Zulu Territory
     Range 0 0 5119 4095
     Realm britannia
     MIDI 27
-    Type POI
+    Type World
     Area 1310720
     EnterText You have entered Zulu Territory.
     LeaveText You have left Zulu Territory.
@@ -53,10 +53,114 @@ Region Zulu Dungeon Territory
     Range 5120 0 7167 4095
     Realm britannia
     MIDI 27
-    Type POI
+    Type World
     Area 524288
     EnterText You have entered Zulu Dungeon Territory.
     LeaveText You have left Zulu Dungeon Territory.
+    EnterScript :areas:EnterArea
+    LeaveScript :areas:LeaveArea
+}
+
+Region Green Acres 8
+{
+    Range 5124 2064 5959 2295
+    Realm britannia
+    MIDI 27
+    Type World
+    Area 12122
+    EnterText You have entered Green Acres 8.
+    LeaveText You have left Green Acres 8.
+    EnterScript :areas:EnterArea
+    LeaveScript :areas:LeaveArea
+}
+
+Region Green Acres 7
+{
+    Range 5960 1748 6143 2295
+    Realm britannia
+    MIDI 27
+    Type World
+    Area 6302
+    EnterText You have entered Green Acres 7.
+    LeaveText You have left Green Acres 7.
+    EnterScript :areas:EnterArea
+    LeaveScript :areas:LeaveArea
+}
+
+Region Green Acres 6
+{
+    Range 5432 1748 5619 1775
+    Realm britannia
+    MIDI 27
+    Type World
+    Area 329
+    EnterText You have entered Green Acres 6.
+    LeaveText You have left Green Acres 6.
+    EnterScript :areas:EnterArea
+    LeaveScript :areas:LeaveArea
+}
+
+Region Green Acres 5
+{
+    Range 5892 1724 6143 1747
+    Realm britannia
+    MIDI 27
+    Type World
+    Area 378
+    EnterText You have entered Green Acres 5.
+    LeaveText You have left Green Acres 5.
+    EnterScript :areas:EnterArea
+    LeaveScript :areas:LeaveArea
+}
+
+Region Green Acres 4
+{
+    Range 5432 1536 5891 1747
+    Realm britannia
+    MIDI 27
+    Type World
+    Area 6095
+    EnterText You have entered Green Acres 4.
+    LeaveText You have left Green Acres 4.
+    EnterScript :areas:EnterArea
+    LeaveScript :areas:LeaveArea
+}
+
+Region Green Acres 3
+{
+    Range 6052 1536 6143 1723
+    Realm britannia
+    MIDI 27
+    Type World
+    Area 1081
+    EnterText You have entered Green Acres 3.
+    LeaveText You have left Green Acres 3.
+    EnterScript :areas:EnterArea
+    LeaveScript :areas:LeaveArea
+}
+
+Region Green Acres 2
+{
+    Range 5376 1044 5911 1267
+    Realm britannia
+    MIDI 27
+    Type World
+    Area 7504
+    EnterText You have entered Green Acres 2.
+    LeaveText You have left Green Acres 2.
+    EnterScript :areas:EnterArea
+    LeaveScript :areas:LeaveArea
+}
+
+Region Green Acres 1
+{
+    Range 5912 512 6143 1267
+    Realm britannia
+    MIDI 27
+    Type World
+    Area 10962
+    EnterText You have entered Green Acres 1.
+    LeaveText You have left Green Acres 1.
     EnterScript :areas:EnterArea
     LeaveScript :areas:LeaveArea
 }
@@ -70,110 +174,6 @@ Region Lost Lands
     Area 114944
     EnterText You have entered Lost Lands.
     LeaveText You have left Lost Lands.
-    EnterScript :areas:EnterArea
-    LeaveScript :areas:LeaveArea
-}
-
-Region Green Acres 8
-{
-    Range 5124 2064 5959 2295
-    Realm britannia
-    MIDI 27
-    Type POI
-    Area 12122
-    EnterText You have entered Green Acres 8.
-    LeaveText You have left Green Acres 8.
-    EnterScript :areas:EnterArea
-    LeaveScript :areas:LeaveArea
-}
-
-Region Green Acres 7
-{
-    Range 5960 1748 6143 2295
-    Realm britannia
-    MIDI 27
-    Type POI
-    Area 6302
-    EnterText You have entered Green Acres 7.
-    LeaveText You have left Green Acres 7.
-    EnterScript :areas:EnterArea
-    LeaveScript :areas:LeaveArea
-}
-
-Region Green Acres 6
-{
-    Range 5432 1748 5619 1775
-    Realm britannia
-    MIDI 27
-    Type POI
-    Area 329
-    EnterText You have entered Green Acres 6.
-    LeaveText You have left Green Acres 6.
-    EnterScript :areas:EnterArea
-    LeaveScript :areas:LeaveArea
-}
-
-Region Green Acres 5
-{
-    Range 5892 1724 6143 1747
-    Realm britannia
-    MIDI 27
-    Type POI
-    Area 378
-    EnterText You have entered Green Acres 5.
-    LeaveText You have left Green Acres 5.
-    EnterScript :areas:EnterArea
-    LeaveScript :areas:LeaveArea
-}
-
-Region Green Acres 4
-{
-    Range 5432 1536 5891 1747
-    Realm britannia
-    MIDI 27
-    Type POI
-    Area 6095
-    EnterText You have entered Green Acres 4.
-    LeaveText You have left Green Acres 4.
-    EnterScript :areas:EnterArea
-    LeaveScript :areas:LeaveArea
-}
-
-Region Green Acres 3
-{
-    Range 6052 1536 6143 1723
-    Realm britannia
-    MIDI 27
-    Type POI
-    Area 1081
-    EnterText You have entered Green Acres 3.
-    LeaveText You have left Green Acres 3.
-    EnterScript :areas:EnterArea
-    LeaveScript :areas:LeaveArea
-}
-
-Region Green Acres 2
-{
-    Range 5376 1044 5911 1267
-    Realm britannia
-    MIDI 27
-    Type POI
-    Area 7504
-    EnterText You have entered Green Acres 2.
-    LeaveText You have left Green Acres 2.
-    EnterScript :areas:EnterArea
-    LeaveScript :areas:LeaveArea
-}
-
-Region Green Acres 1
-{
-    Range 5912 512 6143 1267
-    Realm britannia
-    MIDI 27
-    Type POI
-    Area 10962
-    EnterText You have entered Green Acres 1.
-    LeaveText You have left Green Acres 1.
     EnterScript :areas:EnterArea
     LeaveScript :areas:LeaveArea
 }

--- a/scripts/ai/combat/fight.inc
+++ b/scripts/ai/combat/fight.inc
@@ -4,12 +4,41 @@ include "include/npcboosts";
 include "ai/main/npcinfo";
 include "include/attributes";
 include "ai/main/lootblockers";
+include "include/areas";
+include ":areas:include/areafunctions";
 
 function Fight( opponent )
 
 	if ((opponent.cmdlevel > 0) or (opponent.serial == me.serial))
         	setwarmode(0);
         	opponent := 0;
+		return;
+	endif
+
+	// No Damage Zone - chokepoint for every scripts/ai/main/mainloop*.inc
+	// variant, so this single check covers all of them rather than patching
+	// each one. Note: tamed pets (scripts/ai/tamed.src) and guards
+	// (scripts/ai/instakillguard.src) each define their own separate Fight()
+	// and never reach this one - tamed.src has the equivalent check added
+	// directly; guards are covered by callguards.src never summoning one
+	// against a No-Damage-Zone target in the first place, plus the
+	// RecalcDmg()/DealDamage() backstop in hitscriptinc.inc blocking the
+	// guard's native weapon damage even if one is already mid-chase when a
+	// target crosses into the zone. An attacker outside the zone attacking a
+	// defender inside gets removed here (it would otherwise just sit
+	// uselessly at the boundary forever); the me.script=="tamed" branch below
+	// is defensive in case anything not actually running tamed.src ever ends
+	// up flagged that way.
+	if (IsInNoDamageZone(opponent))
+		setwarmode(0);
+		opponent := 0;
+		if (me.isa(POLCLASS_NPC) && !IsInNoDamageZone(me))
+			if (me.script == "tamed")
+				ConfiscateTamedPetForNoDamageZone(me);
+			else
+				me.kill();
+			endif
+		endif
 		return;
 	endif
 

--- a/scripts/ai/minstrel.src
+++ b/scripts/ai/minstrel.src
@@ -64,7 +64,9 @@ program Minstrel()
     var ev;
     var next_wander := ReadGameClock() + RandomDice( 2, 50, 120 );
     while (1)
-        WanderWithinTown();
+        if (!WanderWithinTown())
+            return;
+        endif
         ev := os::wait_for_event( 120 );
         case (ev.type)
             SYSEVENT_SPEECH:
@@ -75,11 +77,15 @@ program Minstrel()
                 endif
             SYSEVENT_ENGAGED:
                 SayRandomFromArray(ENGAGED_SAYINGS);
-                RunFromOpponent( ev.source, HALT_THRESHOLD );
+                if (!RunFromOpponent( ev.source, HALT_THRESHOLD ))
+                    return;
+                endif
             SYSEVENT_DAMAGED:
                 SayRandomFromArray(DAMAGED_SAYINGS);
                 if (ev.source)
-                    RunFromOpponent( ev.source, HALT_THRESHOLD );
+                    if (!RunFromOpponent( ev.source, HALT_THRESHOLD ))
+                        return;
+                    endif
                 else
                     say( "What evil thou art!" );
                 endif
@@ -89,7 +95,9 @@ program Minstrel()
                 say("Fare thee well!");
         endcase
         if (ReadGameClock() >= next_wander)
-            WanderWithinTown();
+            if (!WanderWithinTown())
+                return;
+            endif
             next_wander := ReadGameClock() + RandomDice( 2, 50, 120 );
         endif
     endwhile

--- a/scripts/ai/noble.src
+++ b/scripts/ai/noble.src
@@ -43,7 +43,10 @@ program noble ()
     set_priority(10);
 
     // Start movement right away so newly spawned nobles do not stand idle.
-    WanderWithinTown();
+    // (hasTownBounds is already guaranteed true here; see the early return above.)
+    if (!WanderWithinTown())
+        return;
+    endif
 
 
     // Keep one blocking wait per loop; avoid a tight event loop that can trigger runaway cycles.
@@ -59,11 +62,15 @@ program noble ()
                endif
             SYSEVENT_ENGAGED:
                 SayRandomFromArray(ENGAGED_SAYINGS);
-                RunFromOpponent( ev.source, HALT_THRESHOLD );
+                if (!RunFromOpponent( ev.source, HALT_THRESHOLD ))
+                    return;
+                endif
             SYSEVENT_DAMAGED:
                 SayRandomFromArray(DAMAGED_SAYINGS);
                 if (ev.source)
-                    RunFromOpponent( ev.source, HALT_THRESHOLD );
+                    if (!RunFromOpponent( ev.source, HALT_THRESHOLD ))
+                        return;
+                    endif
                 else
                     say( "What treachery is this!" );
                 endif
@@ -71,7 +78,9 @@ program noble ()
                 SayRandomFromArray(DISENGAGED_SAYINGS);
         endcase
         if (hasTownBounds and ReadGameClock() >= next_wander)
-            WanderWithinTown();
+            if (!WanderWithinTown())
+                return;
+            endif
             next_wander := ReadGameClock() + RandomDice( 2, 50, 120 );
         endif
         Sleepms(1);

--- a/scripts/ai/person.src
+++ b/scripts/ai/person.src
@@ -54,7 +54,9 @@ program Person()
     set_priority(10);
 
     // Start movement right away so newly spawned townsfolk do not stand idle.
-    WanderWithinTown();
+    if (!WanderWithinTown())
+        return;
+    endif
 
     var ev;
     var next_wander := ReadGameClock() + RandomDice( 2, 50, 120 );
@@ -69,11 +71,15 @@ program Person()
                endif
             SYSEVENT_ENGAGED:
                 SayRandomFromArray(ENGAGED_SAYINGS);
-                RunFromOpponent( ev.source, HALT_THRESHOLD );
+                if (!RunFromOpponent( ev.source, HALT_THRESHOLD ))
+                    return;
+                endif
             SYSEVENT_DAMAGED:
                 SayRandomFromArray(DAMAGED_SAYINGS);
                 if (ev.source)
-                    RunFromOpponent( ev.source, HALT_THRESHOLD );
+                    if (!RunFromOpponent( ev.source, HALT_THRESHOLD ))
+                        return;
+                    endif
                 else
                     say( "What sinister force is this!" );
                 endif
@@ -81,7 +87,9 @@ program Person()
                 SayRandomFromArray(DISENGAGED_SAYINGS);
         endcase
         if (ReadGameClock() >= next_wander)
-            WanderWithinTown();
+            if (!WanderWithinTown())
+                return;
+            endif
             next_wander := ReadGameClock() + RandomDice( 2, 50, 120 );
         endif
     endwhile

--- a/scripts/ai/tamed.src
+++ b/scripts/ai/tamed.src
@@ -16,6 +16,8 @@ include "ai/setup/modsetup";
 include "include/random";
 include "include/attributes";
 include ":housing:utility";
+include "include/areas";
+include ":areas:include/areafunctions";
 
 const HALT_THRESHOLD := 10;
 Const MOVING_EFFECT_FIREBALL	:= 0x36D4;
@@ -144,6 +146,19 @@ function Fight( opponent )
 	following := 0;
 
 	if ( (opponent.serial == me.serial) or (opponent.serial == master.serial) )
+		return;
+	endif
+
+	// No Damage Zone - tamed pets have their own Fight() here, separate from
+	// scripts/ai/combat/fight.inc's shared one, so the check has to be
+	// duplicated. A pet ordered to attack a defender inside the zone gets
+	// confiscated (not killed) rather than just silently blocked.
+	if (IsInNoDamageZone(opponent))
+		SetWarMode( 0 );
+		following := oldfollowing;
+		if (!IsInNoDamageZone(me))
+			ConfiscateTamedPetForNoDamageZone(me);
+		endif
 		return;
 	endif
 
@@ -1116,18 +1131,27 @@ function Follow()
 		if( !Iscowner( master, multi3 ) and !Iscowner( master, multi2 ))
 			if( !IsFriend( master, multi3) and !IsFriend( master, multi2))
 				if (following.multi and !master.multi)
+					following := 0;
 					return;
 				elseif (!following.multi and master.multi)
+					following := 0;
 					return;
 				elseif (me.multi and !master.multi)
+					following := 0;
 					return;
 				elseif (!me.multi and master.multi)
+					following := 0;
 					return;
 				elseif (me.multi and !following.multi)
+					following := 0;
 					return;
 				elseif (!me.multi and following.multi)
+					following := 0;
 					return;
 				elseif(!CheckLineOfSight(me, following))
+					// Transient (e.g. a tower's overhang geometrically
+					// blocking the LOS raycast) - retry instead of
+					// abandoning the follow order like the six cases above.
 					return;
 				endif
 			endif
@@ -1138,18 +1162,27 @@ function Follow()
 		if( !Iscowner( master, multi2 ))
 			if( !IsFriend( master, multi2))
 				if (following.multi and !master.multi)
+					following := 0;
 					return;
 				elseif (!following.multi and master.multi)
+					following := 0;
 					return;
 				elseif (me.multi and !master.multi)
+					following := 0;
 					return;
 				elseif (!me.multi and master.multi)
+					following := 0;
 					return;
 				elseif (me.multi and !following.multi)
+					following := 0;
 					return;
 				elseif (!me.multi and following.multi)
+					following := 0;
 					return;
 				elseif(!CheckLineOfSight(me, following))
+					// Transient (e.g. a tower's overhang geometrically
+					// blocking the LOS raycast) - retry instead of
+					// abandoning the follow order like the six cases above.
 					return;
 				endif
 			endif
@@ -1160,18 +1193,27 @@ function Follow()
 		if( !Iscowner( master, multi3 ))
 			if( !IsFriend( master, multi3))
 				if (following.multi and !master.multi)
+					following := 0;
 					return;
 				elseif (!following.multi and master.multi)
+					following := 0;
 					return;
 				elseif (me.multi and !master.multi)
+					following := 0;
 					return;
 				elseif (!me.multi and master.multi)
+					following := 0;
 					return;
 				elseif (me.multi and !following.multi)
+					following := 0;
 					return;
 				elseif (!me.multi and following.multi)
+					following := 0;
 					return;
 				elseif(!CheckLineOfSight(me, following))
+					// Transient (e.g. a tower's overhang geometrically
+					// blocking the LOS raycast) - retry instead of
+					// abandoning the follow order like the six cases above.
 					return;
 				endif
 			endif

--- a/scripts/ai/townperson.src
+++ b/scripts/ai/townperson.src
@@ -51,7 +51,9 @@ program TownPerson()
     set_priority(10);
 
     // Start movement right away so newly spawned townsfolk do not stand idle.
-    WanderWithinTown();
+    if (!WanderWithinTown())
+        return;
+    endif
 
     // (Old while loop removed; only the new, shared-saying-based loop remains)
     var ev;
@@ -66,11 +68,15 @@ program TownPerson()
                endif
             SYSEVENT_ENGAGED:
                 SayRandomFromArray(ENGAGED_SAYINGS);
-                RunFromOpponent( ev.source, HALT_THRESHOLD );
+                if (!RunFromOpponent( ev.source, HALT_THRESHOLD ))
+                    return;
+                endif
             SYSEVENT_DAMAGED:
                 SayRandomFromArray(DAMAGED_SAYINGS);
                 if (ev.source)
-                    RunFromOpponent( ev.source, HALT_THRESHOLD );
+                    if (!RunFromOpponent( ev.source, HALT_THRESHOLD ))
+                        return;
+                    endif
                 else
                     say( "What sinister force is this!" );
                 endif
@@ -78,7 +84,9 @@ program TownPerson()
                 SayRandomFromArray(DISENGAGED_SAYINGS);
         endcase
         if (ReadGameClock() >= next_wander)
-            WanderWithinTown();
+            if (!WanderWithinTown())
+                return;
+            endif
             next_wander := ReadGameClock() + RandomDice( 2, 50, 120 );
         endif
     endwhile

--- a/scripts/include/anchors.inc
+++ b/scripts/include/anchors.inc
@@ -272,6 +272,9 @@ function EnforceTownBounds(from_combat)
         return 1;
 endfunction
 
+// Returns 0 if this NPC was jailed/killed by EnforceTownBounds (caller must
+// stop running: SendToJailAndRespawn does not itself halt the script), 1 if
+// it's still alive and in bounds.
 function WanderWithinTown()
         var me := Self();
         if(ANCHORS_DEBUG)
@@ -282,13 +285,13 @@ function WanderWithinTown()
         endif
 
         if (!EnforceTownBounds(0))
-                return;
+                return 0;
         endif
 
         TryOpenNearbyNpcDoors();
         StepCivilianThroughDoorIfNeeded();
         Wander();
-        EnforceTownBounds(0);
+        return EnforceTownBounds(0);
 endfunction
 
 function IsDoorPushCivilianTemplate(me)

--- a/scripts/include/areas.inc
+++ b/scripts/include/areas.inc
@@ -291,11 +291,11 @@ function IsInAntiLootingArea( byref who )
 		return 1;
 	endif
 
-	if( !allowed[match.area_index] && HasPolicy(match.mask, AREA_POLICY_NO_LOOTING) )
+	if( !allowed[match.area_index] && (HasPolicy(match.mask, AREA_POLICY_NO_LOOTING) || HasPolicy(match.mask, AREA_POLICY_NO_DAMAGE_ZONE)) )
 		set_priority(old_prio);
 		return 1;
 	endif
-	
+
 	set_priority(old_prio);
 
 	return 0;
@@ -319,13 +319,13 @@ function IsInAntiMagicArea( byref who )
 		set_priority(old_prio);
 		return 0;
 	endif
-	
+
 	var allowed	:= GetObjProperty( who, PROPID_MOBILE_AREAS_ALLOWED_ANTIMAGIC );
 	if( !allowed )
 		allowed := {};
 	endif
-	
-	if( !allowed[match.area_index] && HasPolicy(match.mask, AREA_POLICY_ANTI_MAGIC) )
+
+	if( !allowed[match.area_index] && (HasPolicy(match.mask, AREA_POLICY_ANTI_MAGIC) || HasPolicy(match.mask, AREA_POLICY_NO_DAMAGE_ZONE)) )
 		set_priority(old_prio);
 		return 1;
 	endif
@@ -479,4 +479,8 @@ endfunction
 
 function IsInRPArea(who)
 	return HasPolicy(GetAreaPolicyMaskForWho(who), AREA_POLICY_RP_AREA);
+endfunction
+
+function IsInNoDamageZone(who)
+	return HasPolicy(GetAreaPolicyMaskForWho(who), AREA_POLICY_NO_DAMAGE_ZONE);
 endfunction

--- a/scripts/include/classfirsts.inc
+++ b/scripts/include/classfirsts.inc
@@ -1,0 +1,46 @@
+use datafile;
+
+const CLASSFIRSTS_DATAFILE := ":classfirsts:classfirsts";
+
+function OpenClassFirstsDataFile()
+	var df := OpenDataFile( CLASSFIRSTS_DATAFILE );
+	if( !df )
+		CreateDataFile( CLASSFIRSTS_DATAFILE, DF_KEYTYPE_STRING );
+		df := OpenDataFile( CLASSFIRSTS_DATAFILE );
+	endif
+	return df;
+endfunction
+
+// Name of the first player to reach this level/classe key (e.g. "1m"), or 0 if unclaimed.
+function GetClassFirst( key )
+	var df := OpenClassFirstsDataFile();
+	if( !df )
+		return 0;
+	endif
+
+	var elem := df.FindElement( key );
+	var name := 0;
+	if( elem )
+		name := elem.GetProp( "name" );
+	endif
+
+	UnloadDataFile( CLASSFIRSTS_DATAFILE );
+	return name;
+endfunction
+
+function SetClassFirst( key, name )
+	var df := OpenClassFirstsDataFile();
+	if( !df )
+		return;
+	endif
+
+	var elem := df.FindElement( key );
+	if( !elem )
+		elem := df.CreateElement( key );
+	endif
+	if( elem )
+		elem.SetProp( "name", name );
+	endif
+
+	UnloadDataFile( CLASSFIRSTS_DATAFILE );
+endfunction

--- a/scripts/include/skillpoints.inc
+++ b/scripts/include/skillpoints.inc
@@ -282,7 +282,7 @@ var skill := GetAttributeIdBySkillId(skillid);
 		endif
 	endif
 
-	if (IsInSafeArea(who))
+	if (IsInSafeArea(who) || IsInNoDamageZone(who))
 		if (skill == ATTRIBUTEID_ARCHERY or skill == ATTRIBUTEID_PARRY or skill == ATTRIBUTEID_MACEFIGHTING or skill == ATTRIBUTEID_SWORDSMANSHIP or skill == ATTRIBUTEID_FENCING or skill == ATTRIBUTEID_WRESTLING or skill == ATTRIBUTEID_TACTICS or skill == ATTRIBUTEID_MAGICRESISTANCE)
 			rawpoints := 0;
 		elseif (skill == ATTRIBUTEID_MACEFIGHTING + ATTRIBUTEID_HERDING)

--- a/scripts/include/townsfolk.inc
+++ b/scripts/include/townsfolk.inc
@@ -88,6 +88,8 @@ endfunction
 //  RunFromOpponent - shared flee loop used by civilian NPCs.
 //  Enforces town bounds during the flee; jails/kills if chased out of town.
 //  Responds to "hold" keyword, DISENGAGED, and damage events.
+//  Returns 0 if this NPC was jailed/killed by EnforceTownBounds (caller must
+//  stop running), 1 if the flee ended normally (opponent died/disengaged/held).
 //
 /////////////////////////////////////////////////////////////////////////////
 function RunFromOpponent( opponent, HALT_THRESHOLD )
@@ -95,9 +97,11 @@ function RunFromOpponent( opponent, HALT_THRESHOLD )
         DisableEvents( SYSEVENT_ENTEREDAREA + SYSEVENT_LEFTAREA );
 
         var waittime;
+        var survived := 1;
   outer:
 	while (opponent and !opponent.dead)
 		if (!EnforceTownBounds(1))
+			survived := 0;
 			break outer;
 		endif
 
@@ -142,6 +146,7 @@ function RunFromOpponent( opponent, HALT_THRESHOLD )
 
         EnableEvents( SYSEVENT_ENTEREDAREA + SYSEVENT_LEFTAREA, HALT_THRESHOLD );
         SetWarMode( 0 );
+        return survived;
 endfunction
 
 /////////////////////////////////////////////////////////////////////////////

--- a/scripts/textcmd/admin/migrateclassfirsts.src
+++ b/scripts/textcmd/admin/migrateclassfirsts.src
@@ -1,0 +1,39 @@
+// Synopsis: One-time migration of legacy "first to reach class level" CProps into the classfirsts datafile
+use uo;
+
+include "include/classfirsts";
+include ":staff:include/staff";
+
+program textcmd_migrateclassfirsts( who )
+
+	var codes := { "b", "bs", "c", "m", "ma", "p", "pa", "r", "t", "w" };
+	var migrated := 0;
+	var skipped_existing := 0;
+	var skipped_empty := 0;
+
+	foreach code in codes
+		var level;
+		for( level := 1; level <= 6; level := level + 1 )
+			var key := CStr( level ) + code;
+
+			var legacy_name := GetGlobalProperty( key );
+			if( !legacy_name )
+				skipped_empty := skipped_empty + 1;
+				continue;
+			endif
+
+			if( GetClassFirst( key ) )
+				skipped_existing := skipped_existing + 1;
+				continue;
+			endif
+
+			SetClassFirst( key, legacy_name );
+			migrated := migrated + 1;
+			SendSysMessage( who, "Migrated " + key + ": " + legacy_name );
+		endfor
+	endforeach
+
+	SendSysMessage( who, "Class firsts migration complete. Migrated: " + migrated + ", already in datafile: " + skipped_existing + ", no legacy record: " + skipped_empty );
+	LogCommand( who, GetProcess( GetPid() ).name );
+
+endprogram

--- a/scripts/textcmd/player/showclasse.src
+++ b/scripts/textcmd/player/showclasse.src
@@ -6,8 +6,10 @@
 /////////////////////////////////////////////////////////////////////////////
 use uo;
 use polsys;
+use datafile;
 
 include "include/classes";
+include "include/classfirsts";
 
 program show_classe( who )
 
@@ -31,373 +33,373 @@ program show_classe( who )
 			SendSysMessage( who, "You're a qualified level " + level + " " + GetClasseName(classe));
 			IncRevision(who);
 			if(who.cmdlevel == 0)
-				if (!GetGlobalProperty("1m"))
+				if (!GetClassFirst("1m"))
 					if(level == 1 and classe == CLASSEID_MAGE)
 					Broadcast( who.name + " is the first to reach level 1 Mage!" , FONT_BOLD, 1176);
-					SetGlobalProperty("1m", who.name);
+					SetClassFirst("1m", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("2m"))
+				if (!GetClassFirst("2m"))
 					if(level == 2 and classe == CLASSEID_MAGE)
 					Broadcast( who.name + " is the first to reach level 2 Mage!" , FONT_BOLD, 1176);
-					SetGlobalProperty("2m", who.name);
+					SetClassFirst("2m", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("3m"))
+				if (!GetClassFirst("3m"))
 					if(level == 3 and classe == CLASSEID_MAGE)
 					Broadcast( who.name + " is the first to reach level 3 Mage!" , FONT_BOLD, 1176);
-					SetGlobalProperty("3m", who.name);
+					SetClassFirst("3m", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("4m"))
+				if (!GetClassFirst("4m"))
 					if(level == 4 and classe == CLASSEID_MAGE)
 					Broadcast( who.name + " is the first to reach level 4 Mage!" , FONT_BOLD, 1176);
-					SetGlobalProperty("4m", who.name);
+					SetClassFirst("4m", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("5m"))
+				if (!GetClassFirst("5m"))
 					if(level == 5 and classe == CLASSEID_MAGE)
 					Broadcast( who.name + " is the first to reach level 5 Mage!" , FONT_BOLD, 1176);
-					SetGlobalProperty("5m", who.name);
+					SetClassFirst("5m", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("6m"))
+				if (!GetClassFirst("6m"))
 					if(level == 6 and classe == CLASSEID_MAGE)
 					Broadcast( who.name + " is the first to reach level 6 Mage!" , FONT_BOLD, 1176);
-					SetGlobalProperty("6m", who.name);
+					SetClassFirst("6m", who.name);
 					endif
 				endif
 					
-				if (!GetGlobalProperty("1r"))
+				if (!GetClassFirst("1r"))
 					if(level == 1 and classe == CLASSEID_RANGER)
 					Broadcast( who.name + " is the first to reach level 1 Ranger!" , FONT_BOLD, 1176);
-					SetGlobalProperty("1r", who.name);
+					SetClassFirst("1r", who.name);
 					endif
 				endif	
-				if (!GetGlobalProperty("2r"))
+				if (!GetClassFirst("2r"))
 					if(level == 2 and classe == CLASSEID_RANGER)
 					Broadcast( who.name + " is the first to reach level 2 Ranger!" , FONT_BOLD, 1176);
-					SetGlobalProperty("2r", who.name);
+					SetClassFirst("2r", who.name);
 					endif
 				endif	
-				if (!GetGlobalProperty("3r"))
+				if (!GetClassFirst("3r"))
 					if(level == 3 and classe == CLASSEID_RANGER)
 					Broadcast( who.name + " is the first to reach level 3 Ranger!" , FONT_BOLD, 1176);
-					SetGlobalProperty("3r", who.name);
+					SetClassFirst("3r", who.name);
 					endif
 				endif	
-				if (!GetGlobalProperty("4r"))
+				if (!GetClassFirst("4r"))
 					if(level == 4 and classe == CLASSEID_RANGER)
 					Broadcast( who.name + " is the first to reach level 4 Ranger!" , FONT_BOLD, 1176);
-					SetGlobalProperty("4r", who.name);
+					SetClassFirst("4r", who.name);
 					endif
 				endif	
-				if (!GetGlobalProperty("5r"))
+				if (!GetClassFirst("5r"))
 					if(level == 5 and classe == CLASSEID_RANGER)
 					Broadcast( who.name + " is the first to reach level 5 Ranger!" , FONT_BOLD, 1176);
-					SetGlobalProperty("5r", who.name);
+					SetClassFirst("5r", who.name);
 					endif
 				endif	
-				if (!GetGlobalProperty("6r"))
+				if (!GetClassFirst("6r"))
 					if(level == 6 and classe == CLASSEID_RANGER)
 					Broadcast( who.name + " is the first to reach level 6 Ranger!" , FONT_BOLD, 1176);
-					SetGlobalProperty("6r", who.name);
+					SetClassFirst("6r", who.name);
 					endif
 				endif	
 					
-				if (!GetGlobalProperty("1w"))
+				if (!GetClassFirst("1w"))
 					if(level == 1 and classe == CLASSEID_WARRIOR)
 					Broadcast( who.name + " is the first to reach level 1 Warrior!" , FONT_BOLD, 1176);
-					SetGlobalProperty("1w", who.name);
+					SetClassFirst("1w", who.name);
 					endif
 				endif		
-				if (!GetGlobalProperty("2w"))
+				if (!GetClassFirst("2w"))
 					if(level == 2 and classe == CLASSEID_WARRIOR)
 					Broadcast( who.name + " is the first to reach level 2 Warrior!" , FONT_BOLD, 1176);
-					SetGlobalProperty("2w", who.name);
+					SetClassFirst("2w", who.name);
 					endif
 				endif		
-				if (!GetGlobalProperty("3w"))
+				if (!GetClassFirst("3w"))
 					if(level == 3 and classe == CLASSEID_WARRIOR)
 					Broadcast( who.name + " is the first to reach level 3 Warrior!" , FONT_BOLD, 1176);
-					SetGlobalProperty("3w", who.name);
+					SetClassFirst("3w", who.name);
 					endif
 				endif		
-				if (!GetGlobalProperty("4w"))
+				if (!GetClassFirst("4w"))
 					if(level == 4 and classe == CLASSEID_WARRIOR)
 					Broadcast( who.name + " is the first to reach level 4 Warrior!" , FONT_BOLD, 1176);
-					SetGlobalProperty("4w", who.name);
+					SetClassFirst("4w", who.name);
 					endif
 				endif		
-				if (!GetGlobalProperty("5w"))
+				if (!GetClassFirst("5w"))
 					if(level == 5 and classe == CLASSEID_WARRIOR)
 					Broadcast( who.name + " is the first to reach level 5 Warrior!" , FONT_BOLD, 1176);
-					SetGlobalProperty("5w", who.name);
+					SetClassFirst("5w", who.name);
 					endif
 				endif		
-				if (!GetGlobalProperty("6w"))
+				if (!GetClassFirst("6w"))
 					if(level == 6 and classe == CLASSEID_WARRIOR)
 					Broadcast( who.name + " is the first to reach level 6 Warrior!" , FONT_BOLD, 1176);
-					SetGlobalProperty("6w", who.name);
+					SetClassFirst("6w", who.name);
 					endif
 				endif	
 
-				if (!GetGlobalProperty("1t"))
+				if (!GetClassFirst("1t"))
 					if(level == 1 and classe == CLASSEID_THIEF)
 					Broadcast( who.name + " is the first to reach level 1 Thief!" , FONT_BOLD, 1176);
-					SetGlobalProperty("1t", who.name);
+					SetClassFirst("1t", who.name);
 					endif
 				endif	
-				if (!GetGlobalProperty("2t"))
+				if (!GetClassFirst("2t"))
 					if(level == 2 and classe == CLASSEID_THIEF)
 					Broadcast( who.name + " is the first to reach level 2 Thief!" , FONT_BOLD, 1176);
-					SetGlobalProperty("2t", who.name);
+					SetClassFirst("2t", who.name);
 					endif
 				endif	
-				if (!GetGlobalProperty("3t"))
+				if (!GetClassFirst("3t"))
 					if(level == 3 and classe == CLASSEID_THIEF)
 					Broadcast( who.name + " is the first to reach level 3 Thief!" , FONT_BOLD, 1176);
-					SetGlobalProperty("3t", who.name);
+					SetClassFirst("3t", who.name);
 					endif
 				endif	
-				if (!GetGlobalProperty("4t"))
+				if (!GetClassFirst("4t"))
 					if(level == 4 and classe == CLASSEID_THIEF)
 					Broadcast( who.name + " is the first to reach level 4 Thief!" , FONT_BOLD, 1176);
-					SetGlobalProperty("4t", who.name);
+					SetClassFirst("4t", who.name);
 					endif
 				endif	
-				if (!GetGlobalProperty("5t"))
+				if (!GetClassFirst("5t"))
 					if(level == 5 and classe == CLASSEID_THIEF)
 					Broadcast( who.name + " is the first to reach level 5 Thief!" , FONT_BOLD, 1176);
-					SetGlobalProperty("5t", who.name);
+					SetClassFirst("5t", who.name);
 					endif
 				endif	
-				if (!GetGlobalProperty("6t"))
+				if (!GetClassFirst("6t"))
 					if(level == 6 and classe == CLASSEID_THIEF)
 					Broadcast( who.name + " is the first to reach level 6 Thief!" , FONT_BOLD, 1176);
-					SetGlobalProperty("6t", who.name);
+					SetClassFirst("6t", who.name);
 					endif
 				endif	
 
-				if (!GetGlobalProperty("1c"))
+				if (!GetClassFirst("1c"))
 					if(level == 1 and classe == CLASSEID_CRAFTER)
 					Broadcast( who.name + " is the first to reach level 1 Crafter!" , FONT_BOLD, 1176);
-					SetGlobalProperty("1c", who.name);
+					SetClassFirst("1c", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("2c"))
+				if (!GetClassFirst("2c"))
 					if(level == 2 and classe == CLASSEID_CRAFTER)
 					Broadcast( who.name + " is the first to reach level 2 Crafter!" , FONT_BOLD, 1176);
-					SetGlobalProperty("2c", who.name);
+					SetClassFirst("2c", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("3c"))
+				if (!GetClassFirst("3c"))
 					if(level == 3 and classe == CLASSEID_CRAFTER)
 					Broadcast( who.name + " is the first to reach level 3 Crafter!" , FONT_BOLD, 1176);
-					SetGlobalProperty("3c", who.name);
+					SetClassFirst("3c", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("4c"))
+				if (!GetClassFirst("4c"))
 					if(level == 4 and classe == CLASSEID_CRAFTER)
 					Broadcast( who.name + " is the first to reach level 4 Crafter!" , FONT_BOLD, 1176);
-					SetGlobalProperty("4c", who.name);
+					SetClassFirst("4c", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("5c"))
+				if (!GetClassFirst("5c"))
 					if(level == 5 and classe == CLASSEID_CRAFTER)
 					Broadcast( who.name + " is the first to reach level 5 Crafter!" , FONT_BOLD, 1176);
-					SetGlobalProperty("5c", who.name);
+					SetClassFirst("5c", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("6c"))
+				if (!GetClassFirst("6c"))
 					if(level == 6 and classe == CLASSEID_CRAFTER)
 					Broadcast( who.name + " is the first to reach level 6 Crafter!" , FONT_BOLD, 1176);
-					SetGlobalProperty("6c", who.name);
+					SetClassFirst("6c", who.name);
 					endif
 				endif
 
-				if (!GetGlobalProperty("1b"))
+				if (!GetClassFirst("1b"))
 					if(level == 1 and classe == CLASSEID_BARD)
 					Broadcast( who.name + " is the first to reach level 1 Bard!" , FONT_BOLD, 1176);
-					SetGlobalProperty("1b", who.name);
+					SetClassFirst("1b", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("2b"))
+				if (!GetClassFirst("2b"))
 					if(level == 2 and classe == CLASSEID_BARD)
 					Broadcast( who.name + " is the first to reach level 2 Bard!" , FONT_BOLD, 1176);
-					SetGlobalProperty("2b", who.name);
+					SetClassFirst("2b", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("3b"))
+				if (!GetClassFirst("3b"))
 					if(level == 3 and classe == CLASSEID_BARD)
 					Broadcast( who.name + " is the first to reach level 3 Bard!" , FONT_BOLD, 1176);
-					SetGlobalProperty("3b", who.name);
+					SetClassFirst("3b", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("4b"))
+				if (!GetClassFirst("4b"))
 					if(level == 4 and classe == CLASSEID_BARD)
 					Broadcast( who.name + " is the first to reach level 4 Bard!" , FONT_BOLD, 1176);
-					SetGlobalProperty("4b", who.name);
+					SetClassFirst("4b", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("5b"))
+				if (!GetClassFirst("5b"))
 					if(level == 5 and classe == CLASSEID_BARD)
 					Broadcast( who.name + " is the first to reach level 5 Bard!" , FONT_BOLD, 1176);
-					SetGlobalProperty("5b", who.name);
+					SetClassFirst("5b", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("6b"))
+				if (!GetClassFirst("6b"))
 					if(level == 6 and classe == CLASSEID_BARD)
 					Broadcast( who.name + " is the first to reach level 6 Bard!" , FONT_BOLD, 1176);
-					SetGlobalProperty("6b", who.name);
+					SetClassFirst("6b", who.name);
 					endif
 				endif
 
-				if (!GetGlobalProperty("1p"))
+				if (!GetClassFirst("1p"))
 					if(level == 1 and classe == CLASSEID_POWERPLAYER)
 					Broadcast( who.name + " is the first to reach level 1 Powerplayer!" , FONT_BOLD, 1176);
-					SetGlobalProperty("1p", who.name);
+					SetClassFirst("1p", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("2p"))
+				if (!GetClassFirst("2p"))
 					if(level == 2 and classe == CLASSEID_POWERPLAYER)
 					Broadcast( who.name + " is the first to reach level 2 Powerplayer!" , FONT_BOLD, 1176);
-					SetGlobalProperty("2p", who.name);
+					SetClassFirst("2p", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("3p"))
+				if (!GetClassFirst("3p"))
 					if(level == 3 and classe == CLASSEID_POWERPLAYER)
 					Broadcast( who.name + " is the first to reach level 3 Powerplayer!" , FONT_BOLD, 1176);
-					SetGlobalProperty("3p", who.name);
+					SetClassFirst("3p", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("4p"))
+				if (!GetClassFirst("4p"))
 					if(level == 4 and classe == CLASSEID_POWERPLAYER)
 					Broadcast( who.name + " is the first to reach level 4 Powerplayer!" , FONT_BOLD, 1176);
-					SetGlobalProperty("4p", who.name);
+					SetClassFirst("4p", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("5p"))
+				if (!GetClassFirst("5p"))
 					if(level == 5 and classe == CLASSEID_POWERPLAYER)
 					Broadcast( who.name + " is the first to reach level 5 Powerplayer!" , FONT_BOLD, 1176);
-					SetGlobalProperty("5p", who.name);
+					SetClassFirst("5p", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("6p"))
+				if (!GetClassFirst("6p"))
 					if(level == 6 and classe == CLASSEID_POWERPLAYER)
 					Broadcast( who.name + " is the first to reach level 6 Powerplayer!" , FONT_BOLD, 1176);
-					SetGlobalProperty("6p", who.name);
+					SetClassFirst("6p", who.name);
 					endif
 				endif
 
-				if (!GetGlobalProperty("1pa"))
+				if (!GetClassFirst("1pa"))
 					if(level == 1 and classe == CLASSEID_PALADIN)
 					Broadcast( who.name + " is the first to reach level 1 Paladin!" , FONT_BOLD, 1176);
-					SetGlobalProperty("1pa", who.name);
+					SetClassFirst("1pa", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("2pa"))
+				if (!GetClassFirst("2pa"))
 					if(level == 2 and classe == CLASSEID_PALADIN)
 					Broadcast( who.name + " is the first to reach level 2 Paladin!" , FONT_BOLD, 1176);
-					SetGlobalProperty("2pa", who.name);
+					SetClassFirst("2pa", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("3pa"))
+				if (!GetClassFirst("3pa"))
 					if(level == 3 and classe == CLASSEID_PALADIN)
 					Broadcast( who.name + " is the first to reach level 3 Paladin!" , FONT_BOLD, 1176);
-					SetGlobalProperty("3pa", who.name);
+					SetClassFirst("3pa", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("4pa"))
+				if (!GetClassFirst("4pa"))
 					if(level == 4 and classe == CLASSEID_PALADIN)
 					Broadcast( who.name + " is the first to reach level 4 Paladin!" , FONT_BOLD, 1176);
-					SetGlobalProperty("4pa", who.name);
+					SetClassFirst("4pa", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("5pa"))
+				if (!GetClassFirst("5pa"))
 					if(level == 5 and classe == CLASSEID_PALADIN)
 					Broadcast( who.name + " is the first to reach level 5 Paladin!" , FONT_BOLD, 1176);
-					SetGlobalProperty("5pa", who.name);
+					SetClassFirst("5pa", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("6pa"))
+				if (!GetClassFirst("6pa"))
 					if(level == 6 and classe == CLASSEID_PALADIN)
 					Broadcast( who.name + " is the first to reach level 6 Paladin!" , FONT_BOLD, 1176);
-					SetGlobalProperty("6pa", who.name);
+					SetClassFirst("6pa", who.name);
 					endif
 				endif
 
-				if (!GetGlobalProperty("1bs"))
+				if (!GetClassFirst("1bs"))
 					if(level == 1 and classe == CLASSEID_BLADESINGER)
 					Broadcast( who.name + " is the first to reach level 1 Bladesinger!" , FONT_BOLD, 1176);
-					SetGlobalProperty("1bs", who.name);
+					SetClassFirst("1bs", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("2bs"))
+				if (!GetClassFirst("2bs"))
 					if(level == 2 and classe == CLASSEID_BLADESINGER)
 					Broadcast( who.name + " is the first to reach level 2 Bladesinger!" , FONT_BOLD, 1176);
-					SetGlobalProperty("2bs", who.name);
+					SetClassFirst("2bs", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("3bs"))
+				if (!GetClassFirst("3bs"))
 					if(level == 3 and classe == CLASSEID_BLADESINGER)
 					Broadcast( who.name + " is the first to reach level 3 Bladesinger!" , FONT_BOLD, 1176);
-					SetGlobalProperty("3bs", who.name);
+					SetClassFirst("3bs", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("4bs"))
+				if (!GetClassFirst("4bs"))
 					if(level == 4 and classe == CLASSEID_BLADESINGER)
 					Broadcast( who.name + " is the first to reach level 4 Bladesinger!" , FONT_BOLD, 1176);
-					SetGlobalProperty("4bs", who.name);
+					SetClassFirst("4bs", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("5bs"))
+				if (!GetClassFirst("5bs"))
 					if(level == 5 and classe == CLASSEID_BLADESINGER)
 					Broadcast( who.name + " is the first to reach level 5 Bladesinger!" , FONT_BOLD, 1176);
-					SetGlobalProperty("5bs", who.name);
+					SetClassFirst("5bs", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("6bs"))
+				if (!GetClassFirst("6bs"))
 					if(level == 6 and classe == CLASSEID_BLADESINGER)
 					Broadcast( who.name + " is the first to reach level 6 Bladesinger!" , FONT_BOLD, 1176);
-					SetGlobalProperty("6bs", who.name);
+					SetClassFirst("6bs", who.name);
 					endif
 				endif
 
-				if (!GetGlobalProperty("1ma"))
+				if (!GetClassFirst("1ma"))
 					if(level == 1 and classe == CLASSEID_MYSTIC_ARCHER)
 					Broadcast( who.name + " is the first to reach level 1 Mystic Archer!" , FONT_BOLD, 1176);
-					SetGlobalProperty("1ma", who.name);
+					SetClassFirst("1ma", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("2ma"))
+				if (!GetClassFirst("2ma"))
 					if(level == 2 and classe == CLASSEID_MYSTIC_ARCHER)
 					Broadcast( who.name + " is the first to reach level 2 Mystic Archer!" , FONT_BOLD, 1176);
-					SetGlobalProperty("2ma", who.name);
+					SetClassFirst("2ma", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("3ma"))
+				if (!GetClassFirst("3ma"))
 					if(level == 3 and classe == CLASSEID_MYSTIC_ARCHER)
 					Broadcast( who.name + " is the first to reach level 3 Mystic Archer!" , FONT_BOLD, 1176);
-					SetGlobalProperty("3ma", who.name);
+					SetClassFirst("3ma", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("4ma"))
+				if (!GetClassFirst("4ma"))
 					if(level == 4 and classe == CLASSEID_MYSTIC_ARCHER)
 					Broadcast( who.name + " is the first to reach level 4 Mystic Archer!" , FONT_BOLD, 1176);
-					SetGlobalProperty("4ma", who.name);
+					SetClassFirst("4ma", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("5ma"))
+				if (!GetClassFirst("5ma"))
 					if(level == 5 and classe == CLASSEID_MYSTIC_ARCHER)
 					Broadcast( who.name + " is the first to reach level 5 Mystic Archer!" , FONT_BOLD, 1176);
-					SetGlobalProperty("5ma", who.name);
+					SetClassFirst("5ma", who.name);
 					endif
 				endif
-				if (!GetGlobalProperty("6ma"))
+				if (!GetClassFirst("6ma"))
 					if(level == 6 and classe == CLASSEID_MYSTIC_ARCHER)
 					Broadcast( who.name + " is the first to reach level 6 Mystic Archer!" , FONT_BOLD, 1176);
-					SetGlobalProperty("6ma", who.name);
+					SetClassFirst("6ma", who.name);
 					endif
 				endif
 			endif


### PR DESCRIPTION
# Developer Changelog - v1.0.8
**Range:** `9f8189f` (origin/Patch-1.0.7) -> `676adfb` (HEAD)  
**Branch:** Patch-1.0.8  
**Date:** 2026-06-20 -> 2026-07-28  
**Commits in range:** 12 (excluding merge commits)  
**Files changed:** 104 (+13972 / -2098)

---

## Table of Contents

1. [Scope Summary](#1-scope-summary)
2. [Commit Timeline](#2-commit-timeline)
3. [Townstones - Player-Run Town Administration and Membership Cleanup](#3-townstones---player-run-town-administration-and-membership-cleanup)
4. [Areas - Policy Engine Rewrite, Realm Sanitization, and Mask-Value Cache](#4-areas---policy-engine-rewrite-realm-sanitization-and-mask-value-cache)
5. [Go Locations - Indexed Config Generation and Range Fallback](#5-go-locations---indexed-config-generation-and-range-fallback)
6. [Spawnpoint - Restart Helpers and Region-Wide Reset Commands](#6-spawnpoint---restart-helpers-and-region-wide-reset-commands)
7. [Housing - Region-Based Placement Restrictions](#7-housing---region-based-placement-restrictions)
8. [Naming and Identity - Town-Suffix Exploit Closure and Validation Hardening](#8-naming-and-identity---town-suffix-exploit-closure-and-validation-hardening)
9. [Performance - Shutdown Time and Hot-Path Algorithm Fixes](#9-performance---shutdown-time-and-hot-path-algorithm-fixes)
10. [Crafting - Omega Cache Integration Fixes](#10-crafting---omega-cache-integration-fixes)
11. [Omega Cache - Potion Categorization Fix](#11-omega-cache---potion-categorization-fix)
12. [Gameplay Tuning and Script Fixes](#12-gameplay-tuning-and-script-fixes)
13. [Support Data and Tooling](#13-support-data-and-tooling)
14. [Staff Tooling - Character/Account Audit Panel and Name/Death/Poison/Note Tracking](#14-staff-tooling---characteraccount-audit-panel-and-namedeathpoisonnote-tracking)
15. [No Damage Zone - New Area Policy](#15-no-damage-zone---new-area-policy)
16. [Areas Admin Gump - Categorized Display, Info Popup, Page Jump](#16-areas-admin-gump---categorized-display-info-popup-page-jump)
17. [Combat - Shield Zone-Coverage Fix](#17-combat---shield-zone-coverage-fix)
18. [Omega Cache - Permanent Lockout Fix](#18-omega-cache---permanent-lockout-fix)
19. [Class Firsts - Datafile Migration](#19-class-firsts---datafile-migration)
20. [Town NPC AI - Script Halt on Jail/Kill](#20-town-npc-ai---script-halt-on-jailkill)
21. [Multi/Boat Data Corrections](#21-multiboat-data-corrections)
22. [Exhaustive File-by-File Change List](#22-exhaustive-file-by-file-change-list)
23. [Risk and Regression Notes](#23-risk-and-regression-notes)

---

## 1. Scope Summary

Patch 1.0.8 grew across two work windows. The first (through `a3c99f6`) was dominated by the datafile-backed area policy rewrite, the go-location indexing pass, and the player-run townstone/admin cleanup — see sections 3, 5, and 6 for that material, carried forward unchanged from the earlier draft of this document.

The second window (`7bdc099` through `b347427`) closed a live-reported name-collision exploit, fixed a duplicate-character bug it was related to, added region-based house placement restrictions, fixed a real performance regression in the areas package and in two hot commands, and completed Omega Cache integration for two crafting scripts that had been missed or left broken during the original cache rollout:

- A town-suffix name-collision exploit was closed: players could no longer hold both "X" and "X of Town" at once, town names are now blocked in freely-chosen names, and name comparisons are case-insensitive.
- A live 50-second rename-gump hang, and a resulting duplicate-character bug ("two Paladin Rahl of Occlo"), were root-caused to an O(accounts x 5) full `regions.cfg` re-parse per name check, and fixed with a proper cache.
- Staff rename paths (`.setprop name`, `.setname`, `.info`'s rename button) now run through the same name validation as player-initiated renames, scoped to player characters only.
- House placement now blocks city, dungeon, shrine, and graveyard regions by footprint (not just a single point check), replacing an older, narrower check.
- The area-policy mask lookup (`GetPolicyMask`) is now cached; it was previously hitting the datafile subsystem on every single area-policy check, including every AI tick for every mobile shard-wide.
- Two independent O(n^2) algorithms (`.go`'s location-reorder pass, and a shared multi-array sort used by `.gotomulti`/`.gotoboat`) were replaced with linear/O(n log n) equivalents after script-log evidence showed both tripping the runaway-script watchdog.
- The smithy hammer's Omega Cache targeting path was found to be dead code due to a bad merge and was rewritten to match every other crafting script's pattern; the crafter-boost smithy retort had never been integrated with the cache at all and now is.
- A gap in the Omega Cache's category map left 12 leveled potion objtypes (Greater Strength/Cure Potion tiers, etc.) falling into the "Other" bucket instead of "Potions."

A third window (`7c27772`) added a full staff-facing character/account audit tool and wired full name-change, death, poisoning, and account-note tracking into every script that touches them — see section 14. Two additional commits landed in this range (`b347427`, `232ee95`); `b347427`'s crafting/performance/potion-category work is already covered above (sections 9-11), and `232ee95` (a townstone treasury-race, election-cleanup, and townlist-bootstrap fix pass) is not detailed in this document.

A fourth window (`535e60d` through `676adfb`) added a new **No Damage Zone** area policy — a stronger sibling to Safe Area that structurally blocks combat, looting, and magic rather than just nullifying damage — with backstops at every layer that could otherwise deal damage, plus proper tamed-pet confiscation/mount-storage handling. Alongside that:

- A real combat balance bug was fixed: 17 shields had an erroneous `Coverage Hands` tag that made the engine treat them as flat zone-based armor contributors instead of routing through the intended parry-only shield formula, silently granting permanent bonus AR whether or not a parry ever succeeded.
- A live "Omega Cache permanently stuck open" bug was fixed — a server restart could make the anti-double-open guard read as satisfied millions of seconds in the future, wedging the cache shut until real uptime caught up.
- "First to reach class level" tracking was migrated off ad-hoc global CProps onto a proper keyed datafile.
- A bug where jailed/killed town NPCs kept executing their script afterward (instead of stopping) was fixed across all four townsfolk AI scripts, and a related tamed-pet `Follow()` desync was fixed.
- The `.areas` admin gump was reorganized (categorized area list, an info popup, a page-jump control) to stay usable at 200+ entries, and `config/multis.cfg` had a batch of boats and non-house placeable structures that were mislabeled `House` corrected to `Boat`/`Multi` so house-only tooling (including this patch's new footprint-based placement restrictions) doesn't misidentify them.

---

## 2. Commit Timeline

| Commit | Date | Message |
|--------|------|---------|
| `32a2b3a` | 2026-06-20 | backup script path restore |
| `dbfbe79` | 2026-07-20 | Areas fix for lord british castle and blackthornes |
| `a3c99f6` | 2026-07-20 | Bunch of patches for player run towns |
| `7bdc099` | 2026-07-20 | Patch Notes and save datafile error |
| `065ed28` | 2026-07-20 | House placement not allowed in cities |
| `21bb91e` | 2026-07-23 | Name Change update |
| `09bf876` | 2026-07-23 | Areas Fix, and naming fixes |
| `b347427` | 2026-07-23 | Patch notes, and fixes for omega cache, as well as optimization for go gomulti and goboat (see sections 9-11) |
| `232ee95` | 2026-07-23 | Townstone fixes, Minstel and townsfolk fix (not detailed in this document) |
| `7c27772` | 2026-07-23 | New test panel up along with datafiles (see section 14) |
| `535e60d` | 2026-07-23 | Patchnotes (v1.0.8 write-up; meta-commit, no functional changes) |
| `676adfb` | 2026-07-28 | Many updates and fixes to Areas; Fix for Gm shields no more coverage of hands; Omega permanent lockout fix; New area function no damage zone; Class firsts moved to datafile (see sections 15-21) |

---

## 3. Townstones - Player-Run Town Administration and Membership Cleanup

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/townstones/textcmd/admin/createtownstone.src` | Creation flow tightened around existing live stones, townlist insertion, and state restoration from the datafile |
| `pkg/opt/townstones/textcmd/admin/removetownmember.src` | New targeted town-member removal command with election and poll cleanup plus datafile sync |
| `pkg/opt/townstones/textcmd/admin/townbankstatus.src` | Large admin gump expansion for treasury, upgrades, donations, availability, purchase state, member management, and deletion |

### Notable Functional Changes

- `townbankstatus` now surfaces and mutates more live town state:
  - treasury gold,
  - population,
  - upgrades enabled or disabled,
  - donations enabled or disabled,
  - player-town availability,
  - player-town purchased state,
  - purchase price,
  - townstone presence,
  - and region deletion when safe.
- Member management now removes citizens more carefully:
  - account membership is removed from the stone's citizen list,
  - per-character `town` properties are cleared,
  - town suffixes are stripped from character names,
  - population and vote counts are refreshed,
  - elections and polls are cleaned up if the removed member was involved.
- `removetownmember` is a direct targeted cleanup path for staff workflows.
- `createtownstone` now checks for active and live conflicts more aggressively before creating a new stone.
- Townstone state sync now persists the current stone serial, mayor data, population, election flags, poll flags, candidate list, vote totals, vote percentage, timer, and citizen list back into the datafile.

---

## 4. Areas - Policy Engine Rewrite, Realm Sanitization, and Mask-Value Cache

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/areas/include/areapolicy.inc` | New datafile-backed policy engine, parsed-line cache, global bypass masks, realm-name sanitization, and a mask-value cache |
| `pkg/opt/areas/include/areapolicy.inc.bak` | Backup copy of the pre-rewrite policy implementation |
| `pkg/opt/areas/textcmd/admin/areas.src` | Rewritten `.areas` admin gump for viewing and toggling area policy flags |
| `pkg/opt/areas/EnterAreaDelay.src` | Updated to use the new policy resolver path |
| `pkg/opt/areas/LeaveArea.src` | Updated to use the new policy resolver path |
| `pkg/opt/areas/areaban.src` | Updated to use the new policy resolver path |
| `pkg/opt/areas/areas.cfg` | Area definitions refreshed, including the Lord British Castle and Lord Blackthornes Castle fix |
| `scripts/include/areas.inc` | Shared area helpers updated for the new resolver model |
| `scripts/include/anchors.inc` | Anchor and lookup helpers updated to cooperate with the new area model |

### Notable Functional Changes

- The area policy layer now lives in a dedicated resolver backed by per-realm datafiles:
  - masks are stored per area id,
  - a world-catchall bypass mask is OR-merged from known global ids (`feluccawholeworld`, `wholeworld`, `britannia`, `trammelwholeworld`) — confirmed still a one-directional OR merge, so a whole-realm flag (e.g. setting Felucca or Britannia to RP) can force a policy bit on everywhere in that realm, but an individual area still can't opt back out of it since OR can't clear a bit,
  - parsed area lines are cached both per program and in a global property,
  - cache invalidation is fingerprinted by source line count.
- The admin `.areas` workflow now works as a single gump-driven editor for common policy flags such as guarded, no recall, no marking, anti-magic, forbidden, no looting, safe-area, no-PK, and RP-area behavior.
- `areas.cfg` includes the specific Lord British Castle and Lord Blackthornes Castle boundary fix from `dbfbe79`.
- The hot-path area checks now resolve through the new policy layer instead of repeatedly re-parsing config lines.
- **Realm-name sanitization (`7bdc099`):** every realm-taking function in `areapolicy.inc` (`GetRealmAreaLines`, `GetParsedRealmAreaLines`, `ResolveAreaMatchAtLocation`, `ResolvePolicyAtLocation`, `GetGlobalBypassMask`, `GetRealmPolicyDescriptor`) previously did a bare `Lower(CStr(realm))`. A new `SanitizePolicyRealm(realm)` now falls back to `"britannia"` whenever the incoming realm is blank or the literal string `"<uninitialized object>"`, fixing a datafile-save error that occurred when a realm value hadn't been initialized yet.
- **Mask-value cache (`09bf876`):** `GetPolicyMask(realm, area_id)` was hitting the datafile subsystem (`OpenDataFile` + `FindElement` + `GetProp`) on every single area-policy check, and `GetGlobalBypassMask()` calls it 4 more times per resolve for the world-catchall ids — up to 5 datafile round trips per check, on every AI tick for every mobile shard-wide. `GetPolicyMask` is now backed by a per-realm `dictionary` (`area_id -> mask`), cached both per-program and in a `GlobalProperty` (`zh.areapolicy.maskcache.<realm>`), using `.Exists()` rather than truthiness so a cached mask of `0` (the common case) isn't mistaken for "not cached." The cache is invalidated precisely on `SetPolicyMask()` writes (single area id) and wholesale on `PruneStaleRealmPolicies()` (whole-realm bulk delete). This mirrors the existing parsed-line cache and was verified against the ZH3.0 sibling repo's simpler (no world-catchall) implementation for reference before implementing.

---

## 5. Go Locations - Indexed Config Generation and Range Fallback

### Files Changed

| File | Change |
|------|--------|
| `config/golocs_by_id.cfg` | New generated index of go locations by region id, realm, type, range, and GoLoc metadata |
| `config/command_synopses.cfg` | Updated synopsis entry for `.go` and new supporting commands |
| `pythonscripts/generate_golocs_by_id.py` | New generator that builds the indexed go-location config from region data |
| `scripts/textcmd/coun/go.src` | `.go` rebuilt around the indexed go-location config, facet selection, type ordering, and range fallback |
| `regions/regions.cfg` | Massive region metadata expansion to feed the new go-location generator |

### Notable Functional Changes

- `.go` now reads `golocs_by_id.cfg` instead of the older ad hoc config path.
- Regions can now be resolved from either:
  - an explicit `GoLoc`, or
  - the center point of the configured `Range`.
- A `dnp` `GoLoc` value is treated as an intentional skip.
- `0,0,0` explicit coordinates are treated as a placeholder and are replaced from the range center when possible.
- Location ordering is normalized by type (`Jail`, `City`, `Shrine`, `Graveyard`, `Dungeon`, `POI`, `None`) before any leftover entries are appended. See section 9 for the algorithmic rewrite of this ordering pass.
- The generator script exists so the index can be rebuilt from `regions.cfg` instead of hand-maintaining the go list.

---

## 6. Spawnpoint - Restart Helpers and Region-Wide Reset Commands

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/spawnpoint/include/restartspawnpoint.inc` | Shared restart helper extracted for normal restart and max-fill modes |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpoint.src` | Restart command updated to use the shared helper and report next spawn timing |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | New region-wide restart and restartmax command that iterates spawnpoints by selected location ranges |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointmax.src` | Force-fill command updated to use the shared helper and report fill counts |
| `pkg/opt/spawnpoint/config/groups.cfg` | Spawnpoint group config adjusted to support the new region restart workflow |

### Notable Functional Changes

- `RestartSpawnPointWithMode(...)` now encapsulates the restart and max-fill logic:
  - normal restart clears active spawned objects and schedules the next spawn based on the configured frequency,
  - max-fill temporarily enables the group flag if needed, repeatedly checkpoints until the target max is reached, then restores the original group flag.
- `.restartspawnpoint` now reports the next spawn delay after the restart.
- `.restartspawnpointmax` now reports the number of spawned objects relative to the configured maximum.
- `.restartspawnpointarea` is a new command that:
  - lets staff choose a facet,
  - then choose a location from the `golocs_by_id.cfg` index,
  - then restarts every spawnpoint whose coordinates fall inside that location's configured ranges.

---

## 7. Housing - Region-Based Placement Restrictions

### Files Changed

| File | Change |
|------|--------|
| `pkg/std/housing/housedeed.src` | House placement now checked against region types by footprint; dungeon/system-teleporter proximity check extracted into a helper |

### Notable Functional Changes

- Replaced the old single-tile `CheckCity(character)==1` check (which only tested the placing character's own location) with `IsHousePlacementBlockedByRegionType(housetype, where, region_type)`, called once each for `"city"`, `"dungeon"`, `"shrine"`, and `"graveyard"`. This computes the house's full footprint via `GetHouseFootprintBounds(housetype, x, y)` (multi dimensions applied to the placement point) and rejects placement if that footprint overlaps any `regions.cfg` region of the matching `Type`, scoped to the placing character's realm.
- `NormalizeRegionType(region_type)` lowercases and validates the region-type string used for comparison against `regions.cfg`'s `Type` field.
- The old inline dungeon-item / system-teleporter proximity checks (`ListObjectsInBox` scans for objtype `0xa3c8` and `0x6200`) were extracted into `IsHousePlacementBlockedByNearbySpecialObjects(where)`, which returns the rejection message directly instead of duplicating the `ListObjectsInBox` scan and message send inline.
- Staff (`character.cmdlevel >= 4`) are unaffected — all of the above is still gated behind the existing `if (character.cmdlevel < 4)` check.

---

## 8. Naming and Identity - Town-Suffix Exploit Closure and Validation Hardening

### Files Changed

| File | Change |
|------|--------|
| `scripts/include/NameChecker.inc` | Town-suffix-aware duplicate detection, case-insensitive comparison, whitespace normalization, bad-spacing rejection, and caching |
| `pkg/opt/townstones/tstone.src` | `Citizenship()`/`CanselCityzenship()` now duplicate-check before applying a town-suffixed or stripped name |
| `scripts/misc/namechanger.src` | Passes `force_town_check := 1`; added "bad spacing" error message |
| `scripts/misc/oncreate.src` | Passes `force_town_check := 1` |
| `scripts/textcmd/admin/setname.src` | `.setname` now runs through `CheckName`, scoped to player characters only |
| `scripts/textcmd/gm/setprop.src` | `.setprop name` now runs through `CheckName`, scoped to player characters only |
| `scripts/textcmd/seer/info.src` | `.info`'s rename button now runs through `CheckName`, scoped to player characters only |

### Background

A live exploit was reported: a player could join a town as "X" (becoming "X of Town"), create a second character also named "X" on an alt, then leave the town (reverting the first character to bare "X"), ending up holding both "X" and "X of Town" simultaneously — and bypass case-sensitivity to also claim near-duplicates like "Bop"/"bop"/"BOP". Investigating this also surfaced a live duplicate-character bug (two characters both named "Paladin Rahl of Occlo") and a report of a ~50 second hang with stacked rename gumps after a related fix — both root-caused and fixed here.

### Notable Functional Changes

- **`GetKnownTownNames()`** — replaces the old static `bLTowns`-only blacklist scan with a merged list from three sources: the static `bLTowns` fallback, every `City=1` region in `regions.cfg` (covers player-run townstone regions), and `GetGlobalProperty("townlist")` (covers a townstone whose region entry was later removed). Cached per-program and in a `GlobalProperty` (`zh.namechecker.knowntownnames`); `InvalidateKnownTownNamesCache()` is exposed but not yet wired to any call site (regions.cfg is effectively static at runtime today).
- **`StripTownSuffix(name, town_names := 0)`** — strips a trailing `" of <Town>"` for any known town so name-uniqueness comparisons treat `"a pig"` and `"a pig of Trinsic"` as the same identity, closing the join/leave/alt exploit above. Accepts an optional pre-fetched `town_names` list to avoid recomputing it in a loop.
- **`NormalizeNameForCompare(name)`** — lowercases, collapses runs of interior spaces to one, and trims leading/trailing spaces before comparison.
- **`IsNameTaken(candidate_name, exclude_serial := 0)`** — scans up to 5 character slots per account, comparing `NormalizeNameForCompare(StripTownSuffix(name, town_names))`, case-insensitively, excluding `exclude_serial`. Replaces the old exact-string, case-sensitive comparison in `CheckName` (which never caught `"Bop"` vs `"bop"`).
- **`CheckName(name, who := 0, force_town_check := 0)`** — new `force_town_check` parameter: pass `1` whenever the player is actively choosing a brand-new name (character creation, the rename gump, staff rename tools) so town names are always blocked regardless of the player's current town membership; login/reconnect revalidation of an already-assigned, legitimately town-suffixed name leaves this `0`. Also added an unconditional bad-spacing rejection (`name[1] == " " || name[len(name)] == " " || find(name, "  ", 0)`) — leading/trailing/doubled spaces were technically "legal characters" under the old per-character validation loop, but let a base name like `"Rahl "` silently become `"Rahl  of Town"` once a town suffix was appended, evading exact-match duplicate detection. This check is unconditional (not gated by `force_town_check`), so it also self-heals an already-malformed stored name on next login revalidation — this is exactly how the shard's one existing malformed record (`"Paladin Rahl  of Occlo"`, confirmed via `data/pcs.txt` to be the only such record shard-wide) will get caught and forced through a rename.
- **`pkg/opt/townstones/tstone.src`**: `Citizenship(who, item)` now computes the candidate town-suffixed name and calls `IsNameTaken()` before any state mutation, aborting with a message if the resulting name is already in use, rather than mutating town membership and then blindly assigning a colliding name. `CanselCityzenship(who, item)` (leave-town) computes the stripped base name, and if `IsNameTaken()` finds it colliding, sets the character's name to `"AlreadyUsed"` and force-starts `misc/namechanger` instead of blocking the leave — citizen-list removal, population decrement, and the `town` property erasure all still proceed unconditionally, so the player isn't stuck in town membership limbo while they pick a new name.
- **Staff rename paths** now validate through the same `CheckName()` path as player-driven renames, all explicitly scoped to player characters (`what.acct` / `targ.acct` / `who.acct` checks) so NPC renaming by staff is untouched:
  - `.setname` (`scripts/textcmd/admin/setname.src`)
  - `.setprop name` (`scripts/textcmd/gm/setprop.src`)
  - `.info`'s rename button (`scripts/textcmd/seer/info.src`)
- **Performance root cause (the 50-second hang):** the original `IsNameTaken`/`StripTownSuffix` implementation called `GetKnownTownNames()` (a full `regions.cfg` re-parse) on every character-slot comparison. With 5,169 accounts x up to 5 slots, that was ~25,000 redundant full-config re-parses per `CheckName` call — the direct cause of the reported hang and stacked rename gumps. Fixed by hoisting `GetKnownTownNames()` to once per `IsNameTaken`/`CheckName` call (passed through as a parameter) and adding the cache described above.

---

## 9. Performance - Shutdown Time and Hot-Path Algorithm Fixes

### Background

Investigated a live report that "POL Cleanup" during shutdown takes noticeably longer since the areas-to-datafile migration, alongside a slow ~1 hour post-startup CPU stabilization period. `log/script.log` showed the runaway-script watchdog firing on `scripts/textcmd/coun/go.ecl` (3 times) and `pkg/opt/alryc/textcmd/test/gotomulti.ecl` (2 times) — both algorithmic, not areas-related. Note: `log/pol.log` does not capture the console-only cleanup messages, so the runaway scripts are strong circumstantial evidence and worthwhile independent fixes on their own merits, not a proven root cause of the shutdown-time regression specifically (the areas mask-value cache in section 4 is the more directly-implicated fix for that).

### Files Changed (uncommitted)

| File | Change |
|------|--------|
| `scripts/textcmd/coun/go.src` | `ReorderLocationsForDisplay()` rewritten from an O(n^2)*8 pass to a single O(n) bucketing pass |
| `scripts/include/string.inc` | `SortMultiArrayByIndex()` rewritten from an O(n^2) selection sort to an O(n log n) iterative bottom-up merge sort |

### Notable Functional Changes

- **`.go`'s `ReorderLocationsForDisplay()`**: previously called `AppendLocationsByType()` once per type bucket (Jail/City/Shrine/Graveyard/Dungeon/POI/None — 7 passes), each of which rescanned the entire, continuously-growing `ordered` output list via `LocationAlreadyAdded()` for every candidate to dedupe by `Id` or by `Name+X+Y+Z+R` — effectively O(n^2) x 8 passes total (7 typed + 1 final catch-all). With ~200 Britannia go-locations alone, this was heavy enough to trip the runaway-script watchdog. Rewritten as a single O(n) pass: build a `LocationDedupeKey(loc)` (prefers `"id:<Id>"`, falls back to `"xy:<Name>:<X>:<Y>:<Z>:<R>"`), dedupe against a `seen` dictionary once, bucket by `GetLocationTypeLabel()` into a `dictionary` of arrays, then emit known-type buckets in priority order followed by any custom/unrecognized-type entries in original encounter order. Output ordering is unchanged from the old implementation; only the algorithm changed. `AppendLocationsByType()` and `LocationAlreadyAdded()` were removed (confirmed via repo-wide grep that nothing else referenced them).
- **`SortMultiArrayByIndex(MultiArray, SubIndex)`** (`scripts/include/string.inc`): previously an O(n^2) nested-loop selection sort. Rewritten as an iterative bottom-up merge sort (O(n log n)) via a new `MergeRunsByIndex(MultiArray, low, mid, high, SubIndex)` helper, same ascending-by-`SubIndex` output ordering. This is a shared include used by both `pkg/opt/alryc/textcmd/test/gotomulti.src` (`SortHouseMultisByLastLogin`, sorting up to 418 multi records) and `gotoboat.src` (`SortBoatsByLastLogin`) — fixing it here benefits both call sites without touching either file. The merge-loop write-position variable was originally named `out`, which is a reserved word in EScript/POL; renamed to `write_idx`.

---

## 10. Crafting - Omega Cache Integration Fixes

### Files Changed (uncommitted)

| File | Change |
|------|--------|
| `pkg/std/blacksmithy/make_blacksmith_items.src` | `use_hammer` rewritten so Omega Cache targeting is reachable; dead/duplicate legacy code removed |
| `pkg/opt/crafterboost/make_crafter_boosts.src` | Full Omega Cache integration added (previously backpack-only) |

### Notable Functional Changes

- **Blacksmithy (`make_blacksmith_items.src`)**: `use_hammer` previously performed an unconditional `ReserveItem(use_on)` and an unconditional `IsInContainer(character.backpack, use_on)` check *before* any Omega Cache objtype check — unlike every other cache-integrated crafting script (`alchemy.src`, `tinkering.src`, `carpentry.src`, `make_cloth_items.src`, `cooking.src`, `cartography.src`, `inscription.src`), which all check for the cache objtype first. Since the Omega Cache container is a placed house item, it's never "in your backpack," so targeting the cache directly for a plain ingot craft failed with "That item has to be in your backpack." before ever reaching the cache-handling code lower in the file. The only path that worked was the bone-armor sub-flow (target a bone item from backpack first, then target the cache when prompted for ingots), because that second `Target()` call bypassed the broken top-level check. The file also had two near-duplicate copies of the bone/ingot crafting logic (apparent leftover from a bad merge when cache integration was added), including a fallthrough where "no anvil nearby" would silently retry the same target as a plain ingot craft. Rewrote `use_hammer` to check for the cache objtype first (matching the established pattern across the codebase), and factored the repeated ingot-targeting logic into `ResolveIngotTarget(character)` and the anvil-proximity check into `NearAnvil(character)`.
- **Crafter boosts (`make_crafter_boosts.src`)**: the smithy retort (crafting Oil/Alloy/Varnish/Compound/Recharge Powder from Brimstone/Bloodspawn/Daemon Bone/Bat Wing/Dragon's Blood plus an ingot, log, hide, or gem) had never been integrated with the Omega Cache — it didn't include `resourcemanager.inc` and used the plain backpack-only `FindSubstance`/`ConsumeSubstance` helpers throughout, so it would simply stop (insufficient-materials path) if a player ran out of the targeted material in their backpack, regardless of whether a nearby cache had more. Added `resourcemanager`/`omegacache_utils` includes and converted both the explicitly-targeted material and the implicit fixed reagent (which the player never targets directly) to `ResourceRequest`s:
  - The initial target and the Brimstone-combine second target now both check for `OMEGACACHE_OBJTYPE` and route through `SelectMaterialFromCache()`, matching the established pattern.
  - A new `MakeReagentRequest(who, objtype)` builds a backpack-first, cache-fallback `ResourceRequest` for the fixed reagent (mirrors `MakeBackpackRequest()`, but without needing a physical item reference, since the reagent is never targeted by the player).
  - `LeaseResource`/`ExtendResourceLease`/`ReleaseResourceLease`/`ConsumeResource`/`GetAvailableResource` now drive both materials through the crafting loop, matching `MakeBlacksmithItems`'s pattern; the loop's early-exit paths (missing empty flask, can't reach it, can't reserve it) now `break` instead of `return`, so `AutoLoop_finish()` always runs.
  - A small `ObjtypeStruct(objtype)` helper lets the existing item-based `IsIngot`/`IsLog`/`IsGem2` (which only ever read `.objtype` off their argument) be reused against a bare objtype from a cache selection, instead of duplicating their range logic locally.
  - Scope note: the empty-flask consumption for the Recharge Powder product line remains backpack-only (unchanged) — flasks were out of scope for this fix.

---

## 11. Omega Cache - Potion Categorization Fix

### Files Changed (uncommitted)

| File | Change |
|------|--------|
| `pkg/opt/omegacache/categories.cfg` | Added 12 missing leveled-potion objtypes to the `Potions` category |

### Notable Functional Changes

- `categories.cfg`'s `Potions` category had two adjacent documented ranges — "Mage-class potion variants (0xFF19-0xFF3F)" ending at `0xFF40`, and "AlchemyPlus potions (0xFF4E-0xFF95, 0xFFA2)" starting at `0xFF4E` — with a gap at `0xFF41`-`0xFF4D` that neither range covered. That gap is exactly where `pkg/std/alchemy/itemdesc.cfg`'s leveled potion tiers live: Strength Potion [Level 2] (`0xFF41`), Greater Strength Potion [Level 1-3] (`0xFF42`-`0xFF44`), Cure Potion [Level 1-3] (`0xFF45`-`0xFF47`), and Greater Cure Potion [Level 1-5] (`0xFF48`-`0xFF4C`). Since `BuildCategoryMap()` in `omegacache.inc` defaults any unmatched objtype straight to `"Other"`, these 12 potions were showing up in the wrong category bucket in the cache UI. Added all 12 objtypes to the `Potions` category, closing the gap. Confirmed via a full cross-reference of `pkg/std/alchemy/itemdesc.cfg` against `categories.cfg` that no other alchemy objtypes have a similar gap. Cosmetic UI-grouping fix only — no gameplay value changes.

---

## 12. Gameplay Tuning and Script Fixes

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/alchemyplus/newpotions.src` | Protection-style potion duration increased significantly |
| `pkg/opt/holybook/removecurse.src` | Remove Curse success chance changed; paladins now use magery and magic resistance for the roll |
| `pkg/opt/shilhook/shilhook.src` | Skill gain and difficulty checks refactored to use a separate gain skill and a clearer chance calculation |
| `pkg/packethooks/speech/receivespeechhook.src` | Unicode speech packet decoding now uses the native Unicode string path instead of the older CChrZ conversion |
| `pkg/std/treasuremap/treasure.cfg` | One buried treasure coordinate was adjusted |
| `pkg/opt/alryc/README.txt` | Stale README removed during the command and tooling reshuffle |
| `scripts/ai/noble.src` | Nobles now begin wandering immediately after spawn |
| `scripts/ai/person.src` | Generic town NPCs now begin wandering immediately after spawn |
| `scripts/ai/setup/criersetup.inc` | Crier setup now guards missing config more safely and defaults the flee point cleanly |
| `scripts/ai/townperson.src` | Town NPC startup now begins wandering immediately after spawn |
| `scripts/ai/townsfolk.inc` | Townfolk helper updated to stay aligned with the new spawn and movement behavior |
| `scripts/EquipTemplateValidation.src` | Boot-time equip-config validator deduplicated: removed a dead `else` branch, extracted a shared `ValidateEquipEntries()` used across Armor/Weapon/Equip instead of three near-identical inline blocks |

### Notable Functional Changes

- Protection effects now last much longer; the underlying strength is unchanged but the duration calculation was extended.
- Remove Curse is now more class-aware:
  - paladins use magery and magic resistance,
  - other casters still use the earlier item-identification-based path.
- Skill gain now uses a cleaner distinction between the skill used for the difficulty check and the skill used for gain calculations.
- The speech hook fix keeps staff speech logging working even when the packet contains Unicode speech data.
- Town NPCs no longer sit idle right after spawn; they start their wander cycle immediately.
- Crier setup became more defensive around missing NPC config entries.
- `EquipTemplateValidation.src` is a one-shot boot-time validator (~1,279 entries) — the cleanup is a code-quality/maintenance change, not a meaningful perf contributor on its own.

---

## 13. Support Data and Tooling

### Files Changed

| File | Change |
|------|--------|
| `ZHO-DataBackup.ps1` | Data backup destination moved to the Koofr path; the log backup line is now commented out |
| `config/command_synopses.cfg` | Synopsis coverage refreshed for the new staff commands and the updated `.areas`, `.go`, `.restartspawnpoint*`, `.playerruntowns`, `.whereat`, and related entries |
| `pkg/opt/alryc/textcmd/test/gotoboat.src` | New developer command to list boats and teleport to the selected tillerman |
| `pkg/opt/alryc/textcmd/test/gotomulti.src` | New developer command to list house multis and teleport to the selected sign |
| `pkg/opt/alryc/textcmd/test/makecheck.src` | New developer command to create a bank cheque |
| `pkg/opt/alryc/textcmd/test/whereat.src` | New developer command to inspect the location details of a selected mobile, item, or map tile |
| `pol.cfg` | Profiling and sysload watchers were enabled for better live diagnostics |

### Notable Functional Changes

- The backup script now writes to the Koofr-backed destination used by the shard.
- The command synopsis file now covers the new or updated admin and developer commands so they show up in the command browser and help surface.
- The new `alryc` test commands are staff and developer tools and are not intended to affect regular gameplay.

---

## 14. Staff Tooling - Character/Account Audit Panel and Name/Death/Poison/Note Tracking

### Files Changed

| File | Change |
|------|--------|
| `pkg/opt/admin/pkg.cfg` | New minimal package, created solely to give the new datafile a registered namespace (`data/ds/admin/`) |
| `pkg/opt/admin/include/adminpanel.inc` | New shared data layer: name/death/poisoning/account-note history recording, retrieval, and summary building |
| `pkg/opt/admin/textcmd/test/testadminpanel.src` | New `.testadminpanel` staff gump: account browsing and full character audit history |
| `config/cmds.cfg` | Added `DIR pkg/opt/admin/textcmd/test` under the `Test` cmdlevel block |
| `scripts/include/NameChecker.inc` | Added `NameCheckFailureReason(reason_code)` to translate a `CheckName()` rejection code into a human-readable reason |
| `scripts/textcmd/gm/setprop.src` | Fixed a trailing-space bug in the value-rebuild loop; `.setprop name` now shows the real rejection reason and records the change |
| `scripts/textcmd/admin/setname.src` | `.setname` now shows the real rejection reason and records the change |
| `scripts/textcmd/seer/info.src` | `.info`'s rename button and `fixnameguild` now show the real rejection reason (rename button) and record the change |
| `scripts/textcmd/gm/changename.src` | `.changename` now records the change |
| `scripts/textcmd/test/editcharacter.src` | `.editcharacter` now records the change |
| `pkg/commands/commands/gm/mobedit.src` | `mobedit`'s name field now records the change |
| `pkg/opt/spawnpoint/textcmd/admin/newmobedit.src` | `newmobedit`'s name field now records the change |
| `scripts/misc/namechanger.src` | The player rename gump now records the change |
| `scripts/items/racegate.src` | Race-gate name suffixing now records the change |
| `pkg/opt/roleplaying/rperstone.src` | RPer faction join (`[RPer]` suffix) now records the change |
| `scripts/textcmd/admin/removerper.src` | RPer faction removal (name restore) now records the change |
| `scripts/textcmd/admin/admin.src` | `admin.src`'s `fixnameguild` now records the change; the NOTES action now records an account note |
| `scripts/misc/chrdeath.src` | Character death now records a death entry (killer, killer's account, coordinates) |
| `scripts/include/dotempmods.inc` | `SetPoison()` now records a poisoning entry alongside the existing `PoisonedBy` cprop |
| `scripts/textcmd/coun/notes.src` | `.notes` now records an account note (Staff-initiated) |
| `pkg/opt/loot/antiloot.inc` | `AutoJail()` now records an account note (System-initiated) |
| `pkg/opt/spawnpoint/textcmd/admin/despawn.src` | Fixed `program` name (was still `forcespawn`, copy-pasted from that file); added a null/invalid-spawnpoint guard |
| `pkg/opt/spawnpoint/textcmd/admin/primespawn.src` | Same `program` name fix and null/invalid-spawnpoint guard as `despawn.src` |
| `pkg/opt/spawnpoint/textcmd/admin/forcespawn.src` | Added the same null/invalid-spawnpoint guard |
| `pkg/opt/spawnpoint/textcmd/admin/gotomobtype.src` | Removed a leftover debug `Print("stuff")` call |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | `ReorderLocationsForDisplay()` rewritten from the same O(n^2)*8-pass shape fixed for `.go` in section 9 to a single O(n) dedupe-and-bucket pass |

### Background

Building the audit panel required first finding every place in the codebase where a player character's name can actually change, so each one could be wired into the new tracking layer; that sweep turned up a live bug (`.setprop`'s trailing-space append, section 8 already covers the underlying `CheckName` bad-spacing rejection it was tripping) and several small pre-existing bugs in unrelated spawnpoint commands that were touched only incidentally while adding `RecordCharacterNameChange` calls to `newmobedit.src`'s neighbors.

### Notable Functional Changes

**New staff command `.testadminpanel` (Test cmdlevel):**
- Gump flow: choose "Account" -> pick a letter A-Z (5-column grid, dynamically sized to the letter count so it can't overflow) -> paged account list (8 per page, each row showing the account name as a button plus its IP and last login date) -> character list for that account -> character detail.
- `ShowCharacterList` (the account-landing screen) shows the account name, a "Notes" subtitle with the full word-wrapped latest account note (via the existing `GFWordWrap()` utility, so the gump is sized to the actual wrapped line count instead of truncating), an attribution line (`"- <initiator>, <timestamp>"` or `"- Unknown"`), a running count of stored note records, and then the account's characters as buttons.
- `ShowCharacterDetail` shows a "Character Information" title with "Names", "Killed By", and "Poisoned By" subtitled sections (10/5/5 most-recent-first respectively), each ending with a "more in datafile" total count.

**New shared data layer (`pkg/opt/admin/include/adminpanel.inc`):**
- One DataFile per account (`AdminPanelFilespec`, under `data/ds/admin/`), created in a dedicated new `admin` package purely because DataFile filespecs must resolve to a real, registered `pkg.cfg` package name.
- Name and death/poisoning history is keyed per character serial (a reserved `"_account_"` element key holds account-wide note history instead), so history stays attached to a character across renames rather than being keyed by name.
- Every recorded entry stores a timestamp (`FormatEpochTimestamp`), the recording script's name (`CurrentScriptName()`, via `GetProcess(GetPid()).name` - the same idiom `staff.inc`'s `LogCommand` already uses), and an initiator classification (`Staff`/`Player`/`System`).
- `TrimHistoryToLimit` caps every history array at 100 entries (`ADMINPANEL_MAX_HISTORY`), erasing from the front, applied on every write so none of the four tracked histories can grow unbounded.
- `RecordCharacterNameChange` only records when `mobile.isa(POLCLASS_MOBILE) && mobile.acct` - NPCs have no account and are never recorded, confirmed no hook fires on any NPC/template renaming path.
- The first time a character's name history is recorded, if history is empty, the character's pre-change name is bootstrapped in as an "unknown"-origin entry (blank script/initiator/timestamp) so a character that existed before this tracking was added isn't misattributed a fabricated origin.
- `RecordCharacterDeath` resolves the killer's account independently via `SystemFindObjectBySerial(killer_serial, SYSFIND_SEARCH_OFFLINE_MOBILES)` rather than depending on `chrdeath.src`'s existing online-only name resolution, so the killer's account still shows if they've since logged off.
- `RecordAccountNote`/`GetLatestNoteInfo`: the account's existing single `Notes` cprop remains the untouched source of truth for the note itself; a parallel `notes_history` array (also capped at 100) records every write with attribution. `GetLatestNoteInfo` cross-references the two by comparing note text and falls back to blank attribution if they don't match, so a note set through any not-yet-wired path is shown as `"Unknown"` rather than misattributed to the wrong staffer.

**Wiring - every character rename site found in the codebase now calls `RecordCharacterNameChange`, scoped to accounts only:**
- Staff-initiated: `.setprop name`, `.setname`, `.info`'s rename button, `.info`'s `fixnameguild`, `admin.src`'s `fixnameguild`, `.changename`, `.editcharacter`, `mobedit`/`newmobedit`, `.removerper`.
- Player-initiated: the rename gump (`namechanger.src`), race-gate name suffixing (`racegate.src`), and RPer faction join (`rperstone.src`, appending `" [RPer]"`).
- Account notes (`RecordAccountNote`): `.notes`, `.info`'s NOTES action, and `admin.src`'s NOTES action (all Staff-initiated); `antiloot.inc`'s `AutoJail()` (System-initiated, fires on repeat town-looting offenses).

**Bug fixes surfaced during the sweep:**
- `.setprop`'s value-rebuild loop appended a trailing space after every word, including the last (e.g. `"Paladin Rahl One "`), which silently tripped `CheckName`'s bad-spacing rejection while showing a generic "already in use" message that masked the real cause. Fixed the trailing space (`pval := pval[1, len(pval)-1];`) and added `NameCheckFailureReason()` so `.setprop`, `.setname`, and `.info`'s rename button all now show the actual rejection reason.
- `despawn.src` and `primespawn.src` both still had `program forcespawn(...)` as their program declaration (evidently copy-pasted from `forcespawn.src` when those two commands were created) instead of matching their own filenames; corrected, and a null/invalid-spawnpoint guard was added to both plus `forcespawn.src` itself.
- Removed a leftover debug `Print("stuff")` call in `gotomobtype.src`.
- `restartspawnpointarea.src` had its own copy of the same O(n^2)*8-pass location-reordering logic documented in section 9 for `.go`; rewritten to the identical single O(n) dedupe-then-bucket pattern (dedupe by `Key`, bucket by type label, emit known types in priority order, then unrecognized-type entries in original encounter order).

---

## 15. No Damage Zone - New Area Policy

### Files Changed

| File | Change |
|---|---|
| `pkg/opt/areas/include/areapolicy.inc` | New `AREA_POLICY_NO_DAMAGE_ZONE := 1024` bitflag |
| `pkg/opt/areas/include/areafunctions.inc` | New `SetNoDamageZoneProperties()`, `RemoveNoDamageZoneProperties()`, `StoreDonatorMountForNoDamageZone()`, `ConfiscateTamedPetForNoDamageZone()`; new `include ":housing:utility";` |
| `pkg/opt/areas/EnterAreaDelay.src` | Sets `InNoDamageZone` + sends "This is a NO DAMAGE zone." on entry, checked before the Safe Area block |
| `pkg/opt/areas/LeaveArea.src` | Clears `InNoDamageZone` on exit |
| `pkg/opt/areas/callguards.src` | Guards no longer spawn against a criminal/murderer/tamed-attacker who is inside a No Damage Zone |
| `pkg/systems/combat/include/hitscriptinc.inc` | `RecalcDmg()` and `DealDamage()` bail out (and clear war mode) if the defender is in a No Damage Zone — independent backstop, not skipped for NPC-vs-NPC like the NOPK checks |
| `pkg/systems/combat/banishonhit.src` | Bails out if either side is in a No Damage Zone |
| `pkg/systems/combat/banishscript.src` | Bails out if either side is in a No Damage Zone |
| `pkg/systems/combat/blackrockscript.src` | Bails out if either side is in a No Damage Zone (its summoned/animated branches apply guaranteed-lethal damage unconditionally and had no other guard) |
| `pkg/packethooks/packethook/packethook.src` | `OnTarget()` and `checkAttack()` reject targeting/attacking anything (PC or NPC) inside a No Damage Zone |
| `scripts/ai/combat/fight.inc` | Shared `Fight()` chokepoint: drops the opponent and clears war mode if it's in a No Damage Zone; kills or confiscates `me` if `me` is an NPC outside the zone attacking in |
| `scripts/ai/tamed.src` | Tamed pets have their own separate `Fight()` — duplicated the same check, confiscating (not killing) the pet |
| `scripts/include/areas.inc` | New `IsInNoDamageZone(who)`; `IsInAntiLootingArea()` and `IsInAntiMagicArea()` now also return true for a No Damage Zone |
| `scripts/include/skillpoints.inc` | Skill gain is blocked in a No Damage Zone the same way it already was in a Safe Area |
| `pkg/opt/areas/textcmd/admin/areas.src` | New "No Damage Zone" checkbox column; `RefreshOnlineAreaStatus()` now also syncs `InNoDamageZone` for online characters when config is saved |

### Overview

No Damage Zone is a new, stronger sibling to Safe Area: Safe Area grants invulnerability (damage still "happens" but is nullified), whereas No Damage Zone tries to stop combat from ever starting in the first place, backed up by hard returns at every layer that could otherwise apply damage (packethook targeting, `Fight()`, the three proc scripts, and the core damage-calc functions). GMs (`who.cmdlevel`) are exempt from the flag entirely.

### Notable Functional Changes

- `SetNoDamageZoneProperties(who)` sets `InNoDamageZone := 1` on `who`, but returns `0` immediately for staff (`who.cmdlevel`) without setting anything.
- A tamed pet ordered to attack into a zone from outside it is confiscated via `ConfiscateTamedPetForNoDamageZone()`, not simply blocked — donator mounts are stored to their mount stone (`StoreDonatorMountForNoDamageZone()`, mirroring `mountstone.src`'s `StoreMount()` but driven off the live mount mobile); everything else gets a confiscation ticket mailed to its master and is removed via `KillConfiscatedPet()`, the same pattern `tamed.src` already uses for NOPK/Guarded/Safe release violations.
- Explicitly **not** triggered by a pet merely being present, released, or dismounted inside the zone — an owner can walk a pet in and `.release`/`GoWild` it to populate an exhibit; once released it can't target or attack anyone anyway, so it's left alone. Only an explicit outside-in attack order is punished.
- `RecalcDmg()`/`DealDamage()` checks are deliberately *not* skipped for NPC-vs-NPC combat (unlike the existing NOPK checks) — they're a last-resort backstop in case damage reaches this point some other way (e.g. the flag toggling live mid-fight), since combat is already meant to be blocked upstream.
- `IsInAntiLootingArea()`/`IsInAntiMagicArea()` folding in the new flag means a No Damage Zone is automatically also a no-loot, no-magic area without needing the flag set twice per area line.

### Expected Impact

New tool for staff to designate zones (event areas, screenshots/roleplay hubs, hub cities, etc.) where PvP/PvE damage cannot occur at all, with tamed-pet handling that doesn't just strand a pet uselessly at the boundary.

---
