### PR TITLE
Patch update

### DIFF
--- a/pkg/opt/ArtifactSystem/championrelic.src
+++ b/pkg/opt/ArtifactSystem/championrelic.src
@@ -27,6 +27,11 @@ program championrelic(who, item)
 		return 0;
 	endif
 
+	if (IsInCityRegion(who))
+		SendSysMessage(who, "You cannot activate this relic in a city.", FONT_NORMAL, RELIC_FONT_COLOR);
+		return 0;
+	endif
+
 	var level := CInt(GetObjProperty(item, "MagicItemLevel"));
 	var templates;
 

--- a/pkg/packethooks/megacliloc/mobiledata.src
+++ b/pkg/packethooks/megacliloc/mobiledata.src
@@ -115,6 +115,16 @@ program mobiledata(parms)
 				allprops.append(prop);
 			endif
 
+			var masterserial := GetObjProperty(xObject, "master");
+			if (masterserial)
+				var petmaster := SystemFindObjectBySerial(masterserial, SYSFIND_SEARCH_OFFLINE_MOBILES);
+				if (petmaster)
+					prop.clilocid := 1070722;
+					prop.values := array {"Owner: " + petmaster.name};
+					allprops.append(prop);
+				endif
+			endif
+
 			elem_prot := GetObjProperty(xObject, "FireProtection");
 			if(elem_prot)
 				prop.clilocid := 1063492;

--- a/pkg/std/boat/boat.src
+++ b/pkg/std/boat/boat.src
@@ -4,6 +4,7 @@ use os;
 use uo;
 use boat;
 use vitals;
+use basic;
 
 include "include/eventid";
 include "include/myutil";
@@ -13,6 +14,8 @@ include "util/key";
 include "plankutil";
 include "include/random";
 include "include/res";
+include "util/bank";
+include ":housing:utility";
 
 const STATE_STATIONARY := 0;
 const STATE_MOVING := 1;
@@ -110,14 +113,27 @@ function CanCommandMe( who )
   return 1;
 endfunction
 
+function CheckBoatForBossMobiles()
+  foreach mob in (boat.mobiles)
+    if(mob.isa(POLCLASS_NPC) and (GetObjProperty(mob, "Boss") or GetObjProperty(mob, "SuperBoss") or GetObjProperty(mob, "Champion")))
+      ConfiscateBossPet(mob, "boat");
+    endif
+  endforeach
+endfunction
+
 function boat_script()
   RegisterForSpeechEvents( tillerman, 12 );
   var nextencounter := ReadGameClock()+120;
   var nextsound := ReadGameClock()+5;
+  var nextbosscheck := ReadGameClock();
   var driftcounter := 1;
   set_critical(1);
   var x,y;
   while (boat)
+    if ( ReadGameClock() > nextbosscheck )
+      CheckBoatForBossMobiles();
+      nextbosscheck := ReadGameClock()+10;
+    endif
     case (state)
 	  STATE_MOVING:     if ( ReadGameClock() > nextsound )
 				          PlayBoatSounds();

--- a/pkg/std/housing/signcontrol.src
+++ b/pkg/std/housing/signcontrol.src
@@ -52,7 +52,7 @@ program SignListener( sign )
 			if( mobile.serial in bans )
 				MoveObjectToLocation( mobile, sign.x, sign.y, (sign.z-5), sign.realm ,MOVEOBJECT_FORCELOCATION );
 			endif
-			if(mobile.isa(POLCLASS_NPC) and (GetObjProperty(mobile, "Boss") or GetObjProperty(mobile, "SuperBoss")))
+			if(mobile.isa(POLCLASS_NPC) and (GetObjProperty(mobile, "Boss") or GetObjProperty(mobile, "SuperBoss") or GetObjProperty(mobile, "Champion")))
 				ConfiscateBossPet(mobile);
 			endif
 			if(mobile.isa(POLCLASS_NPC) && !GetObjProperty(mobile,"WarriorForHire") && !GetObjProperty(mobile,"nextpay"))
@@ -300,65 +300,6 @@ function Demolish(house, sign)
 	endif
 	DestroyMulti( house );
 
-endfunction
-
-function ConfiscateBossPet(mobile)
-	var master_serial := GetObjProperty(mobile, "master");
-	if(!master_serial or mobile.script != "tamed")
-		// Wild boss — kill outright
-		KillConfiscatedPet(mobile);
-		return;
-	endif
-
-	var pet_name := mobile.name;
-
-	var master := SystemFindObjectBySerial(master_serial);
-	var master_online := 1;
-	if(!master)
-		master := SystemFindObjectBySerial(master_serial, SYSFIND_SEARCH_OFFLINE_MOBILES);
-		master_online := 0;
-	endif
-
-	if(!master)
-		KillConfiscatedPet(mobile);
-		return;
-	endif
-
-	var ticket := 0;
-	var ticket_location := "";
-	if(master_online)
-		ticket := CreateItemInBackpack(master, CONFISCATION_TICKET_OBJTYPE);
-		if(ticket)
-			ticket_location := "backpack";
-		endif
-	endif
-
-	if(!ticket)
-		var bankbox := FindBankBox(master);
-		if(bankbox)
-			ticket := CreateItemInContainer(bankbox, CONFISCATION_TICKET_OBJTYPE);
-			if(ticket)
-				ticket_location := "bank";
-			endif
-		endif
-	endif
-
-	if(!ticket)
-		KillConfiscatedPet(mobile);
-		if(master_online)
-			SendSysMessage(master, "Your pet " + pet_name + " was destroyed for entering a house. A claim ticket could not be created — your backpack and bank are full.", 3, 43);
-		endif
-		return;
-	endif
-
-	var fine := PopulateConfiscatedPetTicket(ticket, master_serial, mobile);
-
-	KillConfiscatedPet(mobile);
-
-	if(master_online)
-		SendSysMessage(master, "Your pet " + pet_name + " has been confiscated for entering a house.");
-		SendSysMessage(master, "A claim ticket has been placed in your " + ticket_location + ". Visit an Animal Trainer and pay " + fine + "gp to reclaim it.", 3, 43);
-	endif
 endfunction
 
 function InsideTent(who,house)

--- a/pkg/std/housing/utility.inc
+++ b/pkg/std/housing/utility.inc
@@ -401,3 +401,62 @@ function KillConfiscatedPet(pet)
 	SetObjProperty(pet, "guardkill", 1);
 	pet.kill();
 endfunction
+
+function ConfiscateBossPet(mobile, locationnoun := "house")
+	var master_serial := GetObjProperty(mobile, "master");
+	if(!master_serial or mobile.script != "tamed")
+		// Wild boss — kill outright
+		KillConfiscatedPet(mobile);
+		return;
+	endif
+
+	var pet_name := mobile.name;
+
+	var master := SystemFindObjectBySerial(master_serial);
+	var master_online := 1;
+	if(!master)
+		master := SystemFindObjectBySerial(master_serial, SYSFIND_SEARCH_OFFLINE_MOBILES);
+		master_online := 0;
+	endif
+
+	if(!master)
+		KillConfiscatedPet(mobile);
+		return;
+	endif
+
+	var ticket := 0;
+	var ticket_location := "";
+	if(master_online)
+		ticket := CreateItemInBackpack(master, CONFISCATION_TICKET_OBJTYPE);
+		if(ticket)
+			ticket_location := "backpack";
+		endif
+	endif
+
+	if(!ticket)
+		var bankbox := FindBankBox(master);
+		if(bankbox)
+			ticket := CreateItemInContainer(bankbox, CONFISCATION_TICKET_OBJTYPE);
+			if(ticket)
+				ticket_location := "bank";
+			endif
+		endif
+	endif
+
+	if(!ticket)
+		KillConfiscatedPet(mobile);
+		if(master_online)
+			SendSysMessage(master, "Your pet " + pet_name + " was destroyed for entering a " + locationnoun + ". A claim ticket could not be created — your backpack and bank are full.", 3, 43);
+		endif
+		return;
+	endif
+
+	var fine := PopulateConfiscatedPetTicket(ticket, master_serial, mobile);
+
+	KillConfiscatedPet(mobile);
+
+	if(master_online)
+		SendSysMessage(master, "Your pet " + pet_name + " has been confiscated for entering a " + locationnoun + ".");
+		SendSysMessage(master, "A claim ticket has been placed in your " + ticket_location + ". Visit an Animal Trainer and pay " + fine + "gp to reclaim it.", 3, 43);
+	endif
+endfunction

--- a/scripts/ai/tamed.src
+++ b/scripts/ai/tamed.src
@@ -23,9 +23,9 @@ include "include/areas";
 const HALT_THRESHOLD := 10;
 Const MOVING_EFFECT_FIREBALL	:= 0x36D4;
 
-// Follow()'s own Sleepms(100) floor caps normal calls at ~10/sec; this is set
+// Follow()'s own Sleepms(25) floor caps normal calls at ~40/sec; this is set
 // well above that so it only fires if something bypasses that floor entirely.
-const FOLLOW_RUNAWAY_THRESHOLD := 25;
+const FOLLOW_RUNAWAY_THRESHOLD := 100;
 const FOLLOW_RUNAWAY_WARN_COOLDOWN := 60;
 
 var me := Self();
@@ -1168,7 +1168,7 @@ function Follow()
 	// waittime (which only has whole-second granularity via wait_for_event).
 	// Applies before any of the branches/early-returns below so none of them
 	// can re-enter Follow() back-to-back with no delay.
-	Sleepms(100);
+	Sleepms(25);
 
 	//var multi4 := GetStandingHeight( master.x, master.y, master.z ).multi;
 

--- a/scripts/include/areas.inc
+++ b/scripts/include/areas.inc
@@ -480,3 +480,7 @@ endfunction
 function IsInRPArea(who)
 	return HasPolicy(GetAreaPolicyMaskForWho(who), AREA_POLICY_RP_AREA);
 endfunction
+
+function IsInCityRegion(who)
+	return CInt(GetRegionString("regions", who.x, who.y, "City", who.realm)) == 1;
+endfunction


### PR DESCRIPTION
# Patch Notes - v1.1.0
**Zuluhotel Omega 2.5 | Live Shard**  
**Date: August 2, 2026**

---

Welcome to **Patch 1.1.0**. This is a smaller follow-up patch focused on **tamed pet ordered-attack fixes** and a **fix for high-HP monsters not dying/despawning properly** in several places around the shard.

---

## What Changed

## Tamed Pets - Ordered Attack Fixes

### Player Impact

- Ordering your pet to attack a monster while inside a no-PK dungeon now actually works - this was being blocked entirely before.
- Ordering your pet to attack a player while in a no-PK area is still refused, but now gives you a clear message instead of occasionally leaving your pet stuck and unresponsive to further commands.
- Ordering your pet to attack anyone while your pet, you, or the target is in a safe area is still blocked, and an untamed (non-donator-mount) pet is still confiscated as before.
- Fixed a bug where an "all kill"/"all attack" order could cause one of your pets to process the command twice on itself.

---

## Monsters - High-HP Death/Despawn Fix

### Player Impact

- Fixed a bug where certain very tough monsters and summoned creatures (including some superboss-tier spawns, summoned blade spirits/energy vortexes/animated dead, Color Wars arena combatants, and Spirit Flock summons) could fail to actually die or despawn when they were supposed to, instead lingering at full health. These now die/despawn correctly.
- Spawn points configured as "Custom NPC" type now correctly remove their monster when the spawn point is destroyed or reset - previously the old monster could be left behind, sometimes resulting in extra/duplicate monsters at that spawn.

---

## Summary

- Ordering your pet to fight a monster in a no-PK dungeon now works.
- Ordering your pet to fight a player in a no-PK area gives a clear refusal message instead of occasionally freezing your pet's commands.
- Fixed pets sometimes double-processing "all kill"/"all attack" orders.
- Fixed certain very tough/summoned monsters not dying or despawning correctly when they should have.
- Fixed "Custom NPC" spawn points not removing their monster on destroy/reset.

Thanks for playing Zuluhotel Omega 2.5.
