### PR TITLE
Test shard

### DIFF
--- a/config/animxlate.cfg
+++ b/config/animxlate.cfg
@@ -321,6 +321,7 @@ MobileType Monster
   Graphic 0x15f
   Graphic 0x160
   Graphic 0x16f
+  Graphic 0x175
   Graphic 0x176
   Graphic 0x17c
   Graphic 0x17d

--- a/config/command_synopses.cfg
+++ b/config/command_synopses.cfg
@@ -71,6 +71,13 @@ Command autoloop
 	CmdLevel	0
 }
 
+Command backfillteleporterserials
+{
+	Synopsis	One-time migration - backfill each house's TeleporterSerials list
+	Level		Administrator
+	CmdLevel	4
+}
+
 Command bank
 {
 	Synopsis	Open your own bank box
@@ -916,6 +923,13 @@ Command home
 	Synopsis	Teleport yourself to the staff home location
 	Level		Counselor
 	CmdLevel	1
+}
+
+Command houseescrow
+{
+	Synopsis	Claim house-demolish escrow packages
+	Level		Player
+	CmdLevel	0
 }
 
 Command housezoneaudit

--- a/config/command_synopses.cfg
+++ b/config/command_synopses.cfg
@@ -22,6 +22,13 @@ Command admin
 	CmdLevel	4
 }
 
+Command aimovementsim
+{
+	Synopsis	Simulate 20k AI movement area-policy checks over ~2 minutes to watch for a handle leak live
+	Level		Developer
+	CmdLevel	5
+}
+
 Command akill
 {
 	Synopsis	Instantly kill all NPCs within a specified tile range
@@ -512,6 +519,13 @@ Command destroyradius
 	CmdLevel	4
 }
 
+Command dfleaktest
+{
+	Synopsis	Stress-test the areas/email datafile open+unload cycle to check for a handle leak
+	Level		Developer
+	CmdLevel	5
+}
+
 Command disarm
 {
 	Synopsis	Move equipped weapons to your backpack or designated disarm bag
@@ -902,6 +916,13 @@ Command home
 	Synopsis	Teleport yourself to the staff home location
 	Level		Counselor
 	CmdLevel	1
+}
+
+Command housezoneaudit
+{
+	Synopsis	List all houses whose footprint currently overlaps a City, Dungeon, Shrine, or Graveyard region
+	Level		Developer
+	CmdLevel	5
 }
 
 Command htmlgump
@@ -1854,6 +1875,13 @@ Command sfx
 	Synopsis	Play a specified sound effect for nearby players
 	Level		Administrator
 	CmdLevel	4
+}
+
+Command shardstress
+{
+	Synopsis	Spawn many concurrent AI/login workers to simulate sustained multi-day-style shard load
+	Level		Developer
+	CmdLevel	5
 }
 
 Command shave

--- a/config/fileaccess.cfg
+++ b/config/fileaccess.cfg
@@ -7,3 +7,23 @@ FileAccess
     Extension .txt
     Directory *
 }
+
+FileAccess
+{
+    AllowRead 1
+    AllowWrite 1
+    AllowAppend 1
+    Package housing
+    Extension .log
+    Directory *
+}
+
+FileAccess
+{
+    AllowRead 1
+    AllowWrite 1
+    AllowAppend 1
+    Package playervendor
+    Extension .log
+    Directory *
+}

--- a/config/fileaccess.cfg
+++ b/config/fileaccess.cfg
@@ -13,6 +13,7 @@ FileAccess
     AllowRead 1
     AllowWrite 1
     AllowAppend 1
+    AllowRemote 1
     Package housing
     Extension .log
     Directory *
@@ -23,6 +24,7 @@ FileAccess
     AllowRead 1
     AllowWrite 1
     AllowAppend 1
+    AllowRemote 1
     Package playervendor
     Extension .log
     Directory *

--- a/config/golocs_by_id.cfg
+++ b/config/golocs_by_id.cfg
@@ -456,7 +456,7 @@ GoLocEntry skara_brae_farmlands_696_911_2056_2423
 	Realm	britannia
 	Name	Skara Brae Farmlands
 	Id	skara_brae_farmlands_696_911_2056_2423
-	Type	City
+	Type	Suburb
 	Range	696 2056 911 2423
 }
 
@@ -492,7 +492,7 @@ GoLocEntry britain_outer_farmlands_1084_1287_1540_1903
 	Realm	britannia
 	Name	Britain Outer Farmlands
 	Id	britain_outer_farmlands_1084_1287_1540_1903
-	Type	City
+	Type	Suburb
 	Range	1084 1540 1287 1903
 }
 
@@ -573,7 +573,7 @@ GoLocEntry minoc_farmlands_2540_2627_552_603
 	Realm	britannia
 	Name	Minoc Farmlands
 	Id	minoc_farmlands_2540_2627_552_603
-	Type	City
+	Type	Suburb
 	Range	2540 552 2627 603
 }
 
@@ -582,7 +582,7 @@ GoLocEntry minoc_farmlands_2464_2623_604_687
 	Realm	britannia
 	Name	Minoc Farmlands
 	Id	minoc_farmlands_2464_2623_604_687
-	Type	City
+	Type	Suburb
 	Range	2464 604 2623 687
 }
 
@@ -663,7 +663,7 @@ GoLocEntry vesper_outbuildings_2936_3007_600_655
 	Realm	britannia
 	Name	Vesper Outbuildings
 	Id	vesper_outbuildings_2936_3007_600_655
-	Type	City
+	Type	Suburb
 	Range	2936 600 3007 655
 }
 
@@ -672,7 +672,7 @@ GoLocEntry vesper_outbuildings_2716_2819_928_1015
 	Realm	britannia
 	Name	Vesper Outbuildings
 	Id	vesper_outbuildings_2716_2819_928_1015
-	Type	City
+	Type	Suburb
 	Range	2716 928 2819 1015
 }
 
@@ -699,7 +699,7 @@ GoLocEntry yew_farmlands_412_539_772_927
 	Realm	britannia
 	Name	Yew Farmlands
 	Id	yew_farmlands_412_539_772_927
-	Type	City
+	Type	Suburb
 	Range	412 772 539 927
 }
 
@@ -708,7 +708,7 @@ GoLocEntry yew_farmlands_232_499_928_1255
 	Realm	britannia
 	Name	Yew Farmlands
 	Id	yew_farmlands_232_499_928_1255
-	Type	City
+	Type	Suburb
 	Range	232 928 499 1255
 }
 
@@ -717,7 +717,7 @@ GoLocEntry yew_farmlands_500_599_1052_1255
 	Realm	britannia
 	Name	Yew Farmlands
 	Id	yew_farmlands_500_599_1052_1255
-	Type	City
+	Type	Suburb
 	Range	500 1052 599 1255
 }
 
@@ -726,7 +726,7 @@ GoLocEntry yew_farmlands_600_707_928_1255
 	Realm	britannia
 	Name	Yew Farmlands
 	Id	yew_farmlands_600_707_928_1255
-	Type	City
+	Type	Suburb
 	Range	600 928 707 1255
 }
 

--- a/patchnotes/developer-changelog-v1.1.1.md
+++ b/patchnotes/developer-changelog-v1.1.1.md
@@ -1,0 +1,478 @@
+# Developer Changelog - v1.1.1
+**Range:** `f52370c` (origin/Patch-1.1.0) -> `7107d6d` (HEAD)  
+**Branch:** Patch-1.1.1  
+**Date:** 2026-08-07 -> 2026-08-08  
+**Commits in range:** 2 (excluding the boundary merge commit, which carries no new 1.1.1 content)  
+**Files changed (committed):** 48 (+3201 / -567)
+
+---
+
+## Table of Contents
+
+1. [Scope Summary](#1-scope-summary)
+2. [Commit Timeline](#2-commit-timeline)
+3. [Stability - DataFile Handle Leak Fixes (Email + Area Policy)](#3-stability---datafile-handle-leak-fixes-email--area-policy)
+4. [New Staff Tools - Load/Stress-Testing and Leak Diagnostics](#4-new-staff-tools---loadstress-testing-and-leak-diagnostics)
+5. [CheckCity() Rewrite - Realm-Scoped, regions.cfg-Driven City Detection](#5-checkcity-rewrite---realm-scoped-regionscfg-driven-city-detection)
+6. [New "Suburb" Region Type - Farmland/Outbuilding Reclassification](#6-new-suburb-region-type---farmlandoutbuilding-reclassification)
+7. [House Placement - MultiID Resolution Fix and Region-Check Refactor](#7-house-placement---multiid-resolution-fix-and-region-check-refactor)
+8. [House Placement - Per-Account House Limit (New, Cap 5)](#8-house-placement---per-account-house-limit-new-cap-5)
+9. [NPC AI - Sleep-Mode Timing and Wake-Radius Tuning](#9-npc-ai---sleep-mode-timing-and-wake-radius-tuning)
+10. [New House Escrow System - Staff Demolish-and-Escrow, Player Claim Command](#10-new-house-escrow-system---staff-demolish-and-escrow-player-claim-command)
+11. [Player-Vendor Escrow - Shared Module Refactor and Orphaned-Merchant Fixes](#11-player-vendor-escrow---shared-module-refactor-and-orphaned-merchant-fixes)
+12. [New Admin Command - Teleporter Serial Backfill Migration](#12-new-admin-command---teleporter-serial-backfill-migration)
+13. [Tamed Pets - Follow() Runaway-Watch Diagnostics Removed](#13-tamed-pets---follow-runaway-watch-diagnostics-removed)
+14. [CmdLevel Constants - Renumbered to Match the Actual Ladder](#14-cmdlevel-constants---renumbered-to-match-the-actual-ladder)
+15. [Misc Small Fixes](#15-misc-small-fixes)
+16. [Exhaustive File-by-File Change List](#16-exhaustive-file-by-file-change-list)
+17. [Risk and Regression Notes](#17-risk-and-regression-notes)
+
+---
+
+## 1. Scope Summary
+
+Patch 1.1.1 is a large patch built from two commits. `6817955` ("Bunch of fixes to try and stop the shard crashing", 2026-08-07) is a stability pass: it plugs a class of DataFile handle leaks across the email and area-policy systems, adds five new staff-only load/stress-testing and leak-diagnostic tools, rewrites `CheckCity()` to be realm-scoped and driven by `regions.cfg` instead of a hardcoded, incomplete box list, splits farmland/outbuilding regions into a new "Suburb" type so they stop being treated as city, fixes a `GetMultiDimensions()` misuse in house placement that could let houses go undetected inside city/dungeon/shrine/graveyard regions, adds a new per-account house limit (5), and retunes NPC sleep-mode timing. `7107d6d` ("Patch 1.1.1 housing and teleporters fix / housing escrow / taming animals follow speeds", 2026-08-08) is a feature commit: it adds an entirely new staff "Demolish and Escrow" house teardown plus a player-facing `.houseescrow` claim command, refactors the pre-existing player-vendor escrow system into a shared module (fixing two paths that could orphan a merchant's inventory), rewrites house teleporter tracking to use an explicit serial list instead of an unreliable `house.items`-membership check, adds a one-time admin migration command to backfill that new teleporter list for already-placed houses, removes the 1.1.0-era `Follow()` runaway-diagnostic instrumentation (the underlying rate cap itself is untouched), and renumbers the `CMDLEVEL_*` named constants to match this shard's actual 6-level ladder (a phantom "Shard Mom" level and an off-by-one had existed in the constants file, though not in the engine-assigned levels themselves).
+
+---
+
+## 2. Commit Timeline
+
+| Hash | Date | Message |
+|---|---|---|
+| `f52370c` | 2026-08-07 | Merge pull request #316 from Andries1985/Patch-1.1.0 (boundary - no new 1.1.1 content) |
+| `6817955` | 2026-08-07 | Bunch of fixes to try and stop the shard crashing |
+| `7107d6d` | 2026-08-08 | Patch 1.1.1 housing and teleporters fix / housing escrow / taming animals follow speeds |
+
+---
+
+## 3. Stability - DataFile Handle Leak Fixes (Email + Area Policy)
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `pkg/systems/email/chardelete.src` | `OnDelete()` - `UnloadDataFile()` on every exit path |
+| `pkg/systems/email/commands/gm/inspectmail.src` | `ReadMail()` - `UnloadDataFile()` before all 5 return points |
+| `pkg/systems/email/email.src` | `GetMail()` - `UnloadDataFile()` before both return points |
+| `pkg/systems/email/logon.src` | `Logon()` - `UnloadDataFile()` before both return points |
+| `pkg/systems/email/reconnect.src` | `Reconnect()` - same pattern as `logon.src` |
+| `pkg/systems/email/webmail/webmail.src` | `GetInbox()` - `UnloadDataFile()` before final return |
+| `pkg/opt/sysbook/start.src` | adds `UnloadDataFile("staticbooks")` at the end |
+| `pkg/opt/areas/include/areapolicy.inc` | `GetPolicyMask()`, `SetPolicyMask()`, `PruneStaleRealmPolicies()` - `UnloadDataFile()` added on every exit path |
+
+### Overview
+
+Every function above opened a DataFile handle (`"Emails"`, `"AddressBooks"`, `"BlockLists"`, `"staticbooks"`, or a realm's area-policy datafile) and returned without calling `UnloadDataFile()` on at least one exit path - almost always an early-return/error branch, since the "happy path" return in most of these already unloaded correctly. Each open handle that's never unloaded holds a live OS file handle for the life of the process. Given how frequently `logon.src`/`reconnect.src` run (every character login/reconnect) and how often area-policy lookups happen (per [[project-known-engine-constraints]]-adjacent AI/movement code calling into `ResolvePolicyAtLocation()`), this is a plausible contributor to gradual handle exhaustion and an eventual crash under sustained uptime - the stated motivation for this commit.
+
+### Notable Functional Changes
+
+- No behavioral/logic change on any success path - every fix is purely adding a missing `UnloadDataFile()` call before a `return` that previously skipped it.
+- `areapolicy.inc`'s `SetPolicyMask()` and `PruneStaleRealmPolicies()` each had multiple distinct early-return branches (`DFFindElement` failure, `GetRealmAreaLines` failure, `keys` failure) that independently needed the fix, not just one.
+
+### Expected Impact
+
+No player-visible change. Reduces (and per the new `dfleaktest`/`emailstressworker`/`areastressworker` diagnostics in section 4, is intended to be verifiable as having reduced) open-handle growth over long uptime, which is one plausible contributor to the crashes this commit is titled after.
+
+---
+
+## 4. New Staff Tools - Load/Stress-Testing and Leak Diagnostics
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `pkg/opt/alryc/textcmd/test/dfleaktest.src` | New - `.dfleaktest` |
+| `pkg/opt/alryc/textcmd/test/aimovementsim.src` | New - `.aimovementsim` |
+| `pkg/opt/alryc/textcmd/test/shardstress.src` | New - `.shardstress` |
+| `pkg/opt/alryc/stresstest/areastressworker.src` | New - spawned worker, not a direct command |
+| `pkg/opt/alryc/stresstest/emailstressworker.src` | New - spawned worker, not a direct command |
+| `pkg/opt/alryc/textcmd/test/housezoneaudit.src` | New - `.housezoneaudit` (see section 7) |
+| `config/command_synopses.cfg` | Regenerated for `aimovementsim`, `dfleaktest`, `housezoneaudit`, `shardstress` |
+
+### Overview
+
+Five new Developer-only (CmdLevel 5) diagnostic tools, built specifically to reproduce and verify the fixes in this patch under sustained/concurrent load rather than a single serial test loop, since the live crash reports this patch responds to were plausibly load-dependent.
+
+### Notable Functional Changes
+
+- `dfleaktest`: runs 3000 iterations of open/lookup/unload against both the Britannia area-policy datafile and the `"Emails"` datafile (6000 total open/unload cycles), yielding every 100 iterations. Operator watches `pol.exe`'s Handles count in Task Manager before/after - flat count confirms the section 3 fix holds.
+- `aimovementsim`: 20,000 calls to `ResolvePolicyAtLocation()` at random coordinates, batched 50 at a time with a 300ms pause between batches (~120s total), forcibly invalidating the policy-mask cache every 200 calls so it keeps hitting the real datafile-backed lookup instead of a warm cache.
+- `shardstress`: spawns 20 `areastressworker` instances and 10 `emailstressworker` instances, each running for 15 minutes, to simulate sustained mixed player/AI load.
+- `areastressworker` (spawned, not a command): loops for a given duration, invalidating the realm's policy-mask cache every 15 calls and calling `ResolvePolicyAtLocation()` at random coordinates - reproduces many concurrent instances independently warming/missing their own cache, closer to live conditions than one serial loop.
+- `emailstressworker` (spawned, not a command): loops for a given duration doing open/lookup/unload cycles against the `"Emails"` datafile, simulating repeated login/reconnect churn.
+
+### Expected Impact
+
+Staff/developer-facing only. No player-visible change. Gives the team a repeatable way to load-test the area-policy cache and email-datafile paths and watch for handle growth going forward.
+
+---
+
+## 5. CheckCity() Rewrite - Realm-Scoped, regions.cfg-Driven City Detection
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `scripts/include/checkcity.inc` | `CheckCity()` rewritten; new shared helpers `NormalizeRegionType()`, `IsBoxOverlappingRegionType()`, `IsPointInRegionType()` |
+
+### Overview
+
+`CheckCity(item)` was previously a long `If/Elseif` chain of ~18 hardcoded x/y bounding boxes (Britain, Moonglow, Papua, Delucia, Jhelom, Yew, Empath Abbey, Minoc, Trinsic, Skara Brae, Magincia, Occlo, Buccaneers Den, Nujelm, Vesper, Cove, Wind) with no realm parameter at all, so it could false-positive across realms/facets sharing the same coordinates, and it never covered every city-type region actually defined in `regions.cfg` (Occlo Isle, for instance, matched nothing under the old hardcoded list, and was itself misclassified as `Type POI` rather than `Type City` in `regions.cfg` prior to section 6's fix).
+
+### Notable Functional Changes
+
+- `CheckCity(item)` is now a two-line wrapper around `IsPointInRegionType(item.x, item.y, item.realm, "city")`.
+- New `IsBoxOverlappingRegionType(x1, y1, x2, y2, realm, region_type)`: reads `regions/regions.cfg`, filters by normalized region `Type` and (case-insensitively, only when the region specifies one) `Realm`, and returns the first region whose `Range` overlaps the given box, or `0` (fail-open, matching the old behavior when config was unavailable) if none match.
+- New `IsPointInRegionType(x, y, realm, region_type)`: convenience wrapper calling the above with a degenerate zero-size box.
+- New `NormalizeRegionType(region_type)`: lowercases/canonicalizes a region-type string against the known set `poi`, `city`, `suburb`, `dungeon`, `graveyard`, `jail`, `none` (adds `"suburb"`, see section 6).
+- These three helpers are shared with `pkg/std/housing/housedeed.src` (section 7) and the new `pkg/opt/alryc/textcmd/test/housezoneaudit.src` (section 7), replacing three independent, duplicated implementations of essentially the same regions.cfg scan.
+
+### Expected Impact
+
+`CheckCity()` is now realm-scoped and matches every `Type=City` region actually defined in `regions.cfg`, not a hardcoded and incomplete subset. Every downstream consumer of `CheckCity()` (`pkg/std/fishing/fishingnet.src` - nets restricted outside cities; `pkg/opt/botanik/maketree.src` - trees blocked in cities; `pkg/std/alchemy/exploder.src` and `pkg/opt/GMItems/cains_exploder.src` - exploding-potion power reduced in cities; `scripts/control/spawnbookcase.src` - bookcase decay only in cities; `scripts/control/lockchests.src` and `pkg/std/provocation/provocation.src`'s `CheckCity()` calls are dead/commented-out code, unaffected) now evaluates against the corrected, realm-aware region data. Combined with section 6's reclassification, this changes which specific locations count as "city" for all of the above.
+
+---
+
+## 6. New "Suburb" Region Type - Farmland/Outbuilding Reclassification
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `regions/regions.cfg` | Occlo Isle `POI` -> `City`; 5 farmland/outbuilding region groups `City` -> `Suburb` |
+| `pkg/opt/areas/areas.cfg` | Matching `cat=city` -> `cat=suburb` for the same 10 area entries |
+| `config/golocs_by_id.cfg` | Matching `Type City` -> `Type Suburb` for the same GoLoc entries |
+| `pkg/opt/areas/textcmd/admin/areas.src` | `CATEGORY_ORDER` gains `"suburb"` after `"city"` |
+| `scripts/textcmd/coun/go.src` | `type_priority` gains `"Suburb"`; `NormalizeRegionType()` gains a `"suburb"` case |
+| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | Same `type_priority`/normalize additions as `go.src` |
+
+### Overview
+
+`regions.cfg` reclassifies five previously `Type City` region groups - Yew Farmlands (4 ranges), Vesper Outbuildings (2 ranges), Minoc Farmlands (2 ranges), Britain Outer Farmlands, and Skara Brae Farmlands - to a new `Type Suburb`, and separately reclassifies Occlo Isle from `Type POI` to `Type City`. `pkg/opt/areas/areas.cfg` and `config/golocs_by_id.cfg` carry matching reclassifications for the same named areas/GoLocs. `areas.src`'s policy-resolution category order, and both `go.src`'s and `restartspawnpointarea.src`'s location-listing display order, are all updated to insert `"Suburb"`/`"suburb"` immediately after `"City"`/`"city"` so the new type sorts and resolves consistently with the others.
+
+### Notable Functional Changes
+
+- `areas.src`'s `CATEGORY_ORDER` ordering is load-bearing: `ResolveAreaKeyAtLocation()`/`ResolveAreaMatchAtLocation()` in `areapolicy.inc` walk this list in order and the first bounding-box match wins, so this insertion changes which policy applies at any coordinates where a city and a suburb region overlap.
+- `go.src` and `restartspawnpointarea.src` each gain a `"Suburb"` display case in their respective location-normalization functions so suburb regions show a proper label instead of falling through to a generic/blank one.
+
+### Expected Impact
+
+Farmland and outbuilding zones around Yew, Vesper, Minoc, Britain, and Skara Brae are no longer treated as "city" by anything gated on `CheckCity()` or the `city` area category (section 5) - e.g. fishing nets, tree planting, exploding-potion power, and bookcase decay now behave as if those zones are wilderness, not town. Occlo Isle is now correctly recognized as a city region everywhere it wasn't before. The new "Suburb" type also now appears as its own category in `.go` location listings and the spawnpoint-area restart tool's location listings.
+
+---
+
+## 7. House Placement - MultiID Resolution Fix and Region-Check Refactor
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `pkg/std/housing/housedeed.src` | `GetHouseFootprintBounds()`, new `ResolveHouseMultiId()`, `IsHousePlacementBlockedByRegionType()` refactored, debug logging added |
+| `pkg/opt/alryc/textcmd/test/housezoneaudit.src` | New - `.housezoneaudit` |
+| `pkg/opt/townstones/textcmd/admin/createtownstone.src` | `GetRegionRange()` - `GetConfigStringArray` -> `SplitWords(CStr(GetConfigString(...)))` |
+| `pkg/opt/townstones/textcmd/admin/townbankstatus.src` | Same one-line change as above |
+
+### Overview
+
+`GetHouseFootprintBounds(housetype, x, y)` called `GetMultiDimensions(housetype)` directly using the house item's objtype. `GetMultiDimensions()` actually needs the raw multi ID, not the item objtype - `itemdesc.cfg` maps every `"House <objtype>"` block to a separate, much smaller `MultiID` (e.g. House `0xA3EF` -> MultiID `0x3F`), and while `CreateMultiAtLocation()`/`TargetMultiPlacement()` already translate this internally, `GetMultiDimensions()` did not. This means footprint-bounds-dependent region checks (`IsHousePlacementBlockedByRegionType`, i.e. the city/dungeon/shrine/graveyard placement guard) could silently receive wrong or failed dimensions for any house whose objtype differs from its raw multi ID, potentially letting a house be placed inside a restricted region undetected.
+
+### Notable Functional Changes
+
+- New `ResolveHouseMultiId(housetype)`: looks up `:housing:itemdesc.cfg`'s `"House <housetype>"` block and returns its `MultiID`, falling back to the unresolved `housetype` if no block/field is found (with debug logging on each fallback).
+- `GetHouseFootprintBounds()` now calls `GetMultiDimensions(ResolveHouseMultiId(housetype))` instead of `GetMultiDimensions(housetype)` directly.
+- `IsHousePlacementBlockedByRegionType()` no longer inlines its own `regions.cfg` scan - it now calls the shared `IsBoxOverlappingRegionType()` from `checkcity.inc` (section 5).
+- `NormalizeRegionType()` moved out of this file entirely into `checkcity.inc`.
+- Debug `Print()` logging (prefixed `[housedeed][debug]`/`[houselimit][debug]`) added at several points in `Buildhouse()` and `IsHousePlacementBlockedByRegionType()` - console-only, staff-visible.
+- New `.housezoneaudit` command (Developer, CmdLevel 5): scans every realm for placed houses (`ListMultisInBox` + `POLCLASS_HOUSE` filter), recomputes each house's footprint using the same `ResolveHouseMultiId()`/`GetHouseFootprintBounds()` logic as `housedeed.src` (deliberately duplicated to mirror placement-time checks exactly), and reports any house whose footprint overlaps a city/dungeon/shrine/graveyard region - i.e. an audit for houses that were placed illegally before this fix, or that became illegal after a region redefinition. Also includes a one-shot diagnostic trace (`RunRegionDiagnostics()`) built around a specific reported case (towers inside a "Lost Lands" dungeon region).
+- `createtownstone.src` and `townbankstatus.src`'s `GetRegionRange()` both switch from `GetConfigStringArray(elem, "Range")` to `SplitWords(CStr(GetConfigString(elem, "Range")))` for parsing the same `Range` config line - consistent with the parsing approach used in the new `checkcity.inc` helpers, though no comment in the diff states a concrete bug this fixes in these two files specifically.
+
+### Expected Impact
+
+House placement's city/dungeon/shrine/graveyard region guard now correctly evaluates footprint bounds for every house type, including the ones whose item objtype differs from their raw multi ID (previously silently broken for those types). `.housezoneaudit` gives staff a way to find and clean up any already-placed houses that slipped through before this fix.
+
+---
+
+## 8. House Placement - Per-Account House Limit (New, Cap 5)
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `pkg/std/housing/utility.inc` | New `MAX_HOUSES_PER_ACCOUNT`, `GetAccountHouseCount()`, `IsAccountAtHouseLimit()` |
+| `pkg/std/housing/housedeed.src` | `Buildhouse()` - new limit check |
+| `pkg/std/housing/changeowner.src` | `ChangeHouseOwner()` - new limit check, plus a separate `owneracct`/`"Houses"` cprop sync bugfix |
+| `pkg/std/housing/sign.src` | `ChangeHouseOwner()` - new limit check |
+| `pkg/opt/statichousing/ssign.src` | `use_sign()` purchase flow and its own `ChangeHouseOwner()` - new limit check |
+
+### Overview
+
+New feature: an account may not own more than `MAX_HOUSES_PER_ACCOUNT` (5) houses at once. Not described in the commit as a crash fix - it's a scoped feature addition bundled into the same commit.
+
+### Notable Functional Changes
+
+- `GetAccountHouseCount(who)`: resolves the account via `FindAccount(who.acctname)` and sums the `"Houses"` obj-property array's size across all 5 of the account's character slots (`account.GetCharacter(1)` through `(5)`, including offline characters) - a live sum each call, not a maintained counter.
+- `IsAccountAtHouseLimit(who)`: exempts staff (`who.cmdlevel >= 4`, matching `Buildhouse()`'s existing city/dungeon/shrine/graveyard staff-exemption threshold), otherwise denies if `GetAccountHouseCount(who) >= 5`.
+- Wired into every house-acquisition path found in this range: new-deed placement (`housedeed.src`), ownership transfer via `changeowner.src` and `sign.src`'s in-game ownership-change flow, and static-housing sign purchase (`ssign.src`) - each blocks with "You already own the maximum of 5 houses on this account." before the acquisition completes.
+- Separately, `changeowner.src`'s `ChangeHouseOwner()` had a pre-existing bug fixed in the same edit: it set `ownerserial` but never `owneracct`, and never called `AddHouseToCharacter()`/`RemoveHouseFromCharacter()` to keep the `"Houses"` cprop in sync on either the old or new owner - meaning a house transferred via this specific path previously went stale in both parties' house lists (and would have thrown off `GetAccountHouseCount()` for anyone who received a house this way). `sign.src`'s own `ChangeHouseOwner()` already did this correctly and was not affected by the bug.
+
+### Expected Impact
+
+An account cannot acquire a 6th house through deed placement, in-game ownership transfer, or static-housing purchase - existing accounts already over the cap are not retroactively affected (no house is removed), only further acquisition is blocked. Staff (Administrator and above) are exempt. The `changeowner.src` cprop-sync fix means houses transferred through that specific code path now correctly show up in the new owner's (and disappear from the old owner's) house list and account house count going forward.
+
+---
+
+## 9. NPC AI - Sleep-Mode Timing and Wake-Radius Tuning
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `scripts/ai/main/killpcsloop.inc` | New `NPC_SLEEP_AFTER_WANDERS := 150` (was a bare `60`) |
+| `scripts/ai/main/sleepmode.inc` | New `NPC_SLEEP_WAKE_RADIUS := 20`; wake-on-entered-area radius unified to match |
+
+### Overview
+
+`killpcsloop.inc`'s main AI loop counted consecutive idle cycles (`wanders`, ~2s each via `wait_for_event(2)`) before attempting to put an NPC into sleep mode, previously triggering at 60 (~2 minutes). `sleepmode.inc` had two related but mismatched radius values: a proximity check before actually going dormant (20) and the radius used to re-enable `SYSEVENT_ENTEREDAREA` to wake the NPC back up (18).
+
+### Notable Functional Changes
+
+- `NPC_SLEEP_AFTER_WANDERS` raised from 60 to 150 - NPCs now need ~5 minutes of inactivity (up from ~2 minutes) before `sleepmode()` is even attempted. `sleepmode()` still does its own proximity check before actually going dormant.
+- `NPC_SLEEP_WAKE_RADIUS` (20) now used for both the pre-sleep proximity check and the `EnableEvents(SYSEVENT_ENTEREDAREA, ...)` wake trigger (previously 18 for the latter) - both directions are now the same value: "if someone's close enough to prevent sleep, they're close enough to end it."
+- The separate hiding-skill branch (stealthy/rogue-type NPCs, `GetEffectiveSkill(me, 21) > 0`) keeps its own short wake radius of 4, unchanged.
+
+### Expected Impact
+
+NPCs stay active longer before going dormant (5 minutes of no player interaction instead of 2), and the radius that wakes a dormant NPC back up is now consistent with the radius that would have kept it awake in the first place, removing a small dead zone (18-20 tiles) where an NPC could go to sleep with a player just barely outside the old wake trigger.
+
+---
+
+## 10. New House Escrow System - Staff Demolish-and-Escrow, Player Claim Command
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `pkg/std/housing/houseescrow.inc` | New (1206 lines) - core escrow logic |
+| `scripts/textcmd/player/houseescrow.src` | New (405 lines) - `.houseescrow` player/staff command |
+| `pkg/std/housing/sign.src` | New gump case 17 "Demolish and Escrow (For Staff Only)"; teleporter-placement rewrite (see also section 12); decay-timestamp field un-commented |
+| `pkg/std/housing/signcontrol.src` | Dead decay-check block un-commented and fixed; `CleanupHouseTeleporters()` added to `Demolish()` |
+| `pkg/std/housing/setup.inc` | New `HOUSE_DECAY_PERIOD` constant (placeholder, `DECAY` flag itself still 0) |
+| `pkg/std/housing/utility.inc` | New `IsLocationInThisHouse()`, `CleanupHouseTeleporters()`, owner-last-login helpers, `ResolveHouseTypeDisplayName()` |
+| `pkg/utils/gumps/include/yesNoSizable.inc` | `YesNoVar()` rewritten to also scale gump height to wrapped line count |
+| `config/command_synopses.cfg` | New `.houseescrow` entry |
+| `config/fileaccess.cfg` | New `.log` file-access grants for the `housing` and `playervendor` packages |
+
+### Overview
+
+A new staff-only "Demolish and Escrow" house teardown, explicitly modeled on but deliberately not sharing code with the pre-existing player-vendor escrow system (section 11) - a comment in `houseescrow.inc` states this is so the two systems "can't drift into each other." When staff use the new sign-gump option, the house's entire contents (secure containers, redeedable furniture groups, Omega Cache deposits, trash-can tokens, any player-merchant NPCs standing inside, and the resulting house deed itself) are swept into per-owner escrow storage instead of being destroyed, and any player it belonged to (or a staff-reassigned recipient) can later reclaim it with the new `.houseescrow` player command.
+
+### Notable Functional Changes
+
+- New sign gump option, case 17, gated `who.cmdlevel < CMDLEVEL_DEVELOPER` -> `"Staff only."` (i.e. requires the top cmdlevel, 5). Blocks first if any nearby item still has `outside == house.serial` set (owner must redeed outdoor furniture first). Two `YesNoVar` confirmations (a second, sterner one if the house has a `"GuildHouse"` flag). Writes an audit line to console (`[houseescrow][audit] ...`) before proceeding.
+- The sign gump itself was widened (300 -> 360 height) to add an info section: Risk of Escrow (Yes/No, via `IsOwnerAccountAtRisk()`), Owner Last Seen (via `ResolveHouseOwnerLastLogin()`), House Type (via `ResolveHouseTypeDisplayName()`), and teleporter count (placed/total) - all informational display only in this patch, nothing auto-triggers escrow off the "at risk" flag.
+- `DemolishAndEscrowHouse(who, house, sign)`: sets `SCRIPTOPT_NO_RUNAWAY` up front (large houses can trip the 500,000-instruction runaway-script threshold; mitigated with periodic `SleepMS(1)` yields). Resolves the owner (falling back through `owneracct`/sign's `lastownername`, logging `[ORPHANED]` and queuing a GM page via the same shared `gmpages` queue the player-vendor escrow system uses, if resolution fails entirely); creates the house's redeed deed via the same ~40-entry objtype->deed case table `sign.src`'s existing self-service demolish already used (extended with two new entries, `0xA3F1`/`0xA3F2`); destroys structural components; calls the new `CleanupHouseTeleporters()` (section 12); snapshots and classifies every item (secure containers, Omega Cache token, trash cans, redeed-group furniture, generic items) into escrow packs; drains the house's Omega Cache datafile wholesale; force-fires any player-merchant NPCs inside via a `pm_force_fire` event (routed into the *separate* player-vendor escrow system, not this one); removes the house from the owner's character record and destroys the multi; escrows the house deed itself as its own labeled pack.
+- Escrow storage: a DataFile per owner (`:housing:houseescrow_<ownerserial>`, package-prefixed deliberately - a bare filespec resolves relative to the calling script's own package, so without the prefix `houseescrow.inc` and `houseescrow.src` would silently address two different datafiles despite an identical bare name), plus a `"House Demolish Escrow"` StorageArea holding the actual item packs (root backpacks tagged with `ownerserial`/`house_serial`/`house_label`/`created` cprops). Index entries are batch-appended (`AppendHouseEscrowIndexBatch`) for O(N) rather than O(N²) behavior - the comment cites a real house with 346 packs.
+- `.houseescrow` (`scripts/textcmd/player/houseescrow.src`, Player level, CmdLevel 0): with no argument, shows the caller's own paginated escrow gump (5 entries/page) with "To Bank"/"To Backpack" claim buttons per entry. With a numeric argument and `cmdlevel >= 4`, shows a staff view of another character's escrow entries with a "Reassign to targeted character" button per row instead. Claiming (`ClaimHouseEscrowEntry`) snapshots root children before moving (not live iteration), reports if the bank/backpack destination is full, and prunes the datafile entry once fully drained (partial claims leave the remainder in escrow). Gump button IDs are page-relative row numbers reconstructed to an absolute entry index after the gump returns - explicitly to avoid an ID-collision bug that would otherwise occur past 1000 entries (same fix pattern as section 11's player-vendor escrow gump).
+- `signcontrol.src`'s previously dead, commented-out house-decay check (`/* FIXME: ... decay is a string! */`) is un-commented and fixed with a `CInt()` cast; `sign.src` now actively refreshes the `"decay"` obj-property timestamp on every owner/cowner/staff sign click. Both remain dormant in practice since the `DECAY` feature flag itself is still `0`.
+- `yesNoSizable.inc`'s `YesNoVar()` now estimates wrapped line count from prompt length and scales gump height accordingly (previously fixed-height, horizontal-only scaling) - needed for the new, longer house-demolish confirmation text.
+- New `.log` file-access grants (`housing`, `playervendor` packages, `.log` extension) support new `HouseEscrowLog()`/`MerchantEscrowLog()` functions (persistent audit logs to `::log/houseescrow.log` and `::log/merchantescrow.log`, independent of the existing console-only debug print flags).
+
+### Expected Impact
+
+Staff now have a way to tear down and fully preserve a house's contents instead of the previous full-destroy behavior. Affected players (or a staff-designated recipient) can retrieve everything via `.houseescrow`. No existing house-management flow (self-service demolish, redeed, sign gump for owners/cowners) changes behavior beyond the teleporter-tracking rewrite covered in section 12.
+
+---
+
+## 11. Player-Vendor Escrow - Shared Module Refactor and Orphaned-Merchant Fixes
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `pkg/systems/playervendor/include/escrow.inc` | Becomes the shared/canonical escrow module |
+| `pkg/systems/playervendor/commands/player/escrow.src` | Local duplicate code removed; pagination ID-collision fix |
+| `pkg/systems/playervendor/commands/test/pmescrowtest.src` | Local duplicate code removed |
+| `pkg/systems/playervendor/playermerchant.src` | Orphaned-merchant fixes; payout pack capacity raised; staff force-fire permission |
+
+### Overview
+
+This pre-existing escrow system (for cashed-out/closed player vendors) had its entry-encoding, storage-opening, and accessor logic duplicated independently across `escrow.src`, `pmescrowtest.src`, and `playermerchant.src`. This commit centralizes all of it into `escrow.inc` and, while doing so, fixes two paths that could leave a merchant's payout permanently orphaned (unclaimable).
+
+### Notable Functional Changes
+
+- `escrow.inc` gains: `MerchantEscrowLog()` (persistent log, independent of existing debug-print flags), `OpenEscrowStorage()`, `EscrowEscapeField`/`EscrowUnescapeField`, `EncodeEscrowEntryFields`/`EncodeEscrowEntries`/`DecodeEscrowEntries`, and accessor functions (`EntryId`, `EntryOwnerSerial`, `EntryEscrowName`, `EntryVendorName`, `EntryVendorSerial`, `EntryCreated`, `EntryOwnerName`) that check a struct-style field first before falling back to the legacy positional-array index.
+- New `BuildEscrowDatafileNameForSerial(owner_serial)`, with the existing `BuildEscrowDatafileName(player_obj)` refactored to delegate to it - fixes the datafile name from a bare `PLAYERVENDOR_ESCROW_DF_PREFIX + serial` (no package prefix, previously "worked by accident" because every caller happened to already live inside `pkg/systems/playervendor`) to the package-scoped `":playervendor:..."` form, same class of fix as the house-escrow naming in section 10 but flagged here as latent (no confirmed live failure) rather than confirmed-active.
+- `escrow.src`: pagination button IDs changed from absolute entry index to page-relative row number, reconstructed to an absolute index via `start_idx` after the gump returns, with added bounds checks - without this, a player with 1000+ escrow entries could push an absolute-index button ID into another button's numeric range and claim the wrong entry. `ClaimEscrowEntry` now snapshots via `ListRootItemsInContainer` instead of live-iterating while moving, and both it and `RemoveEscrowEntryById` gain `MerchantEscrowLog()` calls at each branch.
+- `pmescrowtest.src`: pure deduplication (local `ENTRY_*_IDX` constants, accessor functions, `OpenEscrowStorage()`, and inline parse/encode logic all removed in favor of the shared module). One unstated side effect: this test tool's vendor-name fallback default changes from its own local `"[TEST] Player Merchant"` to the shared module's `"Player Merchant"`, since its local override was deleted along with the rest of the duplicate code.
+- `playermerchant.src`: `PAYOUT_PACK_MAX_ROOT_ITEMS` 100 -> 225, `PAYOUT_PACK_MAX_WEIGHT` 40000 -> 60000 (matches the new house-escrow pack limits in section 10). The forced-fire event handler now also accepts `ev.source.cmdlevel >= 4` in addition to the merchant's actual master - required so `houseescrow.inc`'s `FireHouseMerchants()` can force-fire a merchant it doesn't own during a house demolish. `AppendEscrowIndex()` previously bailed out early without ever indexing the entry if the merchant had no `master` set (masterless), leaving the already-created escrow root permanently orphaned/unclaimable - it now proceeds regardless, logging `[ORPHANED]` and falling back to a raw-serial datafile name if the owner can't otherwise be resolved. Separately, `HandleMasterlessMerchantCleanup()` previously ran its own standalone teleport-and-kill sequence that never called `CashOut()` at all, destroying a masterless merchant's inventory/gold along with the NPC - it now delegates to `HandleMerchantClosure("masterless_cleanup", 1)`, which does call `CashOut()` before destroying the merchant's storage containers and running the kill sequence.
+
+### Expected Impact
+
+No change to normal vendor cash-out flow for merchants with a live master. Masterless merchants (owner deleted/unresolvable) are no longer silently destroyed with their inventory intact but unclaimable - their payout is now escrowed and locatable (flagged `[ORPHANED]` in the log) instead. The pagination fix prevents a wrong-entry claim for any player who accumulates 1000+ escrow entries. Payout packs can now hold more before a new pack is spun up.
+
+---
+
+## 12. New Admin Command - Teleporter Serial Backfill Migration
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `scripts/textcmd/admin/backfillteleporterserials.src` | New (100 lines) - `.backfillteleporterserials` |
+| `pkg/std/housing/sign.src` | `AddTeleporter()` rewritten to use `TeleporterSerials` cprop instead of `house.items` membership |
+| `pkg/std/housing/utility.inc` | New `CleanupHouseTeleporters()`, `IsLocationInThisHouse()` |
+| `scripts/textcmd/admin/destroymulti.src` | Now calls `CleanupHouseTeleporters()` before destroying a house |
+
+### Overview
+
+House teleporter placement/removal previously validated against `house.items` membership - placement checked whether the newly created teleporter showed up in `house.items`, and removal counted matching-`teleNum` items directly within `house.items` (capped at 2 via a hardcoded counter). This commit introduces an explicit `TeleporterSerials` cprop list on each house as the source of truth, plus a one-time migration command to populate that list for teleporters placed before this change existed.
+
+### Notable Functional Changes
+
+- `sign.src`'s `AddTeleporter(who, house, num)`: placement now validates via the new `IsLocationInThisHouse(house, x, y, z, realm)` (an explicit spatial check against the house's own footprint via `ListMultisInBox`, replacing the old items-membership check) and, on success, appends the new teleporter's serial to `TeleporterSerials`. Removal now iterates the `TeleporterSerials` list (falling back to scanning `house.items` for untracked `0xA3CE` teleporters to backfill the list first if it's empty/missing), destroys matches, and writes back the remainder. Error message text changed from "That is not inside the building." to "You can only place teleporters inside this house." in both spots.
+- New `CleanupHouseTeleporters(house)`: destroys every teleporter tracked in `TeleporterSerials`, plus sweeps `house.items` for any untracked pre-migration teleporters pointing at this house, then clears the cprop. Wired into `DemolishAndEscrowHouse()` (section 10), `sign.src`'s existing case-14 self-service demolish, `signcontrol.src`'s `Demolish()`, and now `scripts/textcmd/admin/destroymulti.src` as well.
+- `.backfillteleporterserials` (Administrator, CmdLevel 4, idempotent - "safe to run more than once"): scans every realm world-wide by objtype (`0xA3CE`) rather than by proximity, specifically because a proximity/spatial search could miss a teleporter's paired partner if it's placed far away; resolves each teleporter's owning house via its `teleportserial` cprop and backfills that house's `TeleporterSerials` list. Orphaned teleporters (owning house no longer exists) are counted and reported but left untouched - explicitly deferred to "a separate cleanup pass."
+
+### Expected Impact
+
+Teleporter placement/removal is now driven by an explicit, house-scoped serial list instead of an unreliable items-membership check, and every path that destroys a house (demolish, redeed, escrow, admin destroymulti) now reliably cleans up its teleporters instead of potentially leaving them behind. Houses with teleporters placed before this patch need `.backfillteleporterserials` run once (already scheduled as part of this deployment) so their existing teleporters are tracked correctly going forward.
+
+---
+
+## 13. Tamed Pets - Follow() Runaway-Watch Diagnostics Removed
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `scripts/ai/tamed.src` | Removes 1.1.0's runaway-watch diagnostic block from `Follow()` |
+
+### Overview
+
+Patch 1.1.0 added a hard `Sleepms(25)` rate floor to `Follow()` (capping calls to ~40/sec) plus a console-only runaway-watch diagnostic that counted calls-per-second and printed a warning if a pet exceeded a threshold. This patch removes only the diagnostic instrumentation.
+
+### Notable Functional Changes
+
+- Removed: `FOLLOW_RUNAWAY_THRESHOLD`, `FOLLOW_RUNAWAY_WARN_COOLDOWN` constants; `followcalls`, `followwindowstart`, `lastfollowwarn` module-level vars; the per-call counting/windowing block and its `"[TamedAI runaway-watch] ..."` console print; the now-unused `use basicio;` import.
+- **Not removed / unchanged:** the actual `Sleepms(25)` rate floor at the top of `Follow()` remains in place, applying before any early-return branch exactly as it did at the end of 1.1.0.
+
+### Expected Impact
+
+No gameplay/behavior change - pet follow speed and rate-limiting are identical to 1.1.0. This is a cleanup of console-only diagnostic logging that had served its purpose (confirming the 1.1.0 floor works) and is no longer needed.
+
+---
+
+## 14. CmdLevel Constants - Renumbered to Match the Actual Ladder
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `scripts/include/constants/cmdlevels.inc` | Removes phantom `CMDLEVEL_SHARD_MOM`; renumbers everything above Counselor |
+
+### Overview
+
+`config/cmds.cfg` defines exactly 6 `CmdLevel` blocks in order: Player, Coun, Seer, GM, Admin, Test. `cmdlevels.inc`'s named constants had a phantom `CMDLEVEL_SHARD_MOM := 2` that doesn't correspond to any real level, which pushed every constant above Counselor one level too high (`CMDLEVEL_SEER` was `3` instead of `2`, up through `CMDLEVEL_DEVELOPER` being `6` instead of the real top level, `5`).
+
+### Notable Functional Changes
+
+- `CMDLEVEL_SHARD_MOM` removed entirely. `CMDLEVEL_SEER` 3->2, `CMDLEVEL_GAME_MASTER` 4->3, `CMDLEVEL_ADMINISTRATOR` 5->4, `CMDLEVEL_DEVELOPER` 6->5.
+- Only two symbol-name consumers of these constants exist repo-wide: `pkg/opt/spawnpoint/spawnpoint.src`'s case statement (pre-existing), and this patch's own new `who.cmdlevel < CMDLEVEL_DEVELOPER` check in `sign.src`'s case-17 escrow gump gate (section 10) - both reference by name and are correct as of this commit's renumbering.
+- Not touched by this change: the large number of pre-existing raw numeric `who.cmdlevel >= 4` / `>= 5` comparisons found elsewhere in the codebase (e.g. `sign.src`'s existing owner/cowner checks). Those were already keyed to the engine's real, unaffected level numbering (`config/cmds.cfg` itself never changed), so their meaning is unchanged by this commit - only code that referenced the old, incorrect `CMDLEVEL_*` *names* was ever wrong.
+
+### Expected Impact
+
+No behavior change for the two confirmed symbol-name consumers (they now correctly reference the shard's real "Administrator"/"Developer" levels). No repo-wide audit of every raw-numeric cmdlevel check was performed as part of this commit - only the two confirmed name-based consumers were verified.
+
+---
+
+## 15. Misc Small Fixes
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `scripts/textcmd/seer/findboat.src` | Removes unused `include "include/account";` |
+| `config/animxlate.cfg` | One new `Graphic 0x175` entry under `MobileType Monster` |
+| `scripts/textcmd/test/editcharacter.src` | Color/hue clamp ceiling raised |
+
+### Notable Functional Changes
+
+- `findboat.src`: no functional code touched, only an unused include removed. No comment in the diff states why.
+- `animxlate.cfg`: registers one additional monster graphic ID (`0x175`) for animation translation, alongside the pre-existing `0x176` entry. No further context in the diff about which creature this is for.
+- `editcharacter.src`: `ClampInt(CInt(GFExtractData(result, ENTRY_COLOR)), 0, 10000)` -> `ClampInt(..., 0, 65535)` - the `.editcharacter` staff tool's hue/color clamp ceiling raised from 10000 to the full 16-bit hue range, so valid hues above 10000 are no longer incorrectly clamped down.
+
+### Expected Impact
+
+Staff-tool-only changes plus one unexplained dead-code removal; no player-facing effect.
+
+---
+
+## 16. Exhaustive File-by-File Change List
+
+| File | Section | Summary |
+|---|---|---|
+| `config/animxlate.cfg` | 15 | One new monster graphic entry |
+| `config/command_synopses.cfg` | 4, 10, 12 | Regenerated for new commands |
+| `config/fileaccess.cfg` | 10 | New `.log` grants for housing/playervendor |
+| `config/golocs_by_id.cfg` | 6 | City -> Suburb reclassification |
+| `pkg/opt/alryc/stresstest/areastressworker.src` | 4 | New - spawned load worker |
+| `pkg/opt/alryc/stresstest/emailstressworker.src` | 4 | New - spawned load worker |
+| `pkg/opt/alryc/textcmd/test/aimovementsim.src` | 4 | New - `.aimovementsim` |
+| `pkg/opt/alryc/textcmd/test/dfleaktest.src` | 4 | New - `.dfleaktest` |
+| `pkg/opt/alryc/textcmd/test/housezoneaudit.src` | 7 | New - `.housezoneaudit` |
+| `pkg/opt/alryc/textcmd/test/shardstress.src` | 4 | New - `.shardstress` |
+| `pkg/opt/areas/areas.cfg` | 6 | City -> Suburb reclassification |
+| `pkg/opt/areas/include/areapolicy.inc` | 3 | `UnloadDataFile()` leak fixes |
+| `pkg/opt/areas/textcmd/admin/areas.src` | 6 | `CATEGORY_ORDER` gains "suburb" |
+| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | 6 | Display ordering gains "Suburb" |
+| `pkg/opt/statichousing/ssign.src` | 8 | House-limit check added |
+| `pkg/opt/sysbook/start.src` | 3 | `UnloadDataFile()` leak fix |
+| `pkg/opt/townstones/textcmd/admin/createtownstone.src` | 7 | `GetConfigStringArray` -> `SplitWords`/`GetConfigString` |
+| `pkg/opt/townstones/textcmd/admin/townbankstatus.src` | 7 | Same as above |
+| `pkg/std/housing/changeowner.src` | 8 | House-limit check + `owneracct`/cprop-sync bugfix |
+| `pkg/std/housing/houseescrow.inc` | 10 | New - core house-escrow logic |
+| `pkg/std/housing/housedeed.src` | 7, 8 | MultiID resolution fix, region-check refactor, house-limit check |
+| `pkg/std/housing/setup.inc` | 10 | New `HOUSE_DECAY_PERIOD` constant (dormant) |
+| `pkg/std/housing/sign.src` | 10, 12 | New escrow gump case, teleporter rewrite, decay timestamp refresh |
+| `pkg/std/housing/signcontrol.src` | 10, 12 | Decay-check fix, `CleanupHouseTeleporters()` added |
+| `pkg/std/housing/utility.inc` | 8, 10, 12 | House-limit helpers, escrow helpers, teleporter cleanup, owner-risk helpers |
+| `pkg/systems/email/chardelete.src` | 3 | `UnloadDataFile()` leak fix |
+| `pkg/systems/email/commands/gm/inspectmail.src` | 3 | `UnloadDataFile()` leak fix |
+| `pkg/systems/email/email.src` | 3 | `UnloadDataFile()` leak fix |
+| `pkg/systems/email/logon.src` | 3 | `UnloadDataFile()` leak fix |
+| `pkg/systems/email/reconnect.src` | 3 | `UnloadDataFile()` leak fix |
+| `pkg/systems/email/webmail/webmail.src` | 3 | `UnloadDataFile()` leak fix |
+| `pkg/systems/playervendor/commands/player/escrow.src` | 11 | Dedup + pagination ID-collision fix |
+| `pkg/systems/playervendor/commands/test/pmescrowtest.src` | 11 | Dedup |
+| `pkg/systems/playervendor/include/escrow.inc` | 11 | Becomes shared escrow module |
+| `pkg/systems/playervendor/playermerchant.src` | 11 | Orphaned-merchant fixes, pack capacity, staff force-fire |
+| `pkg/utils/gumps/include/yesNoSizable.inc` | 10 | `YesNoVar()` vertical scaling |
+| `regions/regions.cfg` | 6 | City/Suburb reclassification, Occlo Isle -> City |
+| `scripts/ai/main/killpcsloop.inc` | 9 | Sleep-after-wanders threshold 60 -> 150 |
+| `scripts/ai/main/sleepmode.inc` | 9 | Wake radius unified to 20 |
+| `scripts/ai/tamed.src` | 13 | Runaway-watch diagnostics removed |
+| `scripts/include/checkcity.inc` | 5 | `CheckCity()` rewrite, new shared region helpers |
+| `scripts/include/constants/cmdlevels.inc` | 14 | Renumbered to match actual ladder |
+| `scripts/textcmd/admin/backfillteleporterserials.src` | 12 | New - `.backfillteleporterserials` |
+| `scripts/textcmd/admin/destroymulti.src` | 12 | `CleanupHouseTeleporters()` added |
+| `scripts/textcmd/coun/go.src` | 6 | Display ordering gains "Suburb" |
+| `scripts/textcmd/player/houseescrow.src` | 10 | New - `.houseescrow` |
+| `scripts/textcmd/seer/findboat.src` | 15 | Unused include removed |
+| `scripts/textcmd/test/editcharacter.src` | 15 | Hue clamp ceiling raised |
+| `patchnotes/developer-changelog-v1.1.1.md` | - | This file |
+| `patchnotes/patch-v1.1.1.md` | - | Player-facing notes |
+| `patchnotes/launchernotes.md` | - | Replaced with this release's player-facing content |
+
+---
+
+## 17. Risk and Regression Notes
+
+- **`CheckCity()`/region reclassification (sections 5-6):** any location logic gated on `CheckCity()` or the `city` area category now behaves differently for the five reclassified farmland/outbuilding zones (no longer "city") and Occlo Isle (now "city"). Confirmed active consumers: fishing nets, tree planting, exploding-potion power, bookcase decay. `lockchests.src` and `provocation.src`'s `CheckCity()` calls are dead/commented-out code and unaffected either way.
+- **House placement MultiID fix (section 7):** `.housezoneaudit` should be run post-deploy to identify any already-placed houses that slipped into a restricted region under the old, broken `GetMultiDimensions()` call - this fix only prevents *new* violations, it does not retroactively move or flag existing ones automatically.
+- **Per-account house limit (section 8):** only blocks new acquisition; accounts already over the 5-house cap are unaffected until they try to acquire another house. Worth confirming intended cap value (5) matches policy before this reaches players, since it's not adjustable without a code change (no config entry, just the `MAX_HOUSES_PER_ACCOUNT` constant).
+- **Teleporter serial backfill (section 12):** `.backfillteleporterserials` needs to be run once, post-deploy, before the new `TeleporterSerials`-based removal logic in `sign.src` can be trusted for houses with pre-existing teleporters (the removal path does have a same-call fallback scan for untracked teleporters, but the backfill command is the deliberate one-time fix for the general case). Orphaned teleporters (house already destroyed) are reported but not cleaned up by this command - flagged as a separate follow-up.
+- **Escrow storage growth (section 10):** house-escrow and player-vendor-escrow entries are only removed from their index once fully claimed - abandoned/orphaned entries (masterless merchants, unresolvable house owners) persist indefinitely in storage unless staff intervene via the reassign flow. No automatic expiry exists yet.
+- **`pmescrowtest.src` vendor-name default (section 11):** this test tool's fallback vendor-name text silently changed from `"[TEST] Player Merchant"` to `"Player Merchant"` as an unstated side effect of removing its local duplicate code - purely a test-tool display string, but worth knowing if `.pmescrowtest` output is compared against old screenshots/docs.
+- **CmdLevel renumbering (section 14):** only two symbol-name consumers were confirmed and verified correct; no repo-wide audit of raw-numeric `cmdlevel` comparisons was performed as part of this commit (none should be affected in principle, since `config/cmds.cfg`'s actual numbering never changed, but this wasn't exhaustively checked file-by-file).
+- **`findboat.src` include removal (section 15):** no stated reason in the diff; if `.findboat` (Seer level) breaks in a way tied to account-related functionality, this removed include is the first thing to check.

--- a/patchnotes/patch-v1.1.1.md
+++ b/patchnotes/patch-v1.1.1.md
@@ -1,5 +1,12 @@
-# Latest Changes
-Always check Discord announcements for all the patch notes.
+# Patch Notes - v1.1.1
+**Zuluhotel Omega 2.5 | Live Shard**  
+**Date: August 8, 2026**
+
+---
+
+Welcome to **Patch 1.1.1**. This patch focuses on **shard stability**, a new **house escrow system** for staff-managed house teardowns, more reliable **house teleporters**, a new **per-account house limit**, and corrections to which areas of the world count as "city" for several gameplay systems.
+
+---
 
 ## What Changed
 

--- a/pkg/opt/alryc/stresstest/areastressworker.src
+++ b/pkg/opt/alryc/stresstest/areastressworker.src
@@ -1,0 +1,51 @@
+/*
+	Spawn-only worker for shardstress.src - simulates one mobile's AI doing
+	continuous area-policy checks (like Follow()/combat/movement do in real
+	play) for a fixed duration. Each spawned instance gets its own fresh
+	_policy_mask_cache (declared in areapolicy.inc), which is the point -
+	many concurrent instances each independently warming/re-missing their
+	own cache is what actually happened on the live shard, not one script
+	looping serially.
+*/
+use uo;
+use os;
+use basicio;
+
+include ":areas:include/areapolicy";
+include "include/random";
+
+// Invalidates the shared realm cache far more often than any real staff
+// edit would - deliberately worse than production so a clean result here
+// is stronger evidence than matching real traffic would be.
+const AREASTRESSWORKER_INVALIDATE_EVERY := 15;
+const AREASTRESSWORKER_YIELD_EVERY := 20;
+const AREASTRESSWORKER_YIELD_MS := 50;
+
+program areastressworker( params )
+
+	var worker_id := params[1];
+	var duration_seconds := params[2];
+
+	var end_clock := ReadGameClock() + duration_seconds;
+	var calls := 0;
+
+	while( ReadGameClock() < end_clock )
+
+		if( (calls % AREASTRESSWORKER_INVALIDATE_EVERY) == 0 )
+			InvalidatePolicyMaskCache( "britannia" );
+		endif
+
+		var x := Random(6000);
+		var y := Random(4000);
+		ResolvePolicyAtLocation( x, y, "britannia" );
+
+		calls := calls + 1;
+		if( (calls % AREASTRESSWORKER_YIELD_EVERY) == 0 )
+			SleepMS( AREASTRESSWORKER_YIELD_MS );
+		endif
+	endwhile
+
+	SysLog("[shardstress] area-worker="+worker_id+" done calls="+calls);
+	Print("[shardstress] area-worker="+worker_id+" done calls="+calls);
+
+endprogram

--- a/pkg/opt/alryc/stresstest/emailstressworker.src
+++ b/pkg/opt/alryc/stresstest/emailstressworker.src
@@ -1,0 +1,37 @@
+/*
+	Spawn-only worker for shardstress.src - simulates one player repeatedly
+	logging in/reconnecting (logon.src/reconnect.src both open the Emails
+	datafile fresh on every single call, no caching), for a fixed duration.
+*/
+use uo;
+use os;
+use basicio;
+
+include ":datafile:datafile";
+
+const EMAILSTRESSWORKER_PAUSE_MS := 100;
+
+program emailstressworker( params )
+
+	var worker_id := params[1];
+	var duration_seconds := params[2];
+
+	var end_clock := ReadGameClock() + duration_seconds;
+	var calls := 0;
+
+	while( ReadGameClock() < end_clock )
+
+		var mail_file := DFOpenDataFile( "Emails", DF_CREATE );
+		if( mail_file != error )
+			DFFindElement( mail_file, Hex(worker_id*100000 + calls), DF_NO_CREATE );
+			UnloadDataFile( "Emails" );
+		endif
+
+		calls := calls + 1;
+		SleepMS( EMAILSTRESSWORKER_PAUSE_MS );
+	endwhile
+
+	SysLog("[shardstress] email-worker="+worker_id+" done calls="+calls);
+	Print("[shardstress] email-worker="+worker_id+" done calls="+calls);
+
+endprogram

--- a/pkg/opt/alryc/textcmd/test/aimovementsim.src
+++ b/pkg/opt/alryc/textcmd/test/aimovementsim.src
@@ -1,0 +1,55 @@
+// Synopsis: Simulate 20k AI movement area-policy checks over ~2 minutes to watch for a handle leak live
+use uo;
+use os;
+use basicio;
+
+include ":areas:include/areapolicy";
+include "include/random";
+
+const AIMOVESIM_TOTAL_CALLS := 20000;
+const AIMOVESIM_BATCH_SIZE := 50;
+const AIMOVESIM_BATCH_SLEEP_MS := 300;   // 20000/50 batches * 300ms ~= 120 seconds
+const AIMOVESIM_INVALIDATE_EVERY := 200; // forces the mask cache cold periodically,
+                                          // same as it would be right after a restart
+const AIMOVESIM_PROGRESS_EVERY := 2000;
+
+program aimovementsim( who )
+
+	SendSysMessage( who, "Simulating "+AIMOVESIM_TOTAL_CALLS+" AI movement area-policy checks over ~2 minutes." );
+	SendSysMessage( who, "Open Task Manager -> Details -> Handles column for pol.exe and watch it DURING the run, not just before/after." );
+	Sleep(5);
+
+	SysLog("[aimovesim] start calls="+AIMOVESIM_TOTAL_CALLS);
+	Print("[aimovesim] start calls="+AIMOVESIM_TOTAL_CALLS);
+
+	var i;
+	for( i := 1; i <= AIMOVESIM_TOTAL_CALLS; i := i + 1 )
+
+		// Periodically blow away the whole realm's cache, forcing the next
+		// several checks back onto the real datafile lookup - this is the
+		// only part of the loop that actually exercises the fix. Without
+		// this the cache would just stay warm the whole run and the test
+		// would prove nothing either way.
+		if( (i % AIMOVESIM_INVALIDATE_EVERY) == 0 )
+			InvalidatePolicyMaskCache( "britannia" );
+		endif
+
+		var x := Random(6000);
+		var y := Random(4000);
+		ResolvePolicyAtLocation( x, y, "britannia" );
+
+		if( (i % AIMOVESIM_BATCH_SIZE) == 0 )
+			SleepMS( AIMOVESIM_BATCH_SLEEP_MS );
+		endif
+		if( (i % AIMOVESIM_PROGRESS_EVERY) == 0 )
+			SysLog("[aimovesim] progress calls="+i);
+			Print("[aimovesim] progress calls="+i);
+		endif
+	endfor
+
+	SysLog("[aimovesim] end calls="+AIMOVESIM_TOTAL_CALLS);
+	Print("[aimovesim] end calls="+AIMOVESIM_TOTAL_CALLS);
+
+	SendSysMessage( who, "Done. Flat/stable Handles the whole way through = fix is holding. Steady climb the whole run = still leaking." );
+
+endprogram

--- a/pkg/opt/alryc/textcmd/test/dfleaktest.src
+++ b/pkg/opt/alryc/textcmd/test/dfleaktest.src
@@ -1,0 +1,47 @@
+// Synopsis: Stress-test the areas/email datafile open+unload cycle to check for a handle leak
+use uo;
+use os;
+use basicio;
+
+include ":areas:include/areapolicy";
+include ":datafile:datafile";
+
+const DFLEAKTEST_ITERATIONS := 3000;
+const DFLEAKTEST_YIELD_EVERY := 100;
+
+program dfleaktest( who )
+
+	SendSysMessage( who, "Running "+DFLEAKTEST_ITERATIONS+" areas+email datafile open/unload cycles in 5 seconds." );
+	SendSysMessage( who, "Switch to Task Manager -> Details -> Handles column for pol.exe now and note the current number." );
+	Sleep(5);
+
+	SysLog("[dfleaktest] start iterations="+DFLEAKTEST_ITERATIONS);
+	Print("[dfleaktest] start iterations="+DFLEAKTEST_ITERATIONS);
+
+	var i;
+	for( i := 1; i <= DFLEAKTEST_ITERATIONS; i := i + 1 )
+
+		var area_file := OpenAreaPolicyFile( "britannia", DF_CREATE );
+		if( area_file != error )
+			DFFindElement( area_file, "britain", DF_NO_CREATE );
+			UnloadDataFile( GetRealmPolicyDescriptor( "britannia" ) );
+		endif
+
+		var mail_file := DFOpenDataFile( "Emails", DF_CREATE );
+		if( mail_file != error )
+			DFFindElement( mail_file, "0", DF_NO_CREATE );
+			UnloadDataFile( "Emails" );
+		endif
+
+		if( (i % DFLEAKTEST_YIELD_EVERY) == 0 )
+			SleepMS(1);
+		endif
+	endfor
+
+	SysLog("[dfleaktest] end iterations="+DFLEAKTEST_ITERATIONS);
+	Print("[dfleaktest] end iterations="+DFLEAKTEST_ITERATIONS);
+
+	SendSysMessage( who, "Done - "+(DFLEAKTEST_ITERATIONS*2)+" total open/unload calls." );
+	SendSysMessage( who, "Check the Handles count again: back near where it started = fix is working. Jumped by roughly that number and stayed = still leaking." );
+
+endprogram

--- a/pkg/opt/alryc/textcmd/test/housezoneaudit.src
+++ b/pkg/opt/alryc/textcmd/test/housezoneaudit.src
@@ -1,0 +1,233 @@
+// Synopsis: List all houses whose footprint currently overlaps a City, Dungeon, Shrine, or Graveyard region
+use uo;
+use os;
+use cfgfile;
+use polsys;
+
+include "include/checkcity";
+
+program housezoneaudit(who)
+	RunRegionDiagnostics();
+
+	var violations := CollectZoneViolatingHouses();
+	if (!violations || !violations.size())
+		SendSysMessage(who, "No houses found overlapping city/dungeon/shrine/graveyard regions.");
+		return 0;
+	endif
+
+	SendSysMessage(who, "Found " + CStr(violations.size()) + " house(s) overlapping restricted-zone regions:");
+	Print("[housezoneaudit] " + who.name + " ran audit, found " + CStr(violations.size()) + " violation(s).");
+
+	foreach v in violations
+		var line := v[1] + " -- " + v[2] + " house at " + v[3] + " realm=" + v[5] + " in region '" + v[4] + "' [Type=" + v[6] + "]";
+		SendSysMessage(who, line);
+		Print("[housezoneaudit] " + line);
+	endforeach
+endprogram
+
+function CollectZoneViolatingHouses()
+	var violations := array;
+	var realmslist := Realms();
+
+	foreach realm in realmslist
+		var realm_name := GetRealmNameFromMapId(CInt(realm.mapid));
+		if (!realm_name)
+			continue;
+		endif
+		var realm_width := CInt(realm.width) - 1;
+		var realm_height := CInt(realm.height) - 1;
+
+		var found := ListMultisInBox(0, 0, -128, realm_width, realm_height, 127, realm_name);
+		if (!found or !found.size())
+			continue;
+		endif
+
+		foreach multi in found
+			if (!multi)
+				continue;
+			endif
+			if (!multi.isa(POLCLASS_HOUSE))
+				continue;
+			endif
+
+			var blocked := FindBlockingRegion(multi.objtype, multi.x, multi.y, realm_name);
+			if (!blocked)
+				continue;
+			endif
+
+			var owner_name := ResolveOwnerName(multi);
+			var house_type := CStr(Hex(multi.objtype));
+			var coord_text := CStr(multi.x) + "," + CStr(multi.y) + "," + CStr(multi.z);
+
+			violations.append(array{owner_name, house_type, coord_text, blocked[2], realm_name, blocked[1]});
+			SleepMS(1);
+		endforeach
+	endforeach
+
+	return violations;
+endfunction
+
+function GetRealmNameFromMapId(mapid)
+	if (mapid == 0)
+		return "britannia";
+	elseif (mapid == 1)
+		return "britannia_alt";
+	elseif (mapid == 2)
+		return "ilshenar";
+	elseif (mapid == 3)
+		return "malas";
+	elseif (mapid == 4)
+		return "tokuno";
+	elseif (mapid == 5)
+		return "termur";
+	endif
+
+	return 0;
+endfunction
+
+function ResolveOwnerName(multi)
+	var owner_name := GetObjProperty(multi, "lastownername");
+	if (!owner_name)
+		var owner_serial := CInt(GetObjProperty(multi, "ownerserial"));
+		if (owner_serial)
+			var owner := SystemFindObjectBySerial(owner_serial);
+			if (!owner)
+				owner := SystemFindObjectBySerial(owner_serial, SYSFIND_SEARCH_OFFLINE_MOBILES);
+			endif
+			if (owner)
+				owner_name := owner.name;
+			endif
+		endif
+	endif
+	if (!owner_name)
+		owner_name := "Unknown";
+	endif
+	return owner_name;
+endfunction
+
+// One-shot console trace of the regions.cfg lookup chain, to find where it
+// breaks for a known-bad case ("Lost Lands", Type Dungeon, contains at least
+// two currently-placed towers per gotomulti).
+function RunRegionDiagnostics()
+	Print("[housezoneaudit][diag] ---- region config diagnostics ----");
+
+	var regions_cfg := ReadConfigFile("::regions/regions");
+	if (!regions_cfg)
+		Print("[housezoneaudit][diag] ReadConfigFile('::regions/regions') returned FALSY.");
+		return;
+	endif
+	Print("[housezoneaudit][diag] ReadConfigFile OK.");
+
+	var keys := GetConfigStringKeys(regions_cfg);
+	if (!keys)
+		Print("[housezoneaudit][diag] GetConfigStringKeys returned FALSY.");
+		return;
+	endif
+	Print("[housezoneaudit][diag] total keys=" + CStr(keys.size()));
+
+	var dungeon_count := 0;
+	var lost_lands_seen := 0;
+
+	foreach key in keys
+		if (CStr(key) == "Lost Lands")
+			lost_lands_seen := lost_lands_seen + 1;
+		endif
+
+		var region := FindConfigElem(regions_cfg, key);
+		if (!region)
+			continue;
+		endif
+
+		var t := Lower(CStr(GetConfigString(region, "Type")));
+		if (t == "dungeon")
+			dungeon_count := dungeon_count + 1;
+		endif
+	endforeach
+
+	Print("[housezoneaudit][diag] dungeon_count via full key iteration=" + CStr(dungeon_count));
+	Print("[housezoneaudit][diag] 'Lost Lands' occurrences in keys array=" + CStr(lost_lands_seen));
+
+	var direct := FindConfigElem(regions_cfg, "Lost Lands");
+	if (!direct)
+		Print("[housezoneaudit][diag] Direct FindConfigElem(regions_cfg,'Lost Lands') returned FALSY.");
+	else
+		var dt := GetConfigString(direct, "Type");
+		var dr := SplitWords(CStr(GetConfigString(direct, "Range")));
+		if (!dr or dr.size() < 4)
+			Print("[housezoneaudit][diag] Direct 'Lost Lands' Type='" + CStr(dt) + "' Range=NONE/short");
+		else
+			var rx1 := CInt(dr[1]);
+			var ry1 := CInt(dr[2]);
+			var rx2 := CInt(dr[3]);
+			var ry2 := CInt(dr[4]);
+			Print("[housezoneaudit][diag] Direct 'Lost Lands' Type='" + CStr(dt) + "' Range=" + CStr(rx1) + "," + CStr(ry1) + "," + CStr(rx2) + "," + CStr(ry2));
+
+			// Known tower from the gotomulti screenshot: smalltower at 5803,3375.
+			// Pure point-in-box check, independent of GetMultiDimensions/objtype lookup.
+			var px := 5803;
+			var py := 3375;
+			var inside := 0;
+			if ((px >= rx1) and (px <= rx2) and (py >= ry1) and (py <= ry2))
+				inside := 1;
+			endif
+			Print("[housezoneaudit][diag] point 5803,3375 inside Lost Lands Range box=" + CStr(inside));
+		endif
+	endif
+
+	Print("[housezoneaudit][diag] ---- end diagnostics ----");
+endfunction
+
+// Mirrors GetHouseFootprintBounds()/ResolveHouseMultiId() in
+// pkg/std/housing/housedeed.src so the audit matches exactly what
+// placement-time checks. GetMultiDimensions() needs the raw multi ID from
+// pkg/std/housing/itemdesc.cfg's "MultiID" field, not the house objtype.
+function ResolveHouseMultiId(housetype)
+	var house_itemdesc := ReadConfigFile(":housing:itemdesc");
+	if (!house_itemdesc)
+		return housetype;
+	endif
+
+	var elem := house_itemdesc[housetype];
+	if (!elem)
+		elem := FindConfigElem(house_itemdesc, housetype);
+	endif
+	if (!elem)
+		return housetype;
+	endif
+
+	var multiid := GetConfigInt(elem, "MultiID");
+	if (!multiid)
+		return housetype;
+	endif
+
+	return multiid;
+endfunction
+
+function GetHouseFootprintBounds(housetype, x, y)
+	var dims := GetMultiDimensions(ResolveHouseMultiId(housetype));
+	if (!dims)
+		return 0;
+	endif
+
+	return { x + dims.xmin, y + dims.ymin, x + dims.xmax, y + dims.ymax };
+endfunction
+
+// Returns array{region_type, region_name} for the first matching region, or 0.
+// NormalizeRegionType()/IsBoxOverlappingRegionType() live in include/checkcity,
+// shared with CheckCity() and housedeed.src's placement check.
+function FindBlockingRegion(housetype, x, y, realm)
+	var bounds := GetHouseFootprintBounds(housetype, x, y);
+	if (!bounds)
+		return 0;
+	endif
+
+	var blocked_types := array{"city", "dungeon", "shrine", "graveyard"};
+	foreach region_type in blocked_types
+		var blocking_region := IsBoxOverlappingRegionType(bounds[1], bounds[2], bounds[3], bounds[4], realm, region_type);
+		if (blocking_region)
+			return array{region_type, blocking_region.name};
+		endif
+	endforeach
+
+	return 0;
+endfunction

--- a/pkg/opt/alryc/textcmd/test/shardstress.src
+++ b/pkg/opt/alryc/textcmd/test/shardstress.src
@@ -1,0 +1,46 @@
+// Synopsis: Spawn many concurrent AI/login workers to simulate sustained multi-day-style shard load
+use uo;
+use os;
+use basicio;
+
+const SHARDSTRESS_AREA_WORKERS := 20;
+const SHARDSTRESS_EMAIL_WORKERS := 10;
+const SHARDSTRESS_DURATION_MINUTES := 15; // bump this for a longer soak - it's just a duration
+                                           // passed to self-terminating workers, safe to set to
+                                           // hours if you want to actually leave it running
+
+program shardstress( who )
+
+	var duration_seconds := SHARDSTRESS_DURATION_MINUTES * 60;
+	var i;
+	var script;
+
+	SendSysMessage( who, "Spawning "+SHARDSTRESS_AREA_WORKERS+" area-check workers and "+SHARDSTRESS_EMAIL_WORKERS+" email-login workers, "+SHARDSTRESS_DURATION_MINUTES+" minutes each." );
+	SendSysMessage( who, "This simulates sustained mixed player/AI load, not a single script's burst. Watch pol.exe's Handles count in Task Manager over the whole run." );
+	Sleep(5);
+
+	SysLog("[shardstress] spawning area="+SHARDSTRESS_AREA_WORKERS+" email="+SHARDSTRESS_EMAIL_WORKERS+" duration_min="+SHARDSTRESS_DURATION_MINUTES);
+	Print("[shardstress] spawning area="+SHARDSTRESS_AREA_WORKERS+" email="+SHARDSTRESS_EMAIL_WORKERS+" duration_min="+SHARDSTRESS_DURATION_MINUTES);
+
+	for( i := 1; i <= SHARDSTRESS_AREA_WORKERS; i := i + 1 )
+		script := start_script( ":alryc:stresstest/areastressworker", {i, duration_seconds} );
+		if( script.errortext )
+			SysLog("[shardstress] area-worker "+i+" failed to start: "+script.errortext);
+		endif
+		SleepMS(50);
+	endfor
+
+	for( i := 1; i <= SHARDSTRESS_EMAIL_WORKERS; i := i + 1 )
+		script := start_script( ":alryc:stresstest/emailstressworker", {i, duration_seconds} );
+		if( script.errortext )
+			SysLog("[shardstress] email-worker "+i+" failed to start: "+script.errortext);
+		endif
+		SleepMS(50);
+	endfor
+
+	SysLog("[shardstress] all "+(SHARDSTRESS_AREA_WORKERS+SHARDSTRESS_EMAIL_WORKERS)+" workers spawned - running for ~"+SHARDSTRESS_DURATION_MINUTES+" minutes");
+	Print("[shardstress] all "+(SHARDSTRESS_AREA_WORKERS+SHARDSTRESS_EMAIL_WORKERS)+" workers spawned - running for ~"+SHARDSTRESS_DURATION_MINUTES+" minutes");
+
+	SendSysMessage( who, "All workers spawned and running independently. Each logs to console+pol.log via SysLog when it finishes. Afterward: grep shardstress log/pol.log" );
+
+endprogram

--- a/pkg/opt/areas/areas.cfg
+++ b/pkg/opt/areas/areas.cfg
@@ -73,11 +73,11 @@ Areas britannia
 	Area 1232 1519 3596 3923 id=jhelom cat=city Jhelom
 	Area 1372 1531 3948 4051 id=southjhelomisland cat=city South Jhelom Island
 	Area 512 695 2048 2299 id=skarabrae cat=city Skara Brae
-	Area 696 911 2056 2423 id=skarabraefarmlands cat=city Skara Brae Farmlands
+	Area 696 911 2056 2423 id=skarabraefarmlands cat=suburb Skara Brae Farmlands
 	Area 6912 7167 256 511 id=elventown cat=city Elven Town
 	Area 1408 1711 1500 1795 id=britain cat=city Britain
 	Area 1288 1407 1700 1839 id=britainfarmlands cat=city Britain Farmlands
-	Area 1084 1287 1540 1903 id=britainouterfarmlands cat=city Britain Outer Farmlands
+	Area 1084 1287 1540 1903 id=britainouterfarmlands cat=suburb Britain Outer Farmlands
 	Area 1500 1543 1404 1499 id=lordblackthornescastle cat=city Lord Blackthornes Castle
 	Area 1288 1407 1556 1699 id=lordbritishcastle cat=city Lord British Castle
 	Area 3480 3827 1032 1427 id=nujelm cat=city Nujel'm
@@ -86,8 +86,8 @@ Areas britannia
 	Area 5632 5843 3092 3319 id=papau cat=city Papau
 	Area 2204 2295 1112 1243 id=cove cat=city Cove
 	Area 2388 2539 348 603 id=minoc cat=city Minoc
-	Area 2540 2627 552 603 id=minocfarmlands cat=city Minoc Farmlands
-	Area 2464 2623 604 687 id=minocfarmlands2 cat=city Minoc Farmlands
+	Area 2540 2627 552 603 id=minocfarmlands cat=suburb Minoc Farmlands
+	Area 2464 2623 604 687 id=minocfarmlands2 cat=suburb Minoc Farmlands
 	Area 2540 2635 372 551 id=minocisle cat=city Minoc Isle
 	Area 4380 4735 792 1235 id=moonglow cat=city Moonglow
 	Area 4248 4379 876 1103 id=moonglowkeep cat=city Moonglow Keep
@@ -96,14 +96,14 @@ Areas britannia
 	Area 2936 2987 684 799 id=vesper2 cat=city Vesper
 	Area 2988 3035 748 799 id=vesper3 cat=city Vesper
 	Area 2820 3055 800 1015 id=vesper4 cat=city Vesper
-	Area 2936 3007 600 655 id=vesperoutbuildings cat=city Vesper Outbuildings
-	Area 2716 2819 928 1015 id=vesperoutbuildings2 cat=city Vesper Outbuildings
+	Area 2936 3007 600 655 id=vesperoutbuildings cat=suburb Vesper Outbuildings
+	Area 2716 2819 928 1015 id=vesperoutbuildings2 cat=suburb Vesper Outbuildings
 	Area 500 599 928 1051 id=yew cat=city Yew
 	Area 192 411 700 927 id=yewisland cat=city Yew Island
-	Area 412 539 772 927 id=yewfarmlands cat=city Yew Farmlands
-	Area 232 499 928 1255 id=yewfarmlands2 cat=city Yew Farmlands
-	Area 500 599 1052 1255 id=yewfarmlands3 cat=city Yew Farmlands
-	Area 600 707 928 1255 id=yewfarmlands4 cat=city Yew Farmlands
+	Area 412 539 772 927 id=yewfarmlands cat=suburb Yew Farmlands
+	Area 232 499 928 1255 id=yewfarmlands2 cat=suburb Yew Farmlands
+	Area 500 599 1052 1255 id=yewfarmlands3 cat=suburb Yew Farmlands
+	Area 600 707 928 1255 id=yewfarmlands4 cat=suburb Yew Farmlands
 
 	//Britannia Dungeons
 	Area 5632 5947 1760 2047 id=solenhive cat=dungeon Solen Hive

--- a/pkg/opt/areas/include/areapolicy.inc
+++ b/pkg/opt/areas/include/areapolicy.inc
@@ -481,6 +481,7 @@ function GetPolicyMask(realm, area_id)
 				mask := CInt(prop_val);
 			endif
 		endif
+		UnloadDataFile(GetRealmPolicyDescriptor(realm));
 	endif
 
 	return StoreCachedPolicyMask(realm, realm_cache, area_id, mask);
@@ -498,6 +499,7 @@ function SetPolicyMask(realm, area_id, mask, updated_by := "")
 	var elem := DFFindElement(file_ref, CStr(area_id), DF_CREATE);
 	if(elem == error)
 		Print("[areas.persist] set element failed realm=" + CStr(realm) + " area_id=" + CStr(area_id));
+		UnloadDataFile(GetRealmPolicyDescriptor(realm));
 		return elem;
 	endif
 
@@ -518,6 +520,7 @@ function SetPolicyMask(realm, area_id, mask, updated_by := "")
 	endif
 
 	Print("[areas.persist] set end realm=" + CStr(realm) + " area_id=" + CStr(area_id));
+	UnloadDataFile(GetRealmPolicyDescriptor(realm));
 	return CInt(mask);
 endfunction
 
@@ -533,6 +536,7 @@ function PruneStaleRealmPolicies(realm)
 	var area_lines := GetRealmAreaLines(realm);
 	if(area_lines == error)
 		Print("[areas.persist] prune load areas failed realm=" + CStr(realm));
+		UnloadDataFile(GetRealmPolicyDescriptor(realm));
 		return 0;
 	endif
 
@@ -548,6 +552,7 @@ function PruneStaleRealmPolicies(realm)
 	var keys := file_ref.Keys();
 	if(keys == error)
 		Print("[areas.persist] prune keys failed realm=" + CStr(realm));
+		UnloadDataFile(GetRealmPolicyDescriptor(realm));
 		return 0;
 	endif
 	Print("[areas.persist] prune keys realm=" + CStr(realm) + " count=" + CStr(keys.size()));
@@ -571,5 +576,6 @@ function PruneStaleRealmPolicies(realm)
 	InvalidatePolicyMaskCache(realm);
 
 	Print("[areas.persist] prune end realm=" + CStr(realm) + " removed=" + CStr(removed));
+	UnloadDataFile(GetRealmPolicyDescriptor(realm));
 	return removed;
 endfunction

--- a/pkg/opt/areas/textcmd/admin/areas.src
+++ b/pkg/opt/areas/textcmd/admin/areas.src
@@ -52,7 +52,7 @@ var FACET_REALM_OPTIONS := {"britannia", "britannia_alt", "ilshenar", "malas", "
 // file order, which is what ResolveAreaKeyAtLocation()/ResolveAreaMatchAtLocation()
 // in areapolicy.inc walk (first bounding-box match wins) - reordering that would
 // change which policy applies at overlapping coordinates server-wide.
-var CATEGORY_ORDER := {"world", "city", "dungeon", "poi", "graveyard", "shrine", "entrance"};
+var CATEGORY_ORDER := {"world", "city", "suburb", "dungeon", "poi", "graveyard", "shrine", "entrance"};
 
 set_script_option(SCRIPTOPT_NO_RUNAWAY,1);
 

--- a/pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src
+++ b/pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src
@@ -258,7 +258,7 @@ endfunction
 // the old 8-pass approach that re-scanned the growing "ordered" list for
 // every entry (O(n^2)*8) -- same fix as go.src's ReorderLocationsForDisplay.
 function ReorderLocationsForDisplay(locs)
-	var type_priority := {"Jail", "City", "Shrine", "Graveyard", "Dungeon", "POI", "None"};
+	var type_priority := {"Jail", "City", "Suburb", "Shrine", "Graveyard", "Dungeon", "POI", "None"};
 	var known_types := dictionary;
 	foreach wanted_type in type_priority
 		known_types.Insert(wanted_type, 1);
@@ -328,6 +328,8 @@ function NormalizeTypeLabel(region_type)
 			return "POI";
 		"city":
 			return "City";
+		"suburb":
+			return "Suburb";
 		"shrine":
 			return "Shrine";
 		"dungeon":

--- a/pkg/opt/statichousing/ssign.src
+++ b/pkg/opt/statichousing/ssign.src
@@ -189,8 +189,13 @@ program use_sign (who, sign)
 		dataforsale[6] := maxsecures;
 		result := SendDialogGump( who, layoutforsale, dataforsale );
 		case (result[0])
-			1: 		
+			1:
 			if( YesNo( who, "Confirm purchase." ) )
+				if( IsAccountAtHouseLimit(who) )
+					Print("[houselimit][debug] ssign purchase blocked - account at house limit");
+					SendSysMessage( who, "You already own the maximum of " + CStr(MAX_HOUSES_PER_ACCOUNT) + " houses on this account.", FONT_NORMAL, 2595);
+					return;
+				endif
 				if( who.spendgold(Cint(price)) )
 					SetObjProperty( sign, "OrigPrice", price);
 					EraseObjProperty( sign, "Price");
@@ -326,6 +331,11 @@ function ChangeHouseOwner( who , sign )
 	if( oldownerserial == who.serial )
 		return 0;
  	elseif(who.acctname)
+		if( IsAccountAtHouseLimit(who) )
+			Print("[houselimit][debug] ssign.ChangeHouseOwner blocked - account at house limit");
+			Sendsysmessage( who , "You already own the maximum of " + CStr(MAX_HOUSES_PER_ACCOUNT) + " houses on this account.", FONT_NORMAL, 2595 );
+			return 0;
+		endif
 		SetObjProperty( sign , "ownerserial" , who.serial );
 		SetObjProperty( sign , "owneracct" , who.acctname );
 		SetObjProperty( sign , "ownername", who.name );

--- a/pkg/opt/sysbook/start.src
+++ b/pkg/opt/sysbook/start.src
@@ -56,4 +56,5 @@ endif
 endforeach
 
 UnloadConfigFile("zulubooks");
+UnloadDataFile("staticbooks");
 endprogram

--- a/pkg/opt/townstones/textcmd/admin/createtownstone.src
+++ b/pkg/opt/townstones/textcmd/admin/createtownstone.src
@@ -231,7 +231,7 @@ function GetRegionRange(regions_cfg, region_name)
 		return {};
 	endif
 
-	var coords := GetConfigStringArray(elem, "Range");
+	var coords := SplitWords(CStr(GetConfigString(elem, "Range")));
 	if(!coords or coords.size() < 4)
 		return {};
 	endif

--- a/pkg/opt/townstones/textcmd/admin/townbankstatus.src
+++ b/pkg/opt/townstones/textcmd/admin/townbankstatus.src
@@ -1498,7 +1498,7 @@ function GetRegionRange(regions_cfg, region_name)
 		return {};
 	endif
 
-	var coords := GetConfigStringArray(elem, "Range");
+	var coords := SplitWords(CStr(GetConfigString(elem, "Range")));
 	if(!coords or coords.size() < 4)
 		return {};
 	endif

--- a/pkg/std/housing/changeowner.src
+++ b/pkg/std/housing/changeowner.src
@@ -13,6 +13,8 @@
 use uo;
 use os;
 
+include "utility";
+
 program ChangeHouseOwner( who , title )
 
    var houseserial := GetObjProperty( title, "builtserial" );
@@ -33,9 +35,23 @@ program ChangeHouseOwner( who , title )
        SendSysmessage( who , "You are already the owner of that house." );
        return;
    else
+       if( IsAccountAtHouseLimit(who) )
+           Print("[houselimit][debug] changeowner.ChangeHouseOwner blocked - account at house limit");
+           SendSysmessage( who , "You already own the maximum of " + CStr(MAX_HOUSES_PER_ACCOUNT) + " houses on this account." );
+           return;
+       endif
+
        SetObjProperty( house , "ownerserial" , who.serial );
+       SetObjProperty( house , "owneracct" , who.acctname );
        SendSysmessage( who , "You have taken ownership of the house." );
        SendSysmessage( who , "It would be wise to change the locks soon." );
+
+       // Keep the "Houses" cprop in sync - previously this path never updated
+       // it, so the old owner's list went stale and the new owner's never
+       // gained the house (pkg/std/housing/sign.src's ChangeHouseOwner does
+       // this already; this flow just never had it).
+       AddHouseToCharacter(who, house.serial);
+       RemoveHouseFromCharacter(SystemFindObjectBySerial(oldownerserial, SYSFIND_SEARCH_OFFLINE_MOBILES), house.serial);
    endif
 endprogram
 

--- a/pkg/std/housing/housedeed.src
+++ b/pkg/std/housing/housedeed.src
@@ -69,8 +69,16 @@ function Buildhouse( character, deed )
         return;
     endif
 
+    if (IsAccountAtHouseLimit(character))
+        Print("[houselimit][debug] Buildhouse blocked - account at house limit");
+        PrintTextAbovePrivate( deed, "You already own the maximum of " + CStr(MAX_HOUSES_PER_ACCOUNT) + " houses on this account.", character );
+        return;
+    endif
+
     var where := TargetMultiPlacement( character, housetype );
     if (!where) return; endif
+
+    Print("[housedeed][debug] " + CStr(character.name) + " attempting to place housetype=" + CStr(Hex(housetype)) + " at " + CStr(where.x) + "," + CStr(where.y) + " realm=" + CStr(where.realm) + " cmdlevel=" + CStr(character.cmdlevel));
 
     if (character.cmdlevel < 4)
     if(IsHousePlacementBlockedByRegionType(housetype, where, "city"))
@@ -92,6 +100,8 @@ function Buildhouse( character, deed )
         PrintTextAbovePrivate(deed, "You can't build in graveyards.", character);
         return;
     endif
+
+    Print("[housedeed][debug] city/dungeon/shrine/graveyard checks all passed, continuing placement checks");
 
     var blocked_reason := IsHousePlacementBlockedByNearbySpecialObjects(where);
     if(blocked_reason)
@@ -449,41 +459,14 @@ function CreatehouseKeysAndBuiltDeed( character, housetype, where, deed )
     return result;
 endfunction
 
-function NormalizeRegionType(region_type)
-    case(Lower(CStr(region_type)))
-        "poi":
-            return "poi";
-        "city":
-            return "city";
-        "shrine":
-            return "shrine";
-        "dungeon":
-            return "dungeon";
-        "graveyard":
-            return "graveyard";
-        "jail":
-            return "jail";
-        "none":
-            return "none";
-    endcase
-
-    return Lower(CStr(region_type));
-endfunction
-
+// NormalizeRegionType()/IsBoxOverlappingRegionType() live in include/checkcity
+// now (shared with CheckCity() and housezoneaudit.src's audit tool).
 function IsHousePlacementBlockedByRegionType(housetype, where, region_type)
+    Print("[housedeed][debug] IsHousePlacementBlockedByRegionType ENTER type='" + CStr(region_type) + "' housetype=" + CStr(Hex(housetype)));
+
     var bounds := GetHouseFootprintBounds(housetype, where.x, where.y);
     if(!bounds)
-        return 0;
-    endif
-
-    var regions_cfg := ReadConfigFile("::regions/regions");
-    if(!regions_cfg)
-        return 0;
-    endif
-
-    var wanted_region_type := NormalizeRegionType(region_type);
-    var keys := GetConfigStringKeys(regions_cfg);
-    if(!keys)
+        Print("[housedeed][debug]   GetHouseFootprintBounds FAILED for housetype=" + CStr(Hex(housetype)) + " (GetMultiDimensions returned falsy) - region check skipped entirely");
         return 0;
     endif
 
@@ -492,36 +475,15 @@ function IsHousePlacementBlockedByRegionType(housetype, where, region_type)
     var x2 := bounds[3];
     var y2 := bounds[4];
 
-    foreach key in keys
-        var region := FindConfigElem(regions_cfg, key);
-        if(!region)
-            continue;
-        endif
+    Print("[housedeed][debug] IsHousePlacementBlockedByRegionType type='" + NormalizeRegionType(region_type) + "' footprint=" + CStr(x1) + "," + CStr(y1) + " to " + CStr(x2) + "," + CStr(y2) + " realm=" + CStr(where.realm));
 
-        if(NormalizeRegionType(GetConfigString(region, "Type")) != wanted_region_type)
-            continue;
-        endif
+    var blocking_region := IsBoxOverlappingRegionType(x1, y1, x2, y2, where.realm, region_type);
+    if(blocking_region)
+        Print("[housedeed][debug]   BLOCKED - overlaps region '" + CStr(blocking_region.name) + "' range=" + CStr(blocking_region.range[1]) + "," + CStr(blocking_region.range[2]) + " to " + CStr(blocking_region.range[3]) + "," + CStr(blocking_region.range[4]));
+        return 1;
+    endif
 
-        var region_realm := Lower(CStr(GetConfigString(region, "Realm")));
-        if(region_realm and (region_realm != Lower(CStr(where.realm))))
-            continue;
-        endif
-
-        var range := GetConfigStringArray(region, "Range");
-        if(!range or range.size() < 4)
-            continue;
-        endif
-
-        var rx1 := CInt(range[1]);
-        var ry1 := CInt(range[2]);
-        var rx2 := CInt(range[3]);
-        var ry2 := CInt(range[4]);
-
-        if((x1 <= rx2) and (x2 >= rx1) and (y1 <= ry2) and (y2 >= ry1))
-            return 1;
-        endif
-    endforeach
-
+    Print("[housedeed][debug] not blocked - no overlapping '" + NormalizeRegionType(region_type) + "' region in realm");
     return 0;
 endfunction
 
@@ -539,8 +501,40 @@ function IsHousePlacementBlockedByNearbySpecialObjects(where)
     return "";
 endfunction
 
+// GetMultiDimensions() needs the raw multi ID, not the house's item objtype.
+// pkg/std/housing/itemdesc.cfg maps every "House <objtype>" block to a
+// separate, much smaller "MultiID" - e.g. House 0xA3EF has MultiID 0x3F.
+// CreateMultiAtLocation()/TargetMultiPlacement() take the objtype directly
+// and translate internally; GetMultiDimensions() does not.
+function ResolveHouseMultiId(housetype)
+    var house_itemdesc := ReadConfigFile(":housing:itemdesc");
+    if(!house_itemdesc)
+        Print("[housedeed][debug]   ResolveHouseMultiId: ReadConfigFile(':housing:itemdesc') FAILED, using housetype as-is");
+        return housetype;
+    endif
+
+    var elem := house_itemdesc[housetype];
+    if(!elem)
+        elem := FindConfigElem(house_itemdesc, housetype);
+    endif
+    if(!elem)
+        Print("[housedeed][debug]   ResolveHouseMultiId: no House block found for housetype=" + CStr(Hex(housetype)) + ", using housetype as-is");
+        return housetype;
+    endif
+
+    var multiid := GetConfigInt(elem, "MultiID");
+    if(!multiid)
+        Print("[housedeed][debug]   ResolveHouseMultiId: House block for housetype=" + CStr(Hex(housetype)) + " has no MultiID, using housetype as-is");
+        return housetype;
+    endif
+
+    Print("[housedeed][debug]   ResolveHouseMultiId: housetype=" + CStr(Hex(housetype)) + " -> MultiID=" + CStr(Hex(multiid)));
+    return multiid;
+endfunction
+
 function GetHouseFootprintBounds(housetype, x, y)
-    var dims := GetMultiDimensions(housetype);
+    var multiid := ResolveHouseMultiId(housetype);
+    var dims := GetMultiDimensions(multiid);
     if(!dims)
         return 0;
     endif

--- a/pkg/std/housing/houseescrow.inc
+++ b/pkg/std/housing/houseescrow.inc
@@ -1,0 +1,1206 @@
+// houseescrow.inc -- Staff "Demolish and Escrow" core logic.
+//
+// Dedicated, independent escrow storage/claim system for house-demolish
+// contents (secures, redeedable furniture, Omega Cache contents, everything
+// else, and the resulting house deed). Modeled on the player-merchant escrow
+// pattern (pkg/systems/playervendor/include/escrow.inc) but deliberately
+// self-contained -- no cross-package include into pkg/systems/playervendor
+// for storage/pack logic, so the two systems can't drift into each other.
+
+use os;
+use uo;
+use storage;
+use datafile;
+use file;
+use basic;
+use polsys;
+
+include "include/objtype";
+include "include/myutil";
+include "include/constants/usescriptids";
+include "include/omegacache_utils";
+include "utility";
+
+const HOUSE_ESCROW_STORAGE_NAME := "House Demolish Escrow";
+const HOUSE_ESCROW_DF_PREFIX := "houseescrow_";
+const HOUSE_ESCROW_PACK_OBJTYPE := UOBJ_BACKPACK;
+const HOUSE_ESCROW_PACK_MAX_ROOT_ITEMS := 225;
+const HOUSE_ESCROW_PACK_MAX_WEIGHT := 60000;
+const HOUSE_ESCROW_LOG_FILE := "::log/houseescrow.log";
+
+const HOUSE_ENTRY_ID_IDX := 1;
+const HOUSE_ENTRY_OWNERSERIAL_IDX := 2;
+const HOUSE_ENTRY_ESCROWNAME_IDX := 3;
+const HOUSE_ENTRY_LABEL_IDX := 4;
+const HOUSE_ENTRY_HOUSESERIAL_IDX := 5;
+const HOUSE_ENTRY_CREATED_IDX := 6;
+const HOUSE_ENTRY_OWNERNAME_IDX := 7;
+
+////////////////////////////////////////////////////////////////////////////
+// Logging -- persistent troubleshooting record, independent of any live
+// console debug flags.
+////////////////////////////////////////////////////////////////////////////
+function HouseEscrowLog(msg)
+	LogToFile(HOUSE_ESCROW_LOG_FILE, msg, LOG_DATETIME);
+endfunction
+
+// Reuses the shard-global "gmpages" GlobalProperty queue that
+// playermerchant.src's QueueGMPageReport already writes to and the
+// counselor-level .page tooling already reads -- a plain GlobalProperty, not
+// owned by any one package, so replicating the small append here is correct
+// rather than adding a cross-package include just for this.
+function QueueHouseEscrowGMPage(subject_serial, message)
+	var gmpages := GetGlobalProperty("gmpages");
+	if(!gmpages)
+		gmpages := {};
+	endif
+	gmpages.append(subject_serial);
+	gmpages.append("[HouseEscrow] " + message);
+	SetGlobalProperty("gmpages", gmpages);
+endfunction
+
+////////////////////////////////////////////////////////////////////////////
+// Storage area / per-owner DataFile index
+////////////////////////////////////////////////////////////////////////////
+function OpenHouseEscrowStorage()
+	var area := FindStorageArea(HOUSE_ESCROW_STORAGE_NAME);
+	if(!area)
+		area := CreateStorageArea(HOUSE_ESCROW_STORAGE_NAME);
+	endif
+	return area;
+endfunction
+
+// Takes a raw serial, not a character object -- this must keep working even
+// when the owning character can no longer be resolved, so an escrow entry can
+// still be filed and found later instead of silently dropped.
+//
+// Package-scoped (":housing:...") is mandatory here, not cosmetic -- a bare
+// filespec apparently resolves relative to whichever package the calling
+// script was compiled into, so pkg/std/housing/houseescrow.inc (this file)
+// and scripts/textcmd/player/houseescrow.src (the claim command, a
+// different package) were silently writing to/reading from two different
+// datafiles despite using the identical bare name string. Confirmed via
+// this repo's only other cross-file DataFile usage (pkg/opt/townstones'
+// ":townstone:townstone_data", shared verbatim across multiple files) --
+// nothing in this codebase successfully shares a DataFile across files
+// without an explicit package prefix.
+function BuildHouseEscrowDatafileNameForSerial(owner_serial)
+	if(!owner_serial)
+		return "";
+	endif
+	return ":housing:" + HOUSE_ESCROW_DF_PREFIX + CStr(owner_serial);
+endfunction
+
+// Percent-style escaping for the free-text fields (house label / owner name)
+// embedded in the "|"/"^"-delimited entry format. Escape "%" first on encode,
+// restore it last on decode.
+function HouseEscrowEscapeField(s)
+	s := CStr(s);
+	s := StrReplace(s, "%", "%25");
+	s := StrReplace(s, "|", "%7C");
+	s := StrReplace(s, "^", "%5E");
+	return s;
+endfunction
+
+function HouseEscrowUnescapeField(s)
+	s := CStr(s);
+	s := StrReplace(s, "%7C", "|");
+	s := StrReplace(s, "%5E", "^");
+	s := StrReplace(s, "%25", "%");
+	return s;
+endfunction
+
+function HouseEntryId(entry)
+	if(len(entry) >= HOUSE_ENTRY_ID_IDX)
+		return entry[HOUSE_ENTRY_ID_IDX];
+	endif
+	return "";
+endfunction
+
+function HouseEntryOwnerSerial(entry)
+	if(len(entry) >= HOUSE_ENTRY_OWNERSERIAL_IDX)
+		return CInt(entry[HOUSE_ENTRY_OWNERSERIAL_IDX]);
+	endif
+	return 0;
+endfunction
+
+function HouseEntryEscrowName(entry)
+	if(len(entry) >= HOUSE_ENTRY_ESCROWNAME_IDX)
+		return entry[HOUSE_ENTRY_ESCROWNAME_IDX];
+	endif
+	return "";
+endfunction
+
+function HouseEntryLabel(entry)
+	if(len(entry) >= HOUSE_ENTRY_LABEL_IDX)
+		return entry[HOUSE_ENTRY_LABEL_IDX];
+	endif
+	return "House";
+endfunction
+
+function HouseEntryHouseSerial(entry)
+	if(len(entry) >= HOUSE_ENTRY_HOUSESERIAL_IDX)
+		return CInt(entry[HOUSE_ENTRY_HOUSESERIAL_IDX]);
+	endif
+	return 0;
+endfunction
+
+function HouseEntryCreated(entry)
+	if(len(entry) >= HOUSE_ENTRY_CREATED_IDX)
+		return CInt(entry[HOUSE_ENTRY_CREATED_IDX]);
+	endif
+	return 0;
+endfunction
+
+function HouseEntryOwnerName(entry)
+	if(len(entry) >= HOUSE_ENTRY_OWNERNAME_IDX and entry[HOUSE_ENTRY_OWNERNAME_IDX])
+		return entry[HOUSE_ENTRY_OWNERNAME_IDX];
+	endif
+	return "Unknown Owner";
+endfunction
+
+function EncodeHouseEscrowEntryFields(id, ownerserial, escrow_name, house_label, house_serial, created, owner_name)
+	return CStr(id) + "|" + CStr(ownerserial) + "|" + CStr(escrow_name) + "|" + HouseEscrowEscapeField(house_label) + "|" + CStr(house_serial) + "|" + CStr(created) + "|" + HouseEscrowEscapeField(owner_name);
+endfunction
+
+function EncodeHouseEscrowEntries(entries)
+	var encoded := "";
+	foreach entry in entries
+		if(encoded)
+			encoded := encoded + "^";
+		endif
+		encoded := encoded + EncodeHouseEscrowEntryFields(HouseEntryId(entry), HouseEntryOwnerSerial(entry), HouseEntryEscrowName(entry), HouseEntryLabel(entry), HouseEntryHouseSerial(entry), HouseEntryCreated(entry), HouseEntryOwnerName(entry));
+	endforeach
+	return encoded;
+endfunction
+
+function DecodeHouseEscrowEntries(entries_str)
+	var entries := {};
+	if(!entries_str)
+		return entries;
+	endif
+
+	var parts := SplitWords(entries_str, "^");
+	foreach part in parts
+		if(part)
+			var fields := SplitWords(part, "|");
+			if(len(fields) >= 7)
+				entries.append({
+					fields[1],
+					CInt(fields[2]),
+					fields[3],
+					HouseEscrowUnescapeField(fields[4]),
+					CInt(fields[5]),
+					CInt(fields[6]),
+					HouseEscrowUnescapeField(fields[7])
+				});
+			endif
+		endif
+	endforeach
+
+	return entries;
+endfunction
+
+// Read-modify-write of the per-owner datafile's per-house element. No
+// sleep/wait_for_event happens anywhere between OpenDataFile and
+// UnloadDataFile in this function, which keeps it atomic under POL's
+// cooperative script scheduler -- do not add one here without re-adding real
+// synchronization.
+function AppendHouseEscrowIndex(ownerserial, house_serial, escrow_name, house_label, owner_name)
+	var df_name := BuildHouseEscrowDatafileNameForSerial(ownerserial);
+	Print("[houseescrow][debug] AppendHouseEscrowIndex: owner=" + ownerserial + " house=" + house_serial + " -> df_name=" + df_name);
+	if(!df_name)
+		HouseEscrowLog("[ERROR] AppendHouseEscrowIndex: failed to build datafile name for owner=" + ownerserial + " house=" + house_serial);
+		Print("[houseescrow][debug] AppendHouseEscrowIndex: ABORTED -- BuildHouseEscrowDatafileNameForSerial returned empty for owner=" + ownerserial + " (owner serial is likely 0/falsy)");
+		return "";
+	endif
+
+	var df := OpenDataFile(df_name);
+	if(!df)
+		CreateDataFile(df_name);
+		df := OpenDataFile(df_name);
+		if(!df)
+			HouseEscrowLog("[ERROR] AppendHouseEscrowIndex: failed to open/create datafile " + df_name);
+			Print("[houseescrow][debug] AppendHouseEscrowIndex: ABORTED -- could not open/create datafile " + df_name);
+			return "";
+		endif
+	endif
+
+	var house_key := CStr(house_serial);
+	var house_elem := df.FindElement(house_key);
+	if(!house_elem)
+		house_elem := df.CreateElement(house_key);
+	endif
+	if(!house_elem)
+		HouseEscrowLog("[ERROR] AppendHouseEscrowIndex: failed to create/find element " + house_key + " in " + df_name);
+		Print("[houseescrow][debug] AppendHouseEscrowIndex: ABORTED -- could not create/find element " + house_key + " in " + df_name);
+		UnloadDataFile(df_name);
+		return "";
+	endif
+
+	var entry_id := ownerserial + "-" + ReadGameClock() + "-" + Random(100000);
+
+	var entries := DecodeHouseEscrowEntries(house_elem.GetProp("entries"));
+	entries.append({
+		entry_id,
+		CInt(ownerserial),
+		escrow_name,
+		house_label,
+		CInt(house_serial),
+		ReadGameClock(),
+		owner_name
+	});
+	house_elem.SetProp("entries", EncodeHouseEscrowEntries(entries));
+	UnloadDataFile(df_name);
+
+	HouseEscrowLog("Indexed entry_id=" + entry_id + " owner=" + ownerserial + " (" + owner_name + ") house=" + house_serial + " (" + house_label + ") escrow_name=" + escrow_name + " df=" + df_name);
+	Print("[houseescrow][debug] AppendHouseEscrowIndex: SUCCESS entry_id=" + entry_id + " owner=" + ownerserial + " df=" + df_name + " entries_in_element_now=" + len(entries));
+	return entry_id;
+endfunction
+
+// Creates the escrow root and moves the pack into storage, but does NOT
+// index it -- returns the escrow_name string on success ("" on failure) so
+// the caller can batch-index every pack for a house in one shot via
+// AppendHouseEscrowIndexBatch instead of one datafile
+// open/decode/append/encode/save cycle per pack. A house with hundreds of
+// packs (a heavily-loaded fortress, many full secures) doing that per-pack
+// was O(N^2) in the entries list size -- 346 packs in one real test.
+function SaveHouseEscrowPack(hpack, ownerserial, house_serial, house_label)
+	var area := OpenHouseEscrowStorage();
+	if(!area)
+		HouseEscrowLog("[ERROR] SaveHouseEscrowPack: escrow storage area unavailable for house=" + house_serial + " owner=" + ownerserial);
+		return "";
+	endif
+
+	var escrow_name := "HouseEscrow " + ownerserial + " " + house_serial + " " + ReadGameClock() + " " + Random(99999);
+	var escrow_root := CreateRootItemInStorageArea(area, escrow_name, UOBJ_BACKPACK);
+	if(!escrow_root)
+		HouseEscrowLog("[ERROR] SaveHouseEscrowPack: failed to create escrow root " + escrow_name + " for house=" + house_serial);
+		return "";
+	endif
+
+	escrow_root.name := house_label + " Escrow";
+	SetObjProperty(escrow_root, "ownerserial", CInt(ownerserial));
+	SetObjProperty(escrow_root, "house_serial", CInt(house_serial));
+	SetObjProperty(escrow_root, "house_label", house_label);
+	SetObjProperty(escrow_root, "created", ReadGameClock());
+
+	if(!MoveItemToContainer(hpack, escrow_root))
+		HouseEscrowLog("[ERROR] SaveHouseEscrowPack: failed to move pack into escrow root " + escrow_name + " for house=" + house_serial);
+		DestroyRootItemInStorageArea(area, escrow_name);
+		return "";
+	endif
+
+	HouseEscrowLog("Saved pack to escrow root " + escrow_name + " for house=" + house_serial + " owner=" + ownerserial);
+	return escrow_name;
+endfunction
+
+// Indexes every saved pack for one house in a single
+// open/decode/append-all/encode/save cycle -- see the comment on
+// SaveHouseEscrowPack above for why this replaced indexing one pack at a
+// time.
+function AppendHouseEscrowIndexBatch(ownerserial, house_serial, house_label, owner_name, byref escrow_names)
+	if(!len(escrow_names))
+		return;
+	endif
+
+	var df_name := BuildHouseEscrowDatafileNameForSerial(ownerserial);
+	if(!df_name)
+		HouseEscrowLog("[ERROR] AppendHouseEscrowIndexBatch: failed to build datafile name for owner=" + ownerserial + " house=" + house_serial);
+		Print("[houseescrow][debug] AppendHouseEscrowIndexBatch: ABORTED -- BuildHouseEscrowDatafileNameForSerial returned empty for owner=" + ownerserial);
+		return;
+	endif
+
+	var df := OpenDataFile(df_name);
+	if(!df)
+		CreateDataFile(df_name);
+		df := OpenDataFile(df_name);
+		if(!df)
+			HouseEscrowLog("[ERROR] AppendHouseEscrowIndexBatch: failed to open/create datafile " + df_name);
+			Print("[houseescrow][debug] AppendHouseEscrowIndexBatch: ABORTED -- could not open/create datafile " + df_name);
+			return;
+		endif
+	endif
+
+	var house_key := CStr(house_serial);
+	var house_elem := df.FindElement(house_key);
+	if(!house_elem)
+		house_elem := df.CreateElement(house_key);
+	endif
+	if(!house_elem)
+		HouseEscrowLog("[ERROR] AppendHouseEscrowIndexBatch: failed to create/find element " + house_key + " in " + df_name);
+		Print("[houseescrow][debug] AppendHouseEscrowIndexBatch: ABORTED -- could not create/find element " + house_key + " in " + df_name);
+		UnloadDataFile(df_name);
+		return;
+	endif
+
+	var entries := DecodeHouseEscrowEntries(house_elem.GetProp("entries"));
+	foreach escrow_name in escrow_names
+		var entry_id := ownerserial + "-" + ReadGameClock() + "-" + Random(100000);
+		entries.append({
+			entry_id,
+			CInt(ownerserial),
+			escrow_name,
+			house_label,
+			CInt(house_serial),
+			ReadGameClock(),
+			owner_name
+		});
+	endforeach
+	house_elem.SetProp("entries", EncodeHouseEscrowEntries(entries));
+	UnloadDataFile(df_name);
+
+	HouseEscrowLog("AppendHouseEscrowIndexBatch: owner=" + ownerserial + " (" + owner_name + ") house=" + house_serial + " (" + house_label + ") indexed " + len(escrow_names) + " pack(s), df=" + df_name + ", entries_in_element_now=" + len(entries));
+	Print("[houseescrow][debug] AppendHouseEscrowIndexBatch: SUCCESS owner=" + ownerserial + " df=" + df_name + " indexed=" + len(escrow_names) + " entries_in_element_now=" + len(entries));
+endfunction
+
+////////////////////////////////////////////////////////////////////////////
+// Weight-safe pack builder -- independent copy of playermerchant.src's
+// CreatePayoutPack/CanPlaceInPayoutPack/MoveItemToPayoutPacks. No ground-drop
+// fallback: packs can always be spun up fresh.
+////////////////////////////////////////////////////////////////////////////
+function CreateHouseEscrowPack(label, realm)
+	// Staging packs must be created in the SAME realm as the house being
+	// swept -- MoveItemToContainer moving a world item into a container that
+	// lives in a different realm silently fails (returns 0, no exception),
+	// which is exactly what caused mass "could not be moved into escrow"
+	// failures across every item type on a house outside the default
+	// "britannia" realm (this shard has 5: britannia, britannia_alt,
+	// ilshenar, malas, tokuno -- see config/gorealm.cfg). Once a pack is
+	// later moved into the storage area (SaveHouseEscrowPack), realm stops
+	// mattering -- storage-area roots aren't world-realm-bound -- so only
+	// this initial staging creation needs to match.
+	var hpack := CreateItemAtLocation(5288, 1176, 0, HOUSE_ESCROW_PACK_OBJTYPE, 1, realm);
+	if(hpack and !hpack.errortext)
+		hpack.name := label + " escrow";
+		return hpack;
+	endif
+	return 0;
+endfunction
+
+function CanPlaceInHouseEscrowPack(hpack, item)
+	var roots := ListRootItemsInContainer(hpack);
+	if(len(roots) >= HOUSE_ESCROW_PACK_MAX_ROOT_ITEMS)
+		return 0;
+	endif
+	var estweight := CInt(hpack.weight) + CInt(item.weight);
+	if(estweight > HOUSE_ESCROW_PACK_MAX_WEIGHT)
+		return 0;
+	endif
+	return 1;
+endfunction
+
+function MoveItemToHouseEscrowPacks(byref packs, byref item, label, realm, source := "unknown")
+	// Defensive guard against a stale/bad item reference (seen in practice
+	// from live-iteration hazards upstream, e.g. a container listing walked
+	// while being drained) -- without this, item.movable below throws and
+	// the failure gets logged as an unhelpful "<uninitialized object>"
+	// instead of a clear, greppable message. `source` identifies which
+	// call site handed us the bad reference, since that's the one piece
+	// of information the item itself can no longer tell us.
+	if(!item or item.errortext)
+		Print("[houseescrow][ERROR] MoveItemToHouseEscrowPacks: received an invalid/stale item reference (source=" + source + ") for label=" + label + " -- skipped, nothing to move.");
+		HouseEscrowLog("[ERROR] MoveItemToHouseEscrowPacks: received an invalid/stale item reference (source=" + source + ") for label=" + label + " -- skipped, nothing to move.");
+		return 0;
+	endif
+
+	// Locked-down/secured house items have movable=0 -- MoveItemToContainer
+	// silently fails (returns 0, no error) on a non-movable item without
+	// this, which is exactly what left hundreds of empty packs behind: every
+	// locked item failed to move into every existing pack, fell through to
+	// a freshly created pack, failed there too for the same reason, and got
+	// left behind as an empty, still-indexed escrow entry. Same pattern
+	// sign.src's own "recover lost items" flow already uses.
+	if(item.movable == 0)
+		item.movable := 1;
+	endif
+
+	for i := 1 to len(packs)
+		if(CanPlaceInHouseEscrowPack(packs[i], item) and MoveItemToContainer(item, packs[i]))
+			return 1;
+		endif
+	endfor
+
+	var new_pack := CreateHouseEscrowPack(label, realm);
+	if(!new_pack)
+		HouseEscrowLog("[ERROR] MoveItemToHouseEscrowPacks: failed to create a new escrow pack for label=" + label);
+		return 0;
+	endif
+
+	if(MoveItemToContainer(item, new_pack))
+		packs.append(new_pack);
+		return 1;
+	endif
+
+	// Move failed even into a brand-new, empty pack -- don't leave that pack
+	// behind as a phantom empty escrow entry (it was never added to `packs`
+	// above, so it won't get indexed), destroy it, and log loudly with
+	// enough detail to actually chase down why this specific item won't
+	// move (item.movable is already cleared above, so this is something
+	// else -- e.g. a cursed/non-container-safe item, or a genuine engine
+	// container-capacity limit).
+	Print("[houseescrow][ERROR] MoveItemToHouseEscrowPacks: item " + item.serial + " (objtype=" + Hex(item.objtype) + ", name='" + item.name + "', realm=" + item.realm + ", movable=" + item.movable + ") could NOT be moved into escrow pack (realm=" + new_pack.realm + ", label=" + label + ") -- it was left in place, NOT escrowed.");
+	HouseEscrowLog("[ERROR] MoveItemToHouseEscrowPacks: failed to move item " + item.serial + " (objtype=" + Hex(item.objtype) + ", name='" + item.name + "', realm=" + item.realm + ", movable=" + item.movable + ") into a freshly created pack (realm=" + new_pack.realm + ") for label=" + label + " -- item left un-escrowed");
+	DestroyItem(new_pack);
+	return 0;
+endfunction
+
+// Variant for Omega Cache recreation, where the weight of the item(s) about
+// to be created is known before they physically exist.
+function CanFitWeightInHouseEscrowPack(hpack, added_weight)
+	var roots := ListRootItemsInContainer(hpack);
+	if(len(roots) >= HOUSE_ESCROW_PACK_MAX_ROOT_ITEMS)
+		return 0;
+	endif
+	var estweight := CDbl(hpack.weight) + CDbl(added_weight);
+	if(estweight > HOUSE_ESCROW_PACK_MAX_WEIGHT)
+		return 0;
+	endif
+	return 1;
+endfunction
+
+function FindOrCreateHouseEscrowPackForWeight(byref packs, added_weight, label, realm)
+	for i := 1 to len(packs)
+		if(CanFitWeightInHouseEscrowPack(packs[i], added_weight))
+			return packs[i];
+		endif
+	endfor
+
+	var new_pack := CreateHouseEscrowPack(label, realm);
+	if(!new_pack)
+		return 0;
+	endif
+	packs.append(new_pack);
+	return new_pack;
+endfunction
+
+////////////////////////////////////////////////////////////////////////////
+// Bucket helpers
+////////////////////////////////////////////////////////////////////////////
+// Returns the count of child items that could NOT be moved into escrow
+// (left behind in the secure, which is destroyed regardless -- see
+// MoveItemToHouseEscrowPacks for why a move can fail and what gets logged).
+function DrainSecureContainerToPacks(secure_item, byref packs, label, realm)
+	// MoveItemToContainer invokes the source container's CanRemoveScript
+	// (scripts/control/can_remove_container.src) same as a player drag --
+	// confirmed the hard way: every single child of a real secure was
+	// failing to move regardless of movable/realm, while everything else
+	// escrowed fine. That script's SecureRemove() gates removal behind
+	// IsCowner(who, sign)/friend permissions keyed off the container's
+	// "houseserial" cprop, and our headless move has no live player "who"
+	// to satisfy it -- it fails closed for every item, every time. Erase
+	// the tag before draining so CanRemoveScript's houseserial check comes
+	// up falsy and just allows it, same trick the Omega Cache branch above
+	// already uses (EraseObjProperty before DestroyItem) to sidestep this
+	// exact permission gate. Safe here since secure_item is destroyed
+	// outright at the end of this function regardless.
+	EraseObjProperty(secure_item, "houseserial");
+
+	// Snapshot children into a local array BEFORE moving any of them out --
+	// iterating ListRootItemsInContainer(secure_item) live while removing
+	// from that same container mid-loop is exactly the live-iteration
+	// hazard already known elsewhere in this codebase (escrow.src's
+	// DestroyContainerAndContents snapshots first for the same reason). A
+	// handful of items always at the tail of a large drain reads back as
+	// <uninitialized object> without this -- consistent with later entries
+	// in a live container listing going stale as earlier ones are removed.
+	var children_snapshot := {};
+	var bad_at_collection := 0;
+	foreach child in ListRootItemsInContainer(secure_item)
+		if(!child or child.errortext)
+			bad_at_collection := bad_at_collection + 1;
+			continue;
+		endif
+		children_snapshot.append(child);
+	endforeach
+	if(bad_at_collection)
+		HouseEscrowLog("[ERROR] DrainSecureContainerToPacks: ListRootItemsInContainer(" + secure_item.serial + ") returned " + bad_at_collection + " already-bad entry(ies) at collection time (before any moves happened) -- likely pre-existing corrupted item data on this house, not something this sweep caused.");
+		Print("[houseescrow][ERROR] DrainSecureContainerToPacks: secure " + secure_item.serial + " -- " + bad_at_collection + " child(ren) were already bad/uninitialized BEFORE any processing (pre-existing data issue, not caused by this sweep).");
+	endif
+
+	var yield_counter := 0;
+	var failed := 0;
+	foreach child in children_snapshot
+		if(!MoveItemToHouseEscrowPacks(packs, child, label, realm, "secure_child"))
+			failed := failed + 1;
+		endif
+
+		// yield check -- see the SCRIPTOPT_NO_RUNAWAY comment on DemolishAndEscrowHouse.
+		yield_counter := yield_counter + 1;
+		if(yield_counter >= 25)
+			yield_counter := 0;
+			SleepMS(1);
+		endif
+	endforeach
+	DestroyItem(secure_item);
+	return failed;
+endfunction
+
+// Trimmed duplicate of pkg/opt/omegacache/omegacache.inc's RecreateItem() --
+// Omega Cache deposits are DataFile records, not physical items, so draining
+// them into escrow means reconstructing real items from the stored
+// properties. omegacache.inc itself is heavy (pulls in the full gump
+// library) and pkg/std/housing deliberately doesn't depend on it; this is a
+// small, deliberate duplication of just the reconstruction logic.
+function RecreateOmegaCacheItemForEscrow(container, elem, amount)
+	var objtype := CInt(elem.GetProp("objtype"));
+	var newitem := CreateItemInContainer(container, objtype, amount);
+	if(!newitem or newitem.errortext)
+		return 0;
+	endif
+
+	var propnames := elem.PropNames();
+	foreach pname in propnames
+		var val := elem.GetProp(pname);
+
+		if(pname == "qty" or pname == "objtype" or pname == "weight")
+			continue;
+		endif
+
+		if(pname == "color")
+			newitem.color := CInt(val);
+		elseif(pname == "graphic")
+			newitem.graphic := CInt(val);
+		elseif(pname == "quality")
+			newitem.quality := CDbl(val);
+		elseif(pname == "usescript")
+			newitem.usescript := CStr(val);
+		elseif(pname == "equipscript")
+			newitem.equipscript := CStr(val);
+		elseif(pname == "snoopscript")
+			newitem.snoopscript := CStr(val);
+		elseif(pname == "newbie")
+			newitem.newbie := CInt(val);
+		elseif(pname == "insured")
+			newitem.insured := CInt(val);
+		elseif(pname == "cursed")
+			newitem.cursed := CInt(val);
+		elseif(pname == "weight_multiplier_mod")
+			newitem.weight_multiplier_mod := CDbl(val);
+		elseif(pname[1,6] == "cprop_")
+			var cprop_name := pname[7, len(pname)];
+			SetObjProperty(newitem, cprop_name, val);
+		endif
+	endforeach
+
+	var base_name := GetObjProperty(newitem, "BaseName");
+	if(base_name and base_name != "")
+		SetName(newitem, CStr(base_name));
+	endif
+
+	return newitem;
+endfunction
+
+function DrainOmegaCacheStoreToPacks(house_serial, byref packs, label, realm)
+	var df := OpenOmegaCacheStore(house_serial);
+	if(!df)
+		return;
+	endif
+
+	HouseEscrowLog("DrainOmegaCacheStoreToPacks: house=" + house_serial + " keys=" + len(df.Keys()));
+	var yield_counter := 0;
+
+	foreach key in (df.Keys())
+		if(CStr(key)[1,3] == "RL#")
+			continue;
+		endif
+
+		var elem := df.FindElement(key);
+		if(!elem)
+			continue;
+		endif
+
+		var qty := CInt(elem.GetProp("qty"));
+		if(qty <= 0)
+			continue;
+		endif
+
+		var objtype := CInt(elem.GetProp("objtype"));
+		var item_weight := CDbl(elem.GetProp("weight"));
+		var desc_info := GetItemDescriptor(objtype);
+		var stack_limit := 60000;
+		if(desc_info and desc_info.StackLimit)
+			stack_limit := CInt(desc_info.StackLimit);
+		endif
+
+		var remaining := qty;
+		while(remaining > 0)
+			var this_stack := remaining;
+			if(this_stack > stack_limit)
+				this_stack := stack_limit;
+			endif
+
+			// A stack's total weight must fit inside one (possibly brand new,
+			// empty) pack -- subdivide further by weight if needed so we never
+			// ask for more than a fresh pack could ever hold.
+			if(item_weight > 0)
+				var max_by_pack_weight := CInt(HOUSE_ESCROW_PACK_MAX_WEIGHT / item_weight);
+				if(max_by_pack_weight < 1)
+					max_by_pack_weight := 1;
+				endif
+				if(this_stack > max_by_pack_weight)
+					this_stack := max_by_pack_weight;
+				endif
+			endif
+
+			var hpack := FindOrCreateHouseEscrowPackForWeight(packs, item_weight * this_stack, label, realm);
+			if(!hpack)
+				HouseEscrowLog("[ERROR] DrainOmegaCacheStoreToPacks: could not obtain a pack for house=" + house_serial + " objtype=" + Hex(objtype) + " qty=" + this_stack);
+				break;
+			endif
+
+			var newitem := RecreateOmegaCacheItemForEscrow(hpack, elem, this_stack);
+			if(!newitem)
+				HouseEscrowLog("[ERROR] DrainOmegaCacheStoreToPacks: failed to recreate objtype=" + Hex(objtype) + " qty=" + this_stack + " for house=" + house_serial);
+				break;
+			endif
+
+			remaining := remaining - this_stack;
+
+			// yield check -- see the SCRIPTOPT_NO_RUNAWAY comment on DemolishAndEscrowHouse.
+			yield_counter := yield_counter + 1;
+			if(yield_counter >= 10)
+				yield_counter := 0;
+				SleepMS(1);
+			endif
+		endwhile
+	endforeach
+
+	CloseOmegaCacheStore(house_serial);
+endfunction
+
+// Handles one item's redeed-group membership if it has one. Returns 1 if the
+// item was a redeed-group member (handled and its whole group marked
+// processed), 0 if it isn't part of a redeed group at all (falls through to
+// the generic bucket).
+function TryBulkRedeedItem(item, byref processed, byref packs, label, realm)
+	var from_deed := GetObjProperty(item, "FromDeed");
+	var created_serials := GetObjProperty(item, "ItemsCreatedSerials");
+	if(!from_deed or !created_serials)
+		return 0;
+	endif
+
+	var group_items := {};
+	foreach s in created_serials
+		processed[CInt(s)] := 1;
+		var part := SystemFindObjectBySerial(CInt(s));
+		if(part)
+			group_items.append(part);
+		endif
+	endforeach
+
+	if(!len(group_items))
+		return 1;
+	endif
+
+	var itemname, itemqual, lockable, is_excep, the_color, CraftedBy;
+	foreach member in group_items
+		if(member.objtype != UOBJ_COPPER_KEY)
+			if(!itemname)
+				itemname := GetObjProperty(member, "BaseName");
+			endif
+			if(!itemqual)
+				itemqual := member.quality;
+			endif
+			if(!lockable)
+				lockable := GetObjProperty(member, "lockable");
+			endif
+			if(!is_excep)
+				is_excep := GetObjProperty(member, "IsExceptional");
+			endif
+			if(!CraftedBy)
+				CraftedBy := GetObjProperty(member, "CraftedBy");
+			endif
+			if(!the_color)
+				the_color := member.color;
+			endif
+		endif
+
+		if(member.isa(POLCLASS_CONTAINER))
+			// Same live-iteration hazard as DrainSecureContainerToPacks --
+			// snapshot the children before moving any of them out from
+			// under this same loop.
+			var member_children_snapshot := {};
+			var member_bad_at_collection := 0;
+			foreach child in ListRootItemsInContainer(member)
+				if(!child or child.errortext)
+					member_bad_at_collection := member_bad_at_collection + 1;
+					continue;
+				endif
+				member_children_snapshot.append(child);
+			endforeach
+			if(member_bad_at_collection)
+				HouseEscrowLog("[ERROR] TryBulkRedeedItem: ListRootItemsInContainer(" + member.serial + ") returned " + member_bad_at_collection + " already-bad entry(ies) at collection time (before any moves happened) -- likely pre-existing corrupted item data on this house, not something this sweep caused.");
+				Print("[houseescrow][ERROR] TryBulkRedeedItem: member " + member.serial + " -- " + member_bad_at_collection + " child(ren) were already bad/uninitialized BEFORE any processing (pre-existing data issue, not caused by this sweep).");
+			endif
+			foreach child in member_children_snapshot
+				MoveItemToHouseEscrowPacks(packs, child, label, realm, "redeed_member_child");
+			endforeach
+		endif
+
+		member.movable := 1;
+		DestroyItem(member);
+	endforeach
+
+	var staged_deed := CreateItemAtLocation(5288, 1176, 0, CInt(from_deed), 1, realm);
+	if(staged_deed and !staged_deed.errortext)
+		SetObjProperty(staged_deed, "ItemBaseName", itemname);
+		SetObjProperty(staged_deed, "ItemQuality", itemqual);
+		if(itemname)
+			SetName(staged_deed, "deed for : " + itemname);
+		endif
+		if(lockable)
+			SetObjProperty(staged_deed, "ItemIsLockable", 1);
+		endif
+		if(is_excep)
+			SetObjProperty(staged_deed, "ItemIsExceptional", 1);
+			if(CraftedBy)
+				SetObjProperty(staged_deed, "CraftedBy", CraftedBy);
+			endif
+		endif
+		if(the_color)
+			staged_deed.color := the_color;
+		endif
+		MoveItemToHouseEscrowPacks(packs, staged_deed, label, realm, "redeed_staged_deed");
+	else
+		HouseEscrowLog("[ERROR] TryBulkRedeedItem: failed to create replacement deed objtype=" + Hex(CInt(from_deed)) + " for group starting at item=" + item.serial);
+	endif
+
+	return 1;
+endfunction
+
+// Fires any player merchant standing in the house via the existing
+// pm_force_fire event mechanism (pkg/systems/playervendor/playermerchant.src,
+// same path pmfireme.src already uses), routing the payout into the
+// existing, separate "Merchant Escrow" system -- firing a merchant is
+// independent of the house-demolish escrow.
+function FireHouseMerchants(house, who)
+	var fired := 0;
+	foreach mobile in (house.mobiles)
+		if(mobile.isa(POLCLASS_NPC) and (mobile.script == "playermerchant" or mobile.script == ":playervendor:playermerchant"))
+			if(mobile.process)
+				var ev := struct;
+				ev.type := "pm_force_fire";
+				ev.source := who;
+				ev.reason := "house_demolish_escrow";
+				ev.force_escrow := 1;
+				mobile.process.sendevent(ev);
+				HouseEscrowLog("FireHouseMerchants: sent pm_force_fire to merchant " + mobile.serial + " (" + mobile.name + ") in house " + house.serial + ", triggered by staff " + who.serial);
+				fired := fired + 1;
+			endif
+		endif
+	endforeach
+	return fired;
+endfunction
+
+// Same deed-objtype table as sign.src's existing case-14 demolish flow.
+function CreateHouseDeedForType(house_objtype)
+	var deed_objtype := 0;
+	case(house_objtype)
+		0x6064: deed_objtype := 0x6019;
+		0x6066: deed_objtype := 0x601A;
+		0x6068: deed_objtype := 0x6231;
+		0x606A: deed_objtype := 0x601B;
+		0x606C: deed_objtype := 0x601C;
+		0x606E: deed_objtype := 0x601D;
+		0x6070: deed_objtype := 0x601E;
+		0x6072: deed_objtype := 0x601F;
+		0x6074: deed_objtype := 0x6020;
+		0x6076: deed_objtype := 0x6021;
+		0x6078: deed_objtype := 0x6022;
+		0x607A: deed_objtype := 0x6023;
+		0x607C: deed_objtype := 0x6024;
+		0x607E: deed_objtype := 0x6025;
+		0x608C: deed_objtype := 0x6026;
+		0x608D: deed_objtype := 0x6230;
+		0x60A0: deed_objtype := 0x6227;
+		0x60A2: deed_objtype := 0x6228;
+		0x6098: deed_objtype := 0x6229;
+		0x609C: deed_objtype := 0x622A;
+		0x609A: deed_objtype := 0x622B;
+		0x609E: deed_objtype := 0x622C;
+		0x6096: deed_objtype := 0x622D;
+		0x6388: deed_objtype := 0x622E;
+		0x6BB8: deed_objtype := 0x622F;
+		0xA3E0: deed_objtype := 0x6233;
+		0xA3E1: deed_objtype := 0x6234;
+		0xA3E2: deed_objtype := 0x6235;
+		0xA3E3: deed_objtype := 0x6236;
+		0xA3E4: deed_objtype := 0x6237;
+		0xA3E5: deed_objtype := 0x6238;
+		0xA3E6: deed_objtype := 0x6239;
+		0xA3E7: deed_objtype := 0x623D;
+		0xA3E8: deed_objtype := 0x623E;
+		0xA3E9: deed_objtype := 0x623F;
+		0xA3EA: deed_objtype := 0x6240;
+		0xA3EB: deed_objtype := 0x6241;
+		0xA3EC: deed_objtype := 0x6243;
+		0xA3ED: deed_objtype := 0x6244;
+		0xA3EE: deed_objtype := 0x6245;
+		0xA3EF: deed_objtype := 0x6246;
+		0xA3F0: deed_objtype := 0x6247;
+		0xA3F1: deed_objtype := 0x6248;
+		0xA3F2: deed_objtype := 0x6249;
+	endcase
+	return deed_objtype;
+endfunction
+
+////////////////////////////////////////////////////////////////////////////
+// Orchestration entry point
+////////////////////////////////////////////////////////////////////////////
+function DemolishAndEscrowHouse(who, house, sign)
+	// A big house (guild houses especially -- higher lockdown/secure caps)
+	// can mean thousands of items to sweep, each needing several property
+	// reads/container ops. That's real risk of tripping pol.cfg's
+	// RunawayScriptThreshold (500000 instructions without sleeping) partway
+	// through -- which would mean items already destroyed/moved out of the
+	// house, but execution never reaching Step 8/9 below to actually save
+	// anything to escrow. SCRIPTOPT_NO_RUNAWAY is a backstop; the periodic
+	// SleepMS() yields sprinkled through the loops below (search "yield
+	// check") are the primary fix, since they also keep this from
+	// monopolizing the whole (single-threaded, cooperative) scheduler for a
+	// huge house instead of just disabling the safety check outright.
+	Set_Script_Option(SCRIPTOPT_NO_RUNAWAY, 1);
+
+	var result := struct;
+	result.ok := 0;
+	result.escrowed_pack_count := 0;
+	result.owner_name := "Unknown Owner";
+	result.owner_resolved := 0;
+	result.items_left_behind := 0;
+	result.errmsg := "";
+
+	if(!house)
+		result.errmsg := "House not found.";
+		return result;
+	endif
+
+	// Cached up front and used for the rest of this function instead of
+	// house.serial/house.objtype/house.realm -- DestroyMulti(house) runs
+	// partway through, and property access on an already-destroyed multi
+	// isn't something to rely on for the logging/escrow calls that happen
+	// afterward. house_realm also feeds every CreateItemAtLocation/
+	// CreateHouseEscrowPack call below, so escrow packs get created in the
+	// SAME realm as the house being swept -- see CreateHouseEscrowPack.
+	var house_serial := house.serial;
+	var house_objtype := house.objtype;
+	var house_realm := house.realm;
+
+	// Step 1: resolve the owner. Never abort solely because the owner can't
+	// be found -- that's exactly the case this feature exists for.
+	var raw_ownerserial_prop := GetObjProperty(house, "ownerserial");
+	var ownerserial := CInt(raw_ownerserial_prop);
+	Print("[houseescrow][debug] DemolishAndEscrowHouse: house=" + house_serial + " raw ownerserial cprop=" + raw_ownerserial_prop + " -> CInt=" + ownerserial);
+
+	var owner := SystemFindObjectBySerial(ownerserial);
+	if(!owner)
+		owner := SystemFindObjectBySerial(ownerserial, SYSFIND_SEARCH_OFFLINE_MOBILES);
+	endif
+	Print("[houseescrow][debug] DemolishAndEscrowHouse: house=" + house_serial + " owner lookup for serial=" + ownerserial + " -> " + (owner ? (owner.name + "(" + owner.serial + ")") : "NOT FOUND"));
+
+	var owner_name;
+	if(owner)
+		owner_name := owner.name;
+		result.owner_resolved := 1;
+	else
+		owner_name := GetObjProperty(house, "owneracct");
+		if(!owner_name)
+			owner_name := GetObjProperty(sign, "lastownername");
+		endif
+		if(!owner_name)
+			owner_name := "Unknown Owner";
+		endif
+		result.owner_resolved := 0;
+		HouseEscrowLog("[ORPHANED] DemolishAndEscrowHouse: owner serial " + ownerserial + " could not be resolved for house " + house_serial + "; filing escrow under that serial anyway, name fallback=" + owner_name);
+		QueueHouseEscrowGMPage(ownerserial, "House " + house_serial + " demolished-and-escrowed by " + who.name + "(" + who.serial + ") but owner serial " + ownerserial + " could not be resolved to a character. Escrow filed under that serial; use .houseescrow " + ownerserial + " as staff to inspect/reassign.");
+	endif
+	result.owner_name := owner_name;
+
+	var house_label := GetObjProperty(house, "MultiType");
+	if(!house_label or house_label == "")
+		house_label := ResolveHouseTypeDisplayName(house_objtype);
+	endif
+
+	HouseEscrowLog("DemolishAndEscrowHouse: starting house=" + house_serial + " owner=" + ownerserial + " (" + owner_name + ") resolved=" + result.owner_resolved + " type=" + house_label + " triggered_by=" + who.serial);
+	Print("[houseescrow][debug] DemolishAndEscrowHouse: starting house=" + house_serial + " owner=" + ownerserial + " (" + owner_name + ") resolved=" + result.owner_resolved);
+
+	// Step 2: create the house deed while house.objtype is still valid. Held
+	// aside and escrowed last, as its own separately-labeled pack.
+	var deed_objtype := CreateHouseDeedForType(house_objtype);
+	var house_deed := 0;
+	if(deed_objtype)
+		house_deed := CreateItemAtLocation(5288, 1176, 0, deed_objtype, 1, house_realm);
+	endif
+
+	// Step 3: destroy structural components -- unchanged from the existing
+	// case-14 demolish flow (sign.src), never escrowed. Must happen before
+	// the house.items snapshot below.
+	var addonitem, founditem;
+	addonitem := CInt(GetObjProperty(house, "component1"));
+	if(addonitem) DestroyItem(SystemFindObjectBySerial(addonitem)); endif
+	addonitem := CInt(GetObjProperty(house, "component2"));
+	if(addonitem) DestroyItem(SystemFindObjectBySerial(addonitem)); endif
+	addonitem := CInt(GetObjProperty(house, "component3"));
+	if(addonitem) DestroyItem(SystemFindObjectBySerial(addonitem)); endif
+	addonitem := CInt(GetObjProperty(house, "builtdeed"));
+	if(addonitem)
+		founditem := DestroyItem(SystemFindObjectBySerial(addonitem));
+		if(founditem <> 1) founditem := DestroyItem(SystemFindObjectBySerial(addonitem, 1)); endif
+		if(founditem <> 1) DestroyItem(SystemFindObjectBySerial(addonitem, 2)); endif
+	endif
+
+	if(house_objtype == 0x608D)
+		foreach item in ListItemsNearLocation(sign.x, sign.y, 0, 8)
+			if((item.objtype == 0x177d) or (item.objtype == 0xb41) or (item.objtype == 0xb42))
+				DestroyItem(item);
+			endif
+		endforeach
+	endif
+
+	// Destroy every teleporter this house has ever placed via the canonical
+	// CProp-tracked cleanup (utility.inc) -- catches untracked/legacy
+	// teleporters too, more reliably than a plain "teleportserial" sweep of
+	// house.items. Runs before the snapshot below so teleporters never enter
+	// the classification pass at all.
+	CleanupHouseTeleporters(house);
+
+	// Step 4: snapshot house.items before any further destruction.
+	// house.items/ListItemsNearLocation can apparently hand back a small
+	// number of already-bad/error entries directly (confirmed in practice:
+	// traced a batch of "invalid item reference" failures at the generic
+	// bucket all the way back to here -- item.serial on a bad entry
+	// silently reads falsy instead of throwing, in EScript's duck-typed
+	// struct access, so nothing before this point ever caught it). Guard
+	// here so bad entries are identified and dropped at the source instead
+	// of silently riding along in items_snapshot for hundreds of items
+	// before finally surfacing downstream as an unhelpful failure.
+	// items_snapshot_serials caches each item's serial AT SNAPSHOT TIME,
+	// parallel-indexed with items_snapshot. The classification loop below
+	// uses these cached values (not a live item.serial re-read) for its
+	// "already processed"/"is the sign" checks -- see the comment there for
+	// why a live re-read isn't safe.
+	var items_snapshot := {};
+	var items_snapshot_serials := {};
+	var snapshot_serials := dictionary;
+	var snapshot_bad_count := 0;
+	foreach item in (house.items)
+		if(!item or item.errortext)
+			snapshot_bad_count := snapshot_bad_count + 1;
+			continue;
+		endif
+		items_snapshot.append(item);
+		items_snapshot_serials.append(item.serial);
+		snapshot_serials[item.serial] := 1;
+	endforeach
+
+	// Some house-linked items (e.g. secures placed on a tent, validated via
+	// InsideTent() rather than house.items membership -- see
+	// pkg/std/housing/sign.src's own HouseFunctionSecure) never actually
+	// register as house.items members. The existing case-14 self-service
+	// demolish flow compensates with this same proximity sweep so those
+	// items still get handled instead of surviving DestroyMulti as orphans;
+	// dedup by serial against what's already in the snapshot.
+	var proximity_z := 0;
+	repeat
+		foreach item in ListItemsNearLocation(sign.x, sign.y, proximity_z, 20)
+			if(!item or item.errortext)
+				snapshot_bad_count := snapshot_bad_count + 1;
+				continue;
+			endif
+			if(!snapshot_serials[item.serial] and (item.getprop("houseserial") == house_serial or item.getprop("f")))
+				items_snapshot.append(item);
+				items_snapshot_serials.append(item.serial);
+				snapshot_serials[item.serial] := 1;
+			endif
+		endforeach
+		proximity_z := proximity_z + 20;
+	until(proximity_z >= 60);
+
+	HouseEscrowLog("DemolishAndEscrowHouse: house=" + house_serial + " items_snapshot size=" + len(items_snapshot) + " bad_entries_dropped_at_snapshot=" + snapshot_bad_count);
+	if(snapshot_bad_count)
+		Print("[houseescrow][WARNING] DemolishAndEscrowHouse: house=" + house_serial + " -- house.items/proximity sweep returned " + snapshot_bad_count + " already-bad/error entry(ies) directly, dropped before classification even started. This is pre-existing corrupted item data on this house, not something caused by this sweep.");
+	endif
+
+	// Step 5: single classification pass over the snapshot.
+	var packs := {};
+	var processed := dictionary;
+	var secures_drained := 0;
+	var omegacaches_destroyed := 0;
+	var redeed_groups := 0;
+	var generic_moved := 0;
+	var trashcans_redeeded := 0;
+	var items_left_behind := 0;
+	var items_skipped_nested := 0;
+	var yield_counter := 0;
+	var item_index := 0;
+
+	foreach item in items_snapshot
+		item_index := item_index + 1;
+		// Cached at Step 4, when this item was confirmed valid -- NOT a live
+		// item.serial re-read. Confirmed root cause of a set of "invalid/
+		// stale item reference" failures: TryBulkRedeedItem can destroy
+		// OTHER items via ItemsCreatedSerials (a whole redeed group), not
+		// just the one it was called on. If one of those grouped items also
+		// has its own separate entry later in items_snapshot (a genuinely
+		// standalone top-level item sharing the group's tag), it's already
+		// destroyed by the time its own turn comes up here -- and a live
+		// item.serial read on an already-destroyed handle reads back falsy
+		// instead of the real serial, so "processed[item.serial]" misses
+		// its own key and the dangling item limps through every remaining
+		// check instead of being cleanly skipped.
+		var cached_serial := items_snapshot_serials[item_index];
+
+		// yield check -- see the SCRIPTOPT_NO_RUNAWAY comment above.
+		yield_counter := yield_counter + 1;
+		if(yield_counter >= 25)
+			yield_counter := 0;
+			SleepMS(1);
+		endif
+		if(item_index % 100 == 0)
+			HouseEscrowLog("DemolishAndEscrowHouse: house=" + house_serial + " progress " + item_index + "/" + len(items_snapshot));
+		endif
+
+		if(cached_serial == sign.serial)
+			continue;
+		endif
+		if(processed[cached_serial])
+			continue;
+		endif
+
+		// Belt-and-suspenders: if this item was destroyed as a side effect
+		// of something else (e.g. it just wasn't caught above for some
+		// other reason), catch it here with a clear, traceable message
+		// tied to its real serial instead of letting it silently limp
+		// through the branches below and surface as an unhelpful
+		// "<uninitialized object>" failure deep inside the generic bucket.
+		if(!item or item.errortext)
+			HouseEscrowLog("[ERROR] DemolishAndEscrowHouse: item " + cached_serial + " went stale between snapshot and classification (likely destroyed as a side effect of an earlier redeed group sharing its ItemsCreatedSerials) -- skipped.");
+			Print("[houseescrow][ERROR] DemolishAndEscrowHouse: item " + cached_serial + " went stale between snapshot and classification -- skipped, nothing to move.");
+			continue;
+		endif
+
+		// Items nested inside another item (contents of a secure, a
+		// wardrobe, a redeed-placed cabinet, etc.) get carried along
+		// automatically when that parent container is itself moved or
+		// drained -- DrainSecureContainerToPacks/TryBulkRedeedItem each do
+		// their own independent ListRootItemsInContainer lookup for their
+		// container's direct children, and a plain container move via
+		// MoveItemToContainer already brings its contents with it. If
+		// house.items also lists those same nested items individually
+		// (recursively), processing them AGAIN here -- often after their
+		// parent has already been relocated into an escrow pack inside the
+		// storage area -- is what caused mass "could not be moved into
+		// escrow" failures (a real, confirmed case: 343 clothing items
+		// inside one container). Only handle true top-level items here.
+		if(item.container)
+			items_skipped_nested := items_skipped_nested + 1;
+			continue;
+		endif
+
+		if(item.usescript == USESCRIPTID_SECURE_CONTAINER)
+			items_left_behind := items_left_behind + DrainSecureContainerToPacks(item, packs, house_label, house_realm);
+			secures_drained := secures_drained + 1;
+			continue;
+		endif
+
+		if(item.objtype == OMEGACACHE_OBJTYPE)
+			EraseObjProperty(item, "houseserial");
+			DestroyItem(item);
+			omegacaches_destroyed := omegacaches_destroyed + 1;
+			continue;
+		endif
+
+		// Trash cans have no FromDeed/ItemsCreatedSerials (same as
+		// scripts/textcmd/player/redeed.src's own special case for this
+		// objtype) so TryBulkRedeedItem below would never catch them --
+		// destroy and hand back the reusable trash-can token (0x7009) the
+		// same way the player-facing .redeed command does, instead of
+		// escrowing the physical trash can itself.
+		if(item.objtype == 0x7007)
+			DestroyItem(item);
+			var trash_token := CreateItemAtLocation(5288, 1176, 0, 0x7009, 1, house_realm);
+			if(trash_token and !trash_token.errortext)
+				MoveItemToHouseEscrowPacks(packs, trash_token, house_label, house_realm, "trashcan_token");
+			endif
+			trashcans_redeeded := trashcans_redeeded + 1;
+			continue;
+		endif
+
+		if(TryBulkRedeedItem(item, processed, packs, house_label, house_realm))
+			redeed_groups := redeed_groups + 1;
+			continue;
+		endif
+
+		if(MoveItemToHouseEscrowPacks(packs, item, house_label, house_realm, "generic_toplevel"))
+			generic_moved := generic_moved + 1;
+		else
+			items_left_behind := items_left_behind + 1;
+		endif
+	endforeach
+
+	HouseEscrowLog("DemolishAndEscrowHouse: house=" + house_serial + " swept secures=" + secures_drained + " omegacaches=" + omegacaches_destroyed + " redeed_groups=" + redeed_groups + " trashcans=" + trashcans_redeeded + " generic_items=" + generic_moved + " skipped_nested=" + items_skipped_nested + " items_left_behind=" + items_left_behind + " packs_so_far=" + len(packs));
+	if(items_left_behind)
+		Print("[houseescrow][WARNING] DemolishAndEscrowHouse: house=" + house_serial + " -- " + items_left_behind + " item(s) could NOT be escrowed and were left un-escrowed (see prior [houseescrow][ERROR] lines for which items and why).");
+	endif
+	result.items_left_behind := items_left_behind;
+
+	// Step 6: drain the Omega Cache DataFile wholesale, then wipe it exactly
+	// as the existing player-facing demolish flow does. DrainOmegaCacheStoreToPacks
+	// closes its own handle before returning, so re-opening here for the wipe
+	// doesn't stack a second, never-released reference on top of it.
+	DrainOmegaCacheStoreToPacks(house_serial, packs, house_label, house_realm);
+
+	var ocdf := OpenOmegaCacheStore(house_serial);
+	if(ocdf)
+		foreach ockey in (ocdf.Keys())
+			ocdf.DeleteElement(ockey);
+		endforeach
+		CloseOmegaCacheStore(house_serial);
+	endif
+
+	HouseEscrowLog("DemolishAndEscrowHouse: house=" + house_serial + " omega cache drain complete, packs_so_far=" + len(packs));
+
+	// Step 7: fire merchants, house-list bookkeeping, then destroy the multi.
+	var fired := FireHouseMerchants(house, who);
+
+	if(result.owner_resolved)
+		RemoveHouseFromCharacter(owner, house_serial);
+	endif
+
+	DestroyMulti(house);
+	HouseEscrowLog("DemolishAndEscrowHouse: house=" + house_serial + " multi destroyed, proceeding to escrow flush -- " + len(packs) + " content pack(s) pending, deed_created=" + (house_deed and !house_deed.errortext));
+
+	// Step 8: escrow the house deed as its own separately-labeled pack.
+	var deed_escrow_names := {};
+	if(house_deed and !house_deed.errortext)
+		var deed_packs := {};
+		MoveItemToHouseEscrowPacks(deed_packs, house_deed, house_label + " deed", house_realm, "house_deed");
+		foreach hpack in deed_packs
+			var deed_escrow_name := SaveHouseEscrowPack(hpack, ownerserial, house_serial, house_label + " deed");
+			if(deed_escrow_name)
+				deed_escrow_names.append(deed_escrow_name);
+				result.escrowed_pack_count := result.escrowed_pack_count + 1;
+			endif
+		endforeach
+	else
+		HouseEscrowLog("[ERROR] DemolishAndEscrowHouse: no house deed was created for objtype=" + Hex(house_objtype) + ", house=" + house_serial);
+	endif
+	AppendHouseEscrowIndexBatch(ownerserial, house_serial, house_label + " deed", owner_name, deed_escrow_names);
+
+	// Step 9: flush every accumulated content pack, then index them all in
+	// one batch (see SaveHouseEscrowPack/AppendHouseEscrowIndexBatch above).
+	var content_escrow_names := {};
+	foreach hpack in packs
+		var content_escrow_name := SaveHouseEscrowPack(hpack, ownerserial, house_serial, house_label);
+		if(content_escrow_name)
+			content_escrow_names.append(content_escrow_name);
+			result.escrowed_pack_count := result.escrowed_pack_count + 1;
+		endif
+	endforeach
+	AppendHouseEscrowIndexBatch(ownerserial, house_serial, house_label, owner_name, content_escrow_names);
+
+	result.ok := 1;
+	HouseEscrowLog("DemolishAndEscrowHouse: completed house=" + house_serial + " owner=" + ownerserial + " (" + owner_name + ") resolved=" + result.owner_resolved + " packs=" + result.escrowed_pack_count + " merchants_fired=" + fired);
+
+	return result;
+endfunction

--- a/pkg/std/housing/setup.inc
+++ b/pkg/std/housing/setup.inc
@@ -19,6 +19,10 @@ const MAX_BANNED := 20;
 // if set to 1 the house can decay over time
 const DECAY := 0;
 
+// seconds a house may go un-refreshed before it's eligible to decay (only takes
+// effect once DECAY is set to 1); placeholder value, adjust before enabling DECAY
+const HOUSE_DECAY_PERIOD := 604800;
+
 var tile_list := {
 	0x755d,
 	0x755c

--- a/pkg/std/housing/sign.src
+++ b/pkg/std/housing/sign.src
@@ -4,6 +4,7 @@ use os;
 include "include/time";
 include "util/key";
 include ":gumps:yesno";
+include ":gumps:yesNoSizable";
 include "setup";
 include "include/itemutil";
 include "include/objtype";
@@ -13,6 +14,8 @@ include ":gumps:old-gumps";
 include "include/client";
 include "include/constants/usescriptids";
 include "include/omegacache_utils";
+include "include/constants/cmdlevels";
+include "houseescrow";
 
 Const UOBJECT_DOORS_START := 0x0675;
 Const UOBJECT_DOORS_END   := 0x06f4;
@@ -25,10 +28,10 @@ Const KEYRING := 0x1011;
 	"page 0",
         "nodispose",
 
-	"resizepic 0 45 2600 412 300",
+	"resizepic 0 45 2600 412 360",
 	"gumppic 140 0 100",
-	"text 190 30 48 0",
-	"text 190 50 48 33",
+	"text 180 30 48 0",
+	"text 180 50 48 33",
 	"resizepic 15 100 5100 382 25",
 	"text 25 102 0 1",
 	"button 78 104 5209 5003 0 1 0",
@@ -36,23 +39,31 @@ Const KEYRING := 0x1011;
 	"button 230 104 5209 5003 0 2 0",
 	"text 275 102 0 3",
 	"button 360 104 5209 5003 0 3 0",
-	"button 50 308 243 241 1 0 0",
+	"button 50 368 243 241 1 0 0",
 
 	"page 1",
-	"text 40 140 2302 4", // owner
-	"text 120 140 0 5",
-	"text 35 180 2302 6",
-	"text 250 180 0 7",
-	"text 35 200 2302 8",
-	"text 250 200 0 9",
-	"text 35 220 2302 10",
-	"text 250 220 0 11",
+	"text 35 140 2302 4", // owner
+	"text 250 140 0 5",
+	"text 35 160 2302 34",   // Risk of Escrow label   -> data[35]
+	"text 250 160 0 35",     // Risk of Escrow value   -> data[36]
+	"text 35 180 2302 36",   // Owner Last Seen label  -> data[37]
+	"text 250 180 0 37",     // Owner Last Seen value  -> data[38]
+	"text 35 200 2302 38",   // House Type label       -> data[39]
+	"text 145 200 0 39",     // House Type value       -> data[40] (not column-aligned like the rest -- long house names need the extra room before the gump's right edge)
+	"text 35 220 2302 6",
+	"text 250 220 0 7",
+	"text 35 240 2302 8",
+	"text 250 240 0 9",
+	"text 35 260 2302 10",
+	"text 250 260 0 11",
+	"text 35 280 2302 40",   // Number of teleporters label -> data[41]
+	"text 250 280 0 41",     // Number of teleporters value -> data[42]
 	// "text 35 240 2302 12",
 	// "text 35 260 2302 13",
 	// "text 270 260 0 14",
 	// "text 35 280 2302 15",
-	"text 150 308 2302 16",
-	"button 330 308 2714 2715 1 0 1",
+	"text 150 368 2302 16",
+	"button 330 368 2714 2715 1 0 1",
 
 	"page 2",
 	"text 55 130 2302 17",
@@ -89,9 +100,10 @@ Const KEYRING := 0x1011;
 	"button 60 200 2714 2715 1 0 16",
 
         "text 90 230 2302 31",             //House Management
-        "button 60 230 2714 2715 1 0 15"
-       // "text 90 250 2302 32",
-       // "button 60 250 2714 2715 1 0 17"
+        "button 60 230 2714 2715 1 0 15",
+
+        "text 90 260 2302 32",
+        "button 60 260 2714 2715 1 0 17"
 
 );
 
@@ -128,8 +140,16 @@ Const KEYRING := 0x1011;
 	"Demolish the house & get a deed back",// 14
 	"Change the master key", //16
         "House management",
-        " ",
-	" "
+        "Demolish and Escrow (For Staff Only)",
+	" ",
+	"Risk of Escrow:",
+	"",
+	"Owner Last Seen:",
+	"",
+	"House Type:",
+	"",
+	"Number of teleporters:",
+	""
 
 );
 
@@ -175,20 +195,49 @@ program textcmd_sign( who , sign )
 	data[10] := GetObjProperty( house , "maxnumsecure" ) - GetObjProperty( house , "numsecure" ) +"/"+ GetObjProperty( house , "maxnumsecure" );
 	data[12] := GetObjProperty(house, "maxnumomegacache") - GetObjProperty(house, "numomegacache") + "/" + GetObjProperty(house, "maxnumomegacache");
 
+	var owner_acct := GetObjProperty( house , "owneracct" );
+	var owner_last_login := ResolveHouseOwnerLastLogin( owner_acct );
+	data[36] := IsOwnerAccountAtRisk( owner_last_login ) ? "Yes" : "No";
+	data[38] := FormatHouseOwnerLastLoginDate( owner_last_login );
+
+	var house_type := GetObjProperty( house , "MultiType" );
+	if( !house_type or house_type == "" )
+		house_type := ResolveHouseTypeDisplayName( house.objtype );
+	endif
+	data[40] := house_type;
+
+	var placed_teleporters := 0;
+	foreach titem in (house.items)
+		if(GetObjProperty(titem, "teleportserial") == house.serial)
+			placed_teleporters := placed_teleporters + 1;
+		endif
+	endforeach
+	placed_teleporters := CInt(placed_teleporters / 2);
+
+	// Lazily initialize numtele exactly once, same guard AddTeleporter() uses,
+	// so viewing the sign before ever placing a teleporter shows the house's
+	// real allotment instead of 0/0 -- must NOT run if teleporters already
+	// exist, or it would reset an in-progress allocation back to the max.
+	if(!placed_teleporters && !GetObjProperty(house, "numtele"))
+		Setuphouse(house);
+	endif
+
+	var remaining_teleporters := CInt(GetObjProperty(house, "numtele"));
+	data[42] := placed_teleporters + "/" + (placed_teleporters + remaining_teleporters);
+
 	var i;
 
-/* 	if (house.objtype==0x6070 or house.objtype==0x6072)
-		for(i := 38; i <= 45; i := i + 1)
-			layout[i] :="";
-		endfor
+	if( who.cmdlevel < CMDLEVEL_DEVELOPER )
+		layout[len(layout)-1] := "";
+		layout[len(layout)]   := "";
 	endif
- */
+
 	var result := SendDialogGump( who, layout, data );
 
 	// Added IsCowner
 	if(( oserial == who.serial ) || IsCowner(who, house) || who.cmdlevel >= 4)
 		RefreshHouseItems( house );
-		//SetObjProperty(sign, "decay", GetDate()); //FIXME
+		SetObjProperty(sign, "decay", ReadGameClock() + HOUSE_DECAY_PERIOD);
 
 		case (result[0])
 			1:
@@ -292,6 +341,8 @@ program textcmd_sign( who , sign )
 							0xA3EE: CreateItemInBackpack( who, 0x6245, 1 );
 							0xA3EF: CreateItemInBackpack( who, 0x6246, 1 );
 							0xA3F0: CreateItemInBackpack( who, 0x6247, 1 );
+							0xA3F1: CreateItemInBackpack( who, 0x6248, 1 );
+							0xA3F2: CreateItemInBackpack( who, 0x6249, 1 );
 						endcase
 						addonitem := CInt(GetObjProperty( house, "component1" ));
 						if (addonitem) destroyitem(systemfindobjectbyserial(addonitem)); endif
@@ -347,6 +398,9 @@ program textcmd_sign( who , sign )
 							CloseOmegaCacheStore(house.serial);
 						endif
 
+						// Destroy any teleporters this house placed
+						CleanupHouseTeleporters(house);
+
 						DestroyMulti( house );
 					endif
 				else
@@ -361,7 +415,45 @@ program textcmd_sign( who , sign )
 				if( oserial == who.serial )
 					ChangeLocks( who , house );
 				endif
-				
+
+			17:
+				if(who.cmdlevel < CMDLEVEL_DEVELOPER)
+					SendSysMessage(who, "Staff only.");
+					return;
+				endif
+
+				foreach item in ListItemsNearLocation( sign.x, sign.y, sign.z-5, 20 )
+					if(item.getprop("outside") == house.serial)
+						SendSysMessage(who, "You need to redeed furniture outside before you can demolish your house.");
+						return;
+					endif
+				endforeach
+
+				if(YesNoVar(who, "This will demolish the house and move ALL contents (secures, Omega Cache, redeedable furniture, and everything else) into escrow for the house owner. This cannot be undone. Continue?"))
+					if(house.getprop("GuildHouse"))
+						if(!YesNoVar(who, "This is a guild house and removing it will cause errors, don't do this if other options are available."))
+							SendSysMessage(who, "Cancelled.");
+							return;
+						endif
+					endif
+
+					Print("[houseescrow][audit] " + who.name + "(" + who.serial + ") demolished-and-escrowed house " + house.serial + " owned by " + GetObjProperty(house, "owneracct"));
+
+					var escrow_result := DemolishAndEscrowHouse(who, house, sign);
+					if(escrow_result.ok)
+						SendSysMessage(who, "House demolished. " + escrow_result.escrowed_pack_count + " pack(s) placed in escrow for " + escrow_result.owner_name + ". They can claim them with .houseescrow.");
+						if(!escrow_result.owner_resolved)
+							SendSysMessage(who, "NOTE: the owning character could not be found. A GM page was queued; use .houseescrow " + house.getprop("ownerserial") + " to inspect or reassign the escrow.", 3, 43);
+						endif
+						if(escrow_result.items_left_behind)
+							SendSysMessage(who, "WARNING: " + escrow_result.items_left_behind + " item(s) could NOT be escrowed and were left un-escrowed. Check log/houseescrow.log ([ERROR] MoveItemToHouseEscrowPacks lines) for which items and why.", 3, 43);
+						endif
+					else
+						SendSysMessage(who, "Demolish and Escrow failed: " + escrow_result.errmsg);
+					endif
+				else
+					SendSysMessage(who, "Cancelled.");
+				endif
 
 		endcase
 	endif
@@ -1305,15 +1397,25 @@ function AddTeleporter( who, house, num )
 
 		if(GetObjProperty( itemt , "teleportserial" ) == house.serial)
 			var teleNr := GetObjProperty( itemt, "teleNum" );
-			var onlyOne := 0;
+			var teleserials := GetObjProperty( house, "TeleporterSerials" );
+			if (!teleserials)
+				teleserials := {};
+			endif
 			foreach item in (house.items)
-				if( GetObjProperty(item, "teleportserial") && GetObjProperty( item, "teleNum" ) == teleNr)
-					if(onlyOne < 2)
-						DestroyItem(item);	
-						onlyOne := onlyOne+1;
-					endif
+				if( item.objtype == 0xa3ce && GetObjProperty(item, "teleportserial") == house.serial && !(item.serial in teleserials) )
+					teleserials.append(CInt(item.serial));
 				endif
 			endforeach
+			var remainingserials := {};
+			foreach teleserial in (teleserials)
+				var teleitem := SystemFindObjectBySerial( CInt(teleserial) );
+				if( teleitem && GetObjProperty(teleitem, "teleNum") == teleNr )
+					DestroyItem(teleitem);
+				else
+					remainingserials.append(teleserial);
+				endif
+			endforeach
+			SetObjProperty( house, "TeleporterSerials", remainingserials );
 
 			SetObjProperty( house, "numtele" , CInt(GetObjProperty( house, "numtele") + 1) );
             SendSysmessage( who , "Teleporter removed." );
@@ -1331,17 +1433,11 @@ function AddTeleporter( who, house, num )
 				return;
 			endif
 			var tele := CreateItemAtLocation( itemt.x, itemt.y, itemt.z, 0xa3ce, 1 );
-			var inside := 0;
-			foreach item in (house.items)
-				if( tele.serial == item.serial )
-					inside := 1;
-				endif
-			endforeach
-			if (inside)
+			if (IsLocationInThisHouse(house, itemt.x, itemt.y, itemt.z, house.realm))
 				tele.movable := 0;
 				SetObjProperty( tele, "teleportserial" , CInt( house.serial ) );
 				SendSysmessage( who, "Where do you want to place the corresponding teleporter?." );
-				
+
 				var itemt2 := TargetCoordinates( who );
 				if( !itemt2 )
 					DestroyItem(tele);
@@ -1349,13 +1445,7 @@ function AddTeleporter( who, house, num )
 					return;
 				endif
 				var tele2 := CreateItemAtLocation( itemt2.x, itemt2.y, itemt2.z, 0xa3ce, 1 );
-				inside := 0;
-				foreach item in (house.items)
-					if( tele2.serial == item.serial )
-						inside := 1;
-					endif
-				endforeach
-				if (inside)
+				if (IsLocationInThisHouse(house, itemt2.x, itemt2.y, itemt2.z, house.realm))
 					tele2.movable := 0;
 					SetObjProperty( tele2, "teleportserial" , CInt( house.serial ) );
 					nameTeleporter(who, tele, tele2);
@@ -1369,14 +1459,22 @@ function AddTeleporter( who, house, num )
 					SetObjProperty( tele, "GateDestX", itemt2.x );
 					SetObjProperty( tele, "GateDestY", itemt2.y );
 					SetObjProperty( tele, "GateDestZ", itemt2.z );
+
+					var teleserials := GetObjProperty( house, "TeleporterSerials" );
+					if (!teleserials)
+						teleserials := {};
+					endif
+					teleserials.append(CInt(tele.serial));
+					teleserials.append(CInt(tele2.serial));
+					SetObjProperty( house, "TeleporterSerials", teleserials );
 				else
 					DestroyItem(tele);
 					DestroyItem(tele2);
-					SendSysmessage( who , "That is not inside the building.");
+					SendSysmessage( who , "You can only place teleporters inside this house.");
 				endif
 			else
 				DestroyItem(tele);
-                SendSysmessage( who , "That is not inside the building.");
+                SendSysmessage( who , "You can only place teleporters inside this house.");
 			endif
 		else
             SendSysmessage( who , "The house has no more teleporters remaining." );

--- a/pkg/std/housing/sign.src
+++ b/pkg/std/housing/sign.src
@@ -868,6 +868,11 @@ function ChangeHouseOwner( who , house )
 	if( oldownerserial == who.serial )
 		return 0;
  	elseif(who.acctname)
+		if( IsAccountAtHouseLimit(who) )
+			Print("[houselimit][debug] sign.ChangeHouseOwner blocked - account at house limit");
+			SendSysmessage( who , "You already own the maximum of " + CStr(MAX_HOUSES_PER_ACCOUNT) + " houses on this account." );
+			return 0;
+		endif
 		SetObjProperty( house , "ownerserial" , who.serial );
 		SetObjProperty( house , "owneracct" , who.acctname );
 		SendSysmessage( who , "House transfer was successful." );

--- a/pkg/std/housing/signcontrol.src
+++ b/pkg/std/housing/signcontrol.src
@@ -25,13 +25,12 @@ program SignListener( sign )
 
 
 	if(GetObjProperty(sign,"#Z")<>1) addsign(sign); endif
-	/* FIXME: SOMETHING STRANGE... decay is a string!
 	if (DECAY)
-		if (ReadGameClock() > GetObjProperty(sign, "decay"))
+		if (ReadGameClock() > CInt(GetObjProperty(sign, "decay")))
 			Demolish(house, sign);
 			return;
 		endif
-	endif */
+	endif
 
 	CacheData( house );
 	cache := 0;
@@ -298,6 +297,9 @@ function Demolish(house, sign)
 			endif
 		endforeach
 	endif
+
+	CleanupHouseTeleporters(house);
+
 	DestroyMulti( house );
 
 endfunction

--- a/pkg/std/housing/utility.inc
+++ b/pkg/std/housing/utility.inc
@@ -1,3 +1,5 @@
+use polsys;
+
 include "setup";
 include "include/attributes";
 
@@ -358,6 +360,62 @@ else
 	SetObjProperty(who, "Houses", houses2);
 endif
 
+endfunction
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+// Per-account house limit. Houses are tracked per-CHARACTER (the "Houses" cprop
+// above), but an account gets a fixed 5 character slots (account.GetCharacter(1..5),
+// including offline ones), so the account-wide total is a live sum across those
+// slots rather than a separately maintained counter.
+/////////////////////////////////////////////////////////////////////////////////////////////
+const MAX_HOUSES_PER_ACCOUNT := 5;
+
+function GetAccountHouseCount(who)
+	if (!who.acctname)
+		return 0;
+	endif
+
+	var account := FindAccount(who.acctname);
+	if (!account)
+		return 0;
+	endif
+
+	var total := 0;
+	var i;
+	for (i := 1; i <= 5; i := i + 1)
+		var chr := account.GetCharacter(i);
+		if (chr)
+			var houses := GetObjProperty(chr, "Houses");
+			var slot_count := 0;
+			if (houses)
+				slot_count := houses.size();
+				total := total + slot_count;
+			endif
+			Print("[houselimit][debug] account '" + CStr(who.acctname) + "' slot " + CStr(i) + " -> character '" + CStr(chr.name) + "' has " + CStr(slot_count) + " house(s)");
+		endif
+		SleepMS(2);
+	endfor
+
+	Print("[houselimit][debug] account '" + CStr(who.acctname) + "' total house count = " + CStr(total));
+	return total;
+endfunction
+
+// Staff (cmdlevel>=4) are exempt, matching Buildhouse()'s existing
+// city/dungeon/shrine/graveyard cmdlevel<4 gate in housedeed.src.
+function IsAccountAtHouseLimit(who)
+	if (who.cmdlevel >= 4)
+		Print("[houselimit][debug] who '" + CStr(who.name) + "' cmdlevel>=4, exempt from house limit");
+		return 0;
+	endif
+
+	var count := GetAccountHouseCount(who);
+	if (count >= MAX_HOUSES_PER_ACCOUNT)
+		Print("[houselimit][debug] who '" + CStr(who.name) + "' at limit (" + CStr(count) + "/" + CStr(MAX_HOUSES_PER_ACCOUNT) + ") - DENY");
+		return 1;
+	endif
+
+	Print("[houselimit][debug] who '" + CStr(who.name) + "' (" + CStr(count) + "/" + CStr(MAX_HOUSES_PER_ACCOUNT) + ") - allow");
+	return 0;
 endfunction
 
 function RegisterHouseType(deed, house)

--- a/pkg/std/housing/utility.inc
+++ b/pkg/std/housing/utility.inc
@@ -1,7 +1,9 @@
 use polsys;
+use cfgfile;
 
 include "setup";
 include "include/attributes";
+include "include/time";
 
 const VIEW_SECURE := 2;
 const ADD_TO_SECURE := 3;
@@ -363,6 +365,61 @@ endif
 endfunction
 
 /////////////////////////////////////////////////////////////////////////////////////////////
+// Returns 1 if world location x,y,z falls inside this specific house's footprint,
+// and 0 if it's outside every house or inside a DIFFERENT house/boat multi. Used to
+// validate teleporter placement instead of the unreliable "is my new item already
+// showing up in house.items" check, which doesn't actually confirm the item landed
+// inside this house.
+/////////////////////////////////////////////////////////////////////////////////////////////
+function IsLocationInThisHouse(house, x, y, z, realm)
+
+	var found := ListMultisInBox(x, y, z, x, y, z, realm);
+
+	foreach m in (found)
+		if (m.serial == house.serial)
+			return 1;
+		endif
+	endforeach
+
+	return 0;
+
+endfunction
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+// Destroys every teleporter this house has ever placed (tracked via the "TeleporterSerials"
+// cprop) and clears the list. Call this before DestroyMulti() on ANY house teardown path
+// (player demolish, admin .destroymulti, decay) so teleporters can never survive their
+// house being torn down.
+//
+// Also sweeps house.items for teleporters placed before serial-tracking existed (or
+// otherwise untracked) that still happen to sit within this house's own footprint, so
+// upgrading to serial-tracking doesn't strand pre-existing teleporters at demolish time.
+/////////////////////////////////////////////////////////////////////////////////////////////
+function CleanupHouseTeleporters(house)
+
+	var teleserials := GetObjProperty(house, "TeleporterSerials");
+	if (!teleserials)
+		teleserials := {};
+	endif
+
+	foreach item in (house.items)
+		if (item.objtype == 0xA3CE && GetObjProperty(item, "teleportserial") == house.serial && !(item.serial in teleserials))
+			teleserials.append(CInt(item.serial));
+		endif
+	endforeach
+
+	foreach teleserial in (teleserials)
+		var teleitem := SystemFindObjectBySerial(CInt(teleserial));
+		if (teleitem)
+			DestroyItem(teleitem);
+		endif
+	endforeach
+
+	EraseObjProperty(house, "TeleporterSerials");
+
+endfunction
+
+/////////////////////////////////////////////////////////////////////////////////////////////
 // Per-account house limit. Houses are tracked per-CHARACTER (the "Houses" cprop
 // above), but an account gets a fixed 5 character slots (account.GetCharacter(1..5),
 // including offline ones), so the account-wide total is a live sum across those
@@ -517,4 +574,75 @@ function ConfiscateBossPet(mobile, locationnoun := "house")
 		SendSysMessage(master, "Your pet " + pet_name + " has been confiscated for entering a " + locationnoun + ".");
 		SendSysMessage(master, "A claim ticket has been placed in your " + ticket_location + ". Visit an Animal Trainer and pay " + fine + "gp to reclaim it.", 3, 43);
 	endif
+endfunction
+
+////////////////////////////////////////////////////////////////////////////////////
+// House sign "Info" tab support: owner last-login lookup, "at risk of escrow"
+// determination, and a pretty house-type display name.
+///////////////////////////////////////////////////////////////////////////////////
+const FOUR_YEARS_SECONDS := 4 * 365 * 86400;
+
+function ResolveHouseOwnerLastLogin(owner_acct)
+	if(!owner_acct)
+		return -1;
+	endif
+
+	var account := FindAccount(owner_acct);
+	if(!account)
+		return -1;
+	endif
+
+	var last_login := CInt(account.GetProp("LastLogin"));
+	if(!last_login)
+		return 0;
+	endif
+
+	return last_login;
+endfunction
+
+function FormatHouseOwnerLastLoginDate(last_login)
+	if(last_login < 0)
+		return "Unknown";
+	elseif(!last_login)
+		return "Never";
+	endif
+
+	return GetDateString(CInt(last_login));
+endfunction
+
+// Accounts with no recorded login (unknown or never) are treated as "at risk" --
+// conservative, since there's no evidence of recent activity either way.
+function IsOwnerAccountAtRisk(last_login)
+	if(last_login <= 0)
+		return 1;
+	endif
+
+	return ((POLCore().systime - last_login) > FOUR_YEARS_SECONDS);
+endfunction
+
+var _house_itemdesc_cfg := 0;
+
+function ResolveHouseTypeDisplayName(objtype)
+	if(!objtype)
+		return "Unknown";
+	endif
+
+	if(!_house_itemdesc_cfg)
+		_house_itemdesc_cfg := ReadConfigFile(":housing:itemdesc");
+	endif
+
+	if(_house_itemdesc_cfg)
+		var house_elem := _house_itemdesc_cfg[objtype];
+		if(house_elem and !house_elem.errortext)
+			var house_name := GetConfigString(house_elem, "Name");
+			if(house_name and !house_name.errortext and house_name != "")
+				if(Len(house_name) > 5 && house_name[Len(house_name)-4, Len(house_name)] == "house")
+					house_name := house_name[1, Len(house_name)-5];
+				endif
+				return house_name;
+			endif
+		endif
+	endif
+
+	return CStr(Hex(objtype));
 endfunction

--- a/pkg/systems/email/chardelete.src
+++ b/pkg/systems/email/chardelete.src
@@ -19,6 +19,10 @@ program OnDelete( mobile )
 	email_datafile.DeleteElement( Hex( mobile.serial ));
 	addresses_datafile.DeleteElement( Hex( mobile.serial ));
 	block_list_datafile.DeleteElement( Hex( mobile.serial ));
- 
+
+	UnloadDataFile( "Emails" );
+	UnloadDataFile( "AddressBooks" );
+	UnloadDataFile( "BlockLists" );
+
         return 1;
 endprogram

--- a/pkg/systems/email/commands/gm/inspectmail.src
+++ b/pkg/systems/email/commands/gm/inspectmail.src
@@ -17,28 +17,33 @@ program ReadMail( mobile, serial )
 		var targ := Target( mobile );
                 if( !targ )
                 	SendSysMessage( mobile, "Cancelled." );
+                	UnloadDataFile( "Emails" );
                 	return 0;
                 elseif( !targ.IsA( POLCLASS_MOBILE ))
                 	SendSysMessage( mobile, "That is not a player." );
+                	UnloadDataFile( "Emails" );
                 	return 0;
                 elseif( targ.IsA( POLCLASS_NPC ))
                 	SendSysMessage( mobile, "What you selected is not a player." );
+                	UnloadDataFile( "Emails" );
                 	return 0;
                 endif
-                
+
                 serial := targ.serial;
 	endif
-	
+
 	var mail_elem := DFFindElement( email_datafile, Hex( serial ));
 	if( mail_elem )
 		var script := start_script( ":email:email", {mobile, serial} );
         	if( script.errortext )
                 	SendSysMessage( mobile, "Error starting script <:email:email> -->"+script.errortext );
+                	UnloadDataFile( "Emails" );
                 	return 0;
         	endif
 	else
 		SendSysMessage( mobile, "Box "+serial+" does not exist." );
 	endif
- 
+
+        UnloadDataFile( "Emails" );
         return 1;
 endprogram

--- a/pkg/systems/email/email.src
+++ b/pkg/systems/email/email.src
@@ -21,6 +21,8 @@ program GetMail( parms )
 	var message := parms[5];
  
  	if( GetProcess( CInt( GetObjProperty( who, "#CmdMSGPid" ))))
+		UnloadDataFile( "Emails" );
+		UnloadDataFile( "BlockLists" );
 		return 0;
 	else
 		SetObjProperty( who, "#CmdMSGPid", GetPid() );
@@ -37,6 +39,8 @@ program GetMail( parms )
                 	SleepMS(5);
                 endwhile
 	endif
- 
+
+        UnloadDataFile( "Emails" );
+        UnloadDataFile( "BlockLists" );
         return 1;
 endprogram

--- a/pkg/systems/email/logon.src
+++ b/pkg/systems/email/logon.src
@@ -30,10 +30,12 @@ program Logon( mobile )
 		var script := start_script( ":email:emailMessage/newEmail", mobile );
 		if( script.errortext )
 			SendSysMessage( mobile, "Error starting script <:email:emailMessage/newEmail> -->"+script.errortext );
+			UnloadDataFile( "Emails" );
 			return 0;
 		endif
         endif
- 
+
+        UnloadDataFile( "Emails" );
         return 1;
 endprogram
 	

--- a/pkg/systems/email/reconnect.src
+++ b/pkg/systems/email/reconnect.src
@@ -30,10 +30,12 @@ program Reconnect( mobile )
 		var script := start_script( ":email:emailMessage/newEmail", mobile );
 		if( script.errortext )
 			SendSysMessage( mobile, "Error starting script <:email:emailMessage/newEmail> -->"+script.errortext );
+			UnloadDataFile( "Emails" );
 			return 0;
 		endif
         endif
- 
+
+        UnloadDataFile( "Emails" );
         return 1;
 endprogram
 	

--- a/pkg/systems/email/webmail/webmail.src
+++ b/pkg/systems/email/webmail/webmail.src
@@ -25,7 +25,8 @@ program GetInbox( params )
 	endforeach
 
 	GetProcess( pid ).SendEvent( inbox );
- 
+
+	UnloadDataFile( "Emails" );
         return 1;
 endprogram
 	

--- a/pkg/systems/playervendor/commands/player/escrow.src
+++ b/pkg/systems/playervendor/commands/player/escrow.src
@@ -7,18 +7,11 @@ use datafile;
 use polsys;
 
 include "include/objtype";
+include "include/myutil";
 include ":playervendor:include/escrow";
+include "util/bank";
 
-const ESCROW_STORAGE_NAME := "Merchant Escrow";
 const DEBUG_MODE := 0;
-
-const ENTRY_ID_IDX := 1;
-const ENTRY_OWNERSERIAL_IDX := 2;
-const ENTRY_ESCROWNAME_IDX := 3;
-const ENTRY_VENDORNAME_IDX := 4;
-const ENTRY_VENDORSERIAL_IDX := 5;
-const ENTRY_CREATED_IDX := 6;
-const ENTRY_OWNERNAME_IDX := 7;
 
 function EscrowDebugMsg(who, msg)
 	who := who;
@@ -26,34 +19,6 @@ function EscrowDebugMsg(who, msg)
 	if(DEBUG_MODE)
 		Print("[ESCROW s=" + who.serial + "] " + msg);
 	endif
-endfunction
-
-function EntryId(entry)
-	if(len(entry) >= ENTRY_ID_IDX)
-		return entry[ENTRY_ID_IDX];
-	endif
-	return "";
-endfunction
-
-function EntryEscrowName(entry)
-	if(len(entry) >= ENTRY_ESCROWNAME_IDX)
-		return entry[ENTRY_ESCROWNAME_IDX];
-	endif
-	return "";
-endfunction
-
-function EntryVendorName(entry)
-	if(len(entry) >= ENTRY_VENDORNAME_IDX)
-		return entry[ENTRY_VENDORNAME_IDX];
-	endif
-	return "Player Merchant";
-endfunction
-
-function EntryOwnerName(entry)
-	if(len(entry) >= ENTRY_OWNERNAME_IDX and entry[ENTRY_OWNERNAME_IDX])
-		return entry[ENTRY_OWNERNAME_IDX];
-	endif
-	return "Unknown Owner";
 endfunction
 
 function HasSerial(byref serials, target_serial)
@@ -117,26 +82,7 @@ function LoadEscrowEntriesForSerial(who, merchant_serial)
 	var vendor_key := CStr(merchant_serial);
 	var vendor_elem := file.FindElement(vendor_key);
 	if(vendor_elem)
-		var entries_str := vendor_elem.GetProp("entries");
-		if(entries_str)
-			var parts := SplitWords(entries_str, "^");
-			foreach part in parts
-				if(part)
-					var fields := SplitWords(part, "|");
-					if(len(fields) >= 7)
-						entries.append({
-							fields[1],
-							CInt(fields[2]),
-							fields[3],
-							fields[4],
-							CInt(fields[5]),
-							CInt(fields[6]),
-							fields[7]
-						});
-					endif
-				endif
-			endforeach
-		endif
+		entries := DecodeEscrowEntries(vendor_elem.GetProp("entries"));
 	else
 		EscrowDebugMsg(who, "LoadEscrowEntriesForSerial: no vendor element for key=" + vendor_key);
 	endif
@@ -199,8 +145,16 @@ function ShowEscrowGump(who, page)
 		layout.append("text 542 468 53 " + (len(data)-1));
 	endif
 
+	// Button IDs encode a page-relative row number (1..ENTRIES_PER_PAGE), not
+	// the absolute entry index -- a player with 1000+ escrow entries would
+	// otherwise push an absolute-index-based id into the other button's
+	// range (e.g. idx=1001 colliding with idx=1's bank-button id) and claim
+	// the wrong entry. The absolute index is reconstructed from start_idx
+	// (still in scope) after SendDialogGump returns.
 	var row_y := 92;
 	for idx := start_idx to end_idx
+		var row_num := idx - start_idx + 1;
+
 		var merchant_label := "Merchant: " + EntryVendorName(all_entries[idx]) + " (Serial: " + all_entries[idx][ENTRY_VENDORSERIAL_IDX] + ")";
 		data.append(merchant_label);
 		layout.append("text 30 " + row_y + " 53 " + (len(data)-1));
@@ -211,11 +165,11 @@ function ShowEscrowGump(who, page)
 		layout.append("text 30 " + row_y + " 53 " + (len(data)-1));
 		row_y := row_y + 28;
 
-		layout.append("button 150 " + row_y + " 4005 4007 1 0 " + (2000 + idx));
+		layout.append("button 150 " + row_y + " 4005 4007 1 0 " + (2000 + row_num));
 		data.append("To Bank");
 		layout.append("text 182 " + row_y + " 53 " + (len(data)-1));
 
-		layout.append("button 280 " + row_y + " 4005 4007 1 0 " + (1000 + idx));
+		layout.append("button 280 " + row_y + " 4005 4007 1 0 " + (1000 + row_num));
 		data.append("To Backpack");
 		layout.append("text 312 " + row_y + " 53 " + (len(data)-1));
 
@@ -242,10 +196,11 @@ function ShowEscrowGump(who, page)
 
 	if((btn >= 1000 and btn <= 1999) or (btn >= 2000 and btn <= 2999))
 		var to_bank := (btn >= 2000) ? 1 : 0;
-		var entry_idx := (btn >= 2000) ? (btn - 2000) : (btn - 1000);
+		var claim_row := (btn >= 2000) ? (btn - 2000) : (btn - 1000);
+		var entry_idx := start_idx + claim_row - 1;
 		EscrowDebugMsg(who, "ShowEscrowGump: decoded selection entry_idx=" + entry_idx + " to_bank=" + to_bank);
 
-		if(entry_idx >= 1 and entry_idx <= len(all_entries))
+		if(claim_row >= 1 and claim_row <= ENTRIES_PER_PAGE and entry_idx >= 1 and entry_idx <= len(all_entries))
 			ClaimEscrowEntry(who, all_entries[entry_idx], to_bank);
 			ShowEscrowGump(who, page);
 		else
@@ -285,6 +240,7 @@ function ClaimEscrowEntry(who, entry, to_bank)
 	var area := FindStorageArea(ESCROW_STORAGE_NAME);
 	if(!area)
 		EscrowDebugMsg(who, "ClaimEscrowEntry: escrow storage unavailable for entry_id=" + EntryId(entry));
+		MerchantEscrowLog("[ERROR] ClaimEscrowEntry: escrow storage unavailable, entry_id=" + EntryId(entry) + " claimant=" + who.serial);
 		SendSysMessage(who, "Escrow storage is unavailable.");
 		return;
 	endif
@@ -292,22 +248,25 @@ function ClaimEscrowEntry(who, entry, to_bank)
 	var entry_id := EntryId(entry);
 	var entry_escrow_name := EntryEscrowName(entry);
 	EscrowDebugMsg(who, "ClaimEscrowEntry: entry_id=" + entry_id + " escrow_name=" + entry_escrow_name + " to_bank=" + to_bank);
+	MerchantEscrowLog("ClaimEscrowEntry: claimant=" + who.serial + " entry_id=" + entry_id + " escrow_name=" + entry_escrow_name + " to_bank=" + to_bank);
 
-	var root := FindRootItemInStorageArea(area, entry_escrow_name);
-	if(!root)
+	var escrow_root := FindRootItemInStorageArea(area, entry_escrow_name);
+	if(!escrow_root)
 		EscrowDebugMsg(who, "ClaimEscrowEntry: root not found, pruning index for entry_id=" + entry_id);
+		MerchantEscrowLog("[ERROR] ClaimEscrowEntry: root " + entry_escrow_name + " not found, pruning entry_id=" + entry_id);
 		SendSysMessage(who, "That escrow package was not found.");
 		RemoveEscrowEntryById(who, entry_id);
 		return;
 	endif
 
-	EscrowDebugMsg(who, "ClaimEscrowEntry: found root " + entry_escrow_name + " root.name=" + root.name);
+	EscrowDebugMsg(who, "ClaimEscrowEntry: found root " + entry_escrow_name + " root.name=" + escrow_root.name);
 
 	var dest;
 	if(to_bank)
 		dest := FindBankBox(who);
 		if(!dest)
 			EscrowDebugMsg(who, "ClaimEscrowEntry: bank box unavailable for entry_id=" + entry_id);
+			MerchantEscrowLog("[ERROR] ClaimEscrowEntry: bank box unavailable for claimant=" + who.serial + " entry_id=" + entry_id);
 			SendSysMessage(who, "Your bank box is unavailable.");
 			return;
 		endif
@@ -322,12 +281,13 @@ function ClaimEscrowEntry(who, entry, to_bank)
 
 	EscrowDebugMsg(who, "ClaimEscrowEntry: destination resolved type=" + (to_bank ? "bank" : "backpack"));
 
+	// Snapshot the root's direct children before moving any of them -- moving
+	// items out while live-iterating the container's own enumerator can skip
+	// items (the same collect-then-act discipline DestroyContainerAndContents
+	// already uses above).
 	var moved := 0;
-	foreach item in EnumerateItemsInContainer(root)
-		if(item.container != root)
-			continue;
-		endif
-
+	var root_items := ListRootItemsInContainer(escrow_root);
+	foreach item in root_items
 		if(MoveItemToContainer(item, dest))
 			moved := moved + 1;
 		else
@@ -341,8 +301,8 @@ function ClaimEscrowEntry(who, entry, to_bank)
 	endforeach
 
 	var remaining_root_items := 0;
-	foreach rem in EnumerateItemsInContainer(root)
-		if(rem.container == root)
+	foreach rem in EnumerateItemsInContainer(escrow_root)
+		if(rem.container == escrow_root)
 			remaining_root_items := remaining_root_items + 1;
 		endif
 	endforeach
@@ -351,19 +311,22 @@ function ClaimEscrowEntry(who, entry, to_bank)
 
 	if(!remaining_root_items)
 		EscrowDebugMsg(who, "ClaimEscrowEntry: root empty, destroying and pruning entry_id=" + entry_id);
-		DestroyContainerAndContents(root);
-		root := 0;
+		DestroyContainerAndContents(escrow_root);
+		escrow_root := 0;
 		DestroyRootItemInStorageArea(area, entry_escrow_name);
 		RemoveEscrowEntryById(who, entry_id);
+		MerchantEscrowLog("ClaimEscrowEntry: claimant=" + who.serial + " fully claimed and pruned entry_id=" + entry_id + " moved=" + moved);
 		SendSysMessage(who, "Escrow package claimed.");
 	elseif(moved)
 		EscrowDebugMsg(who, "ClaimEscrowEntry: partial claim complete for entry_id=" + entry_id);
+		MerchantEscrowLog("ClaimEscrowEntry: claimant=" + who.serial + " partially claimed entry_id=" + entry_id + " moved=" + moved + " remaining=" + remaining_root_items);
 		SendSysMessage(who, "Partial claim completed; remaining items are still in escrow.");
-		root := 0;
+		escrow_root := 0;
 	else
 		EscrowDebugMsg(who, "ClaimEscrowEntry: no items moved for entry_id=" + entry_id);
+		MerchantEscrowLog("ClaimEscrowEntry: claimant=" + who.serial + " could not move any items for entry_id=" + entry_id);
 		SendSysMessage(who, "No items could be moved from escrow.");
-		root := 0;
+		escrow_root := 0;
 	endif
 endfunction
 
@@ -387,40 +350,26 @@ function RemoveEscrowEntryById(who, entry_id)
 	foreach vendor_key in (file.Keys())
 		var vendor_elem := file.FindElement(vendor_key);
 		if(vendor_elem)
-			var entries_str := vendor_elem.GetProp("entries");
-			if(entries_str)
-				var parts := SplitWords(entries_str, "^");
-				var new_parts := {};
-
-				foreach part in parts
-					if(part)
-						var fields := SplitWords(part, "|");
-						if(len(fields) >= 1 and fields[1] != entry_id)
-							new_parts.append(part);
-						elseif(len(fields) >= 1 and fields[1] == entry_id)
-							found := 1;
-							EscrowDebugMsg(who, "RemoveEscrowEntryById: found entry_id=" + entry_id + " in merchant=" + vendor_key);
-						endif
-					endif
-				endforeach
-
-				if(found)
-					if(len(new_parts) > 0)
-						var encoded := "";
-						foreach p in new_parts
-							if(encoded)
-								encoded := encoded + "^";
-							endif
-							encoded := encoded + p;
-						endforeach
-						vendor_elem.SetProp("entries", encoded);
-						EscrowDebugMsg(who, "RemoveEscrowEntryById: updated merchant=" + vendor_key + " with " + len(new_parts) + " entries");
-					else
-						file.DeleteElement(vendor_key);
-						EscrowDebugMsg(who, "RemoveEscrowEntryById: deleted empty vendor element " + vendor_key);
-					endif
-					break;
+			var entries := DecodeEscrowEntries(vendor_elem.GetProp("entries"));
+			var new_entries := {};
+			foreach entry in entries
+				if(EntryId(entry) == entry_id)
+					found := 1;
+					EscrowDebugMsg(who, "RemoveEscrowEntryById: found entry_id=" + entry_id + " in merchant=" + vendor_key);
+				else
+					new_entries.append(entry);
 				endif
+			endforeach
+
+			if(found)
+				if(len(new_entries) > 0)
+					vendor_elem.SetProp("entries", EncodeEscrowEntries(new_entries));
+					EscrowDebugMsg(who, "RemoveEscrowEntryById: updated merchant=" + vendor_key + " with " + len(new_entries) + " entries");
+				else
+					file.DeleteElement(vendor_key);
+					EscrowDebugMsg(who, "RemoveEscrowEntryById: deleted empty vendor element " + vendor_key);
+				endif
+				break;
 			endif
 		endif
 	endforeach
@@ -428,19 +377,7 @@ function RemoveEscrowEntryById(who, entry_id)
 	UnloadDataFile(df_name);
 	if(!found)
 		EscrowDebugMsg(who, "RemoveEscrowEntryById: entry_id " + entry_id + " not found in any merchant element");
+	else
+		MerchantEscrowLog("RemoveEscrowEntryById: claimant=" + player_serial + " removed entry_id=" + entry_id + " from df=" + df_name);
 	endif
-endfunction
-
-function FindBankBox(character)
-	var worldbank := OpenWorldBank();
-	var bank_obj_name := "Bankbox of " + character.serial;
-	return FindRootItemInStorageArea(worldbank, bank_obj_name);
-endfunction
-
-function OpenWorldBank()
-	var bank := FindStorageArea("World Bank");
-	if(!bank)
-		bank := CreateStorageArea("World Bank");
-	endif
-	return bank;
 endfunction

--- a/pkg/systems/playervendor/commands/test/pmescrowtest.src
+++ b/pkg/systems/playervendor/commands/test/pmescrowtest.src
@@ -12,82 +12,14 @@ include "include/objtype";
 include "include/random";
 include ":playervendor:include/escrow";
 
-const ESCROW_STORAGE_NAME := "Merchant Escrow";
 const TEST_ID_PREFIX := "PMTEST-";
 const TEST_VENDOR_NAME := "[TEST] Player Merchant";
 const DEBUG_PM_ESCROW_TEST := 0;
-const ENTRY_ID_IDX := 1;
-const ENTRY_OWNERSERIAL_IDX := 2;
-const ENTRY_ESCROWNAME_IDX := 3;
-const ENTRY_VENDORNAME_IDX := 4;
-const ENTRY_VENDORSERIAL_IDX := 5;
-const ENTRY_CREATED_IDX := 6;
-const ENTRY_OWNERNAME_IDX := 7;
 
 function DebugMsg(who, msg)
 	if(DEBUG_PM_ESCROW_TEST)
 		Print("[PMTEST s=" + who.serial + "] " + msg);
 	endif
-endfunction
-
-function EntryId(entry)
-	if(entry.id)
-		return entry.id;
-	endif
-	if(len(entry) >= ENTRY_ID_IDX)
-		return entry[ENTRY_ID_IDX];
-	endif
-	return "";
-endfunction
-
-function EntryOwnerSerial(entry)
-	if(entry.ownerserial)
-		return CInt(entry.ownerserial);
-	endif
-	if(len(entry) >= ENTRY_OWNERSERIAL_IDX)
-		return CInt(entry[ENTRY_OWNERSERIAL_IDX]);
-	endif
-	return 0;
-endfunction
-
-function EntryEscrowName(entry)
-	if(entry.escrowname)
-		return entry.escrowname;
-	endif
-	if(len(entry) >= ENTRY_ESCROWNAME_IDX)
-		return entry[ENTRY_ESCROWNAME_IDX];
-	endif
-	return "";
-endfunction
-
-function EntryVendorName(entry)
-	if(entry.vendorname)
-		return entry.vendorname;
-	endif
-	if(len(entry) >= ENTRY_VENDORNAME_IDX)
-		return entry[ENTRY_VENDORNAME_IDX];
-	endif
-	return TEST_VENDOR_NAME;
-endfunction
-
-function EntryVendorSerial(entry)
-	if(entry.vendorserial)
-		return CInt(entry.vendorserial);
-	endif
-	if(len(entry) >= ENTRY_VENDORSERIAL_IDX)
-		return CInt(entry[ENTRY_VENDORSERIAL_IDX]);
-	endif
-	return 0;
-endfunction
-
-function EntryOwnerName(entry)
-	if(entry.ownername)
-		return entry.ownername;
-	endif
-	if(len(entry) >= ENTRY_OWNERNAME_IDX and entry[ENTRY_OWNERNAME_IDX])
-		return entry[ENTRY_OWNERNAME_IDX];
-	endif
-	return "Unknown Owner";
 endfunction
 
 program textcmd_pmescrowtest(who, text)
@@ -125,14 +57,6 @@ function ParseIntOrDefault(raw, default_val)
 	return parsed;
 endfunction
 
-function OpenEscrowStorage()
-	var area := FindStorageArea(ESCROW_STORAGE_NAME);
-	if(!area)
-		area := CreateStorageArea(ESCROW_STORAGE_NAME);
-	endif
-	return area;
-endfunction
-
 function LoadEscrowEntriesForSerial(who, merchant_serial)
 	var entries := {};
 	var df_name := ResolveEscrowDatafileNameForSerial(who, merchant_serial, 0);
@@ -148,26 +72,7 @@ function LoadEscrowEntriesForSerial(who, merchant_serial)
 	var vendor_key := CStr(merchant_serial);
 	var vendor_elem := file.FindElement(vendor_key);
 	if(vendor_elem)
-		var entries_str := vendor_elem.GetProp("entries");
-		if(entries_str)
-			var parts := SplitWords(entries_str, "^");
-			foreach part in parts
-				if(part)
-					var fields := SplitWords(part, "|");
-					if(len(fields) >= 7)
-						entries.append({
-							fields[1],
-							CInt(fields[2]),
-							fields[3],
-							fields[4],
-							CInt(fields[5]),
-							CInt(fields[6]),
-							fields[7]
-						});
-					endif
-				endif
-			endforeach
-		endif
+		entries := DecodeEscrowEntries(vendor_elem.GetProp("entries"));
 	endif
 
 	UnloadDataFile(df_name);
@@ -199,15 +104,7 @@ function SaveEscrowEntriesForSerial(who, merchant_serial, entries)
 		return 0;
 	endif
 
-	var encoded := "";
-	foreach entry in entries
-		if(encoded)
-			encoded := encoded + "^";
-		endif
-		encoded := encoded + entry[1] + "|" + entry[2] + "|" + entry[3] + "|" + entry[4] + "|" + entry[5] + "|" + entry[6] + "|" + entry[7];
-	endforeach
-
-	vendor_elem.SetProp("entries", encoded);
+	vendor_elem.SetProp("entries", EncodeEscrowEntries(entries));
 	UnloadDataFile(df_name);
 	return 1;
 endfunction

--- a/pkg/systems/playervendor/include/escrow.inc
+++ b/pkg/systems/playervendor/include/escrow.inc
@@ -4,8 +4,166 @@ use os;
 use uo;
 use util;
 use datafile;
+use storage;
+use file;
 
 const PLAYERVENDOR_ESCROW_DF_PREFIX := "merchantescrow_";
+const ESCROW_STORAGE_NAME := "Merchant Escrow";
+const MERCHANT_ESCROW_LOG_FILE := "::log/merchantescrow.log";
+
+const ENTRY_ID_IDX := 1;
+const ENTRY_OWNERSERIAL_IDX := 2;
+const ENTRY_ESCROWNAME_IDX := 3;
+const ENTRY_VENDORNAME_IDX := 4;
+const ENTRY_VENDORSERIAL_IDX := 5;
+const ENTRY_CREATED_IDX := 6;
+const ENTRY_OWNERNAME_IDX := 7;
+
+// Persistent troubleshooting log, independent of any live-console debug flags.
+function MerchantEscrowLog(msg)
+	LogToFile(MERCHANT_ESCROW_LOG_FILE, msg, LOG_DATETIME);
+endfunction
+
+function OpenEscrowStorage()
+	var area := FindStorageArea(ESCROW_STORAGE_NAME);
+	if(!area)
+		area := CreateStorageArea(ESCROW_STORAGE_NAME);
+	endif
+	return area;
+endfunction
+
+// Percent-style escaping for the free-text fields (vendor/owner names) embedded
+// in the "|"/"^"-delimited entry format, so a name containing either delimiter
+// can't corrupt the encoding. Order matters: escape "%" first on encode (so it
+// doesn't clobber the escapes just introduced for "|"/"^"), restore it last on
+// decode (mirror order).
+function EscrowEscapeField(s)
+	s := CStr(s);
+	s := StrReplace(s, "%", "%25");
+	s := StrReplace(s, "|", "%7C");
+	s := StrReplace(s, "^", "%5E");
+	return s;
+endfunction
+
+function EscrowUnescapeField(s)
+	s := CStr(s);
+	s := StrReplace(s, "%7C", "|");
+	s := StrReplace(s, "%5E", "^");
+	s := StrReplace(s, "%25", "%");
+	return s;
+endfunction
+
+function EncodeEscrowEntryFields(id, ownerserial, escrow_name, vendor_name, vendor_serial, created, owner_name)
+	return CStr(id) + "|" + CStr(ownerserial) + "|" + CStr(escrow_name) + "|" + EscrowEscapeField(vendor_name) + "|" + CStr(vendor_serial) + "|" + CStr(created) + "|" + EscrowEscapeField(owner_name);
+endfunction
+
+function EncodeEscrowEntries(entries)
+	var encoded := "";
+	foreach entry in entries
+		if(encoded)
+			encoded := encoded + "^";
+		endif
+		encoded := encoded + EncodeEscrowEntryFields(EntryId(entry), EntryOwnerSerial(entry), EntryEscrowName(entry), EntryVendorName(entry), EntryVendorSerial(entry), EntryCreated(entry), EntryOwnerName(entry));
+	endforeach
+	return encoded;
+endfunction
+
+function DecodeEscrowEntries(entries_str)
+	var entries := {};
+	if(!entries_str)
+		return entries;
+	endif
+
+	var parts := SplitWords(entries_str, "^");
+	foreach part in parts
+		if(part)
+			var fields := SplitWords(part, "|");
+			if(len(fields) >= 7)
+				entries.append({
+					fields[1],
+					CInt(fields[2]),
+					fields[3],
+					EscrowUnescapeField(fields[4]),
+					CInt(fields[5]),
+					CInt(fields[6]),
+					EscrowUnescapeField(fields[7])
+				});
+			endif
+		endif
+	endforeach
+
+	return entries;
+endfunction
+
+function EntryId(entry)
+	if(entry.id)
+		return entry.id;
+	endif
+	if(len(entry) >= ENTRY_ID_IDX)
+		return entry[ENTRY_ID_IDX];
+	endif
+	return "";
+endfunction
+
+function EntryOwnerSerial(entry)
+	if(entry.ownerserial)
+		return CInt(entry.ownerserial);
+	endif
+	if(len(entry) >= ENTRY_OWNERSERIAL_IDX)
+		return CInt(entry[ENTRY_OWNERSERIAL_IDX]);
+	endif
+	return 0;
+endfunction
+
+function EntryEscrowName(entry)
+	if(entry.escrowname)
+		return entry.escrowname;
+	endif
+	if(len(entry) >= ENTRY_ESCROWNAME_IDX)
+		return entry[ENTRY_ESCROWNAME_IDX];
+	endif
+	return "";
+endfunction
+
+function EntryVendorName(entry)
+	if(entry.vendorname)
+		return entry.vendorname;
+	endif
+	if(len(entry) >= ENTRY_VENDORNAME_IDX)
+		return entry[ENTRY_VENDORNAME_IDX];
+	endif
+	return "Player Merchant";
+endfunction
+
+function EntryVendorSerial(entry)
+	if(entry.vendorserial)
+		return CInt(entry.vendorserial);
+	endif
+	if(len(entry) >= ENTRY_VENDORSERIAL_IDX)
+		return CInt(entry[ENTRY_VENDORSERIAL_IDX]);
+	endif
+	return 0;
+endfunction
+
+function EntryCreated(entry)
+	if(entry.created)
+		return CInt(entry.created);
+	endif
+	if(len(entry) >= ENTRY_CREATED_IDX)
+		return CInt(entry[ENTRY_CREATED_IDX]);
+	endif
+	return 0;
+endfunction
+
+function EntryOwnerName(entry)
+	if(entry.ownername)
+		return entry.ownername;
+	endif
+	if(len(entry) >= ENTRY_OWNERNAME_IDX and entry[ENTRY_OWNERNAME_IDX])
+		return entry[ENTRY_OWNERNAME_IDX];
+	endif
+	return "Unknown Owner";
+endfunction
 
 function BuildLegacyEscrowDatafileName(player_obj)
 	if(!player_obj)
@@ -112,5 +270,24 @@ function BuildEscrowDatafileName(player_obj)
 		return "";
 	endif
 
-	return PLAYERVENDOR_ESCROW_DF_PREFIX + player_obj.serial;
+	return BuildEscrowDatafileNameForSerial(player_obj.serial);
+endfunction
+
+// Takes a raw serial rather than a live object -- this must keep working even
+// when the owning character can no longer be resolved (deleted/missing), so an
+// escrow entry can still be filed and found later instead of silently dropped.
+// Deliberately accepts a serial of 0 (a masterless merchant has no owner to
+// key by) rather than rejecting it -- that still produces a valid, shared
+// "merchantescrow_0" datafile that masterless-merchant entries can be indexed
+// into (keyed per-merchant within it), instead of failing to build a name at
+// all and leaving the escrow root permanently unindexed.
+//
+// Package-scoped (":playervendor:...") is mandatory -- see the identical fix
+// on pkg/std/housing's BuildHouseEscrowDatafileNameForSerial for why a bare
+// filespec is unsafe (it apparently resolves relative to the calling
+// script's own package). This one happened to work by accident so far only
+// because every current caller (playermerchant.src, escrow.src,
+// pmescrowtest.src) lives inside pkg/systems/playervendor itself.
+function BuildEscrowDatafileNameForSerial(owner_serial)
+	return ":playervendor:" + PLAYERVENDOR_ESCROW_DF_PREFIX + CStr(owner_serial);
 endfunction

--- a/pkg/systems/playervendor/playermerchant.src
+++ b/pkg/systems/playervendor/playermerchant.src
@@ -36,10 +36,9 @@ const CITY_MONTHLY_WAGE_GOLD := 40000;
 const MONTH_LENGTH_DAYS := 30;
 const OWNER_WARN_COOLDOWN := 300;
 const PAYOUT_PACK_OBJTYPE := UOBJ_BACKPACK;
-const PAYOUT_PACK_MAX_ROOT_ITEMS := 100;
-const PAYOUT_PACK_MAX_WEIGHT := 40000;
+const PAYOUT_PACK_MAX_ROOT_ITEMS := 225;
+const PAYOUT_PACK_MAX_WEIGHT := 60000;
 const CHEQUE_MAX_GOLD := 5000000;
-const ESCROW_STORAGE_NAME := "Merchant Escrow";
 const DEBUG_PLAYERMERCHANT := 0;
 
 function PMDebug(msg)
@@ -106,7 +105,7 @@ program merchant()
 					srcserial := ev.source.serial;
 				endif
 				PMDebug("[PLAYERMERCHANT] Force fire event for " + me.serial + " from " + srcserial + ", master=" + master + " force_escrow=" + force_escrow);
-				if(srcserial == master)
+				if(srcserial == master or (ev.source and ev.source.cmdlevel >= 4))
 					HandleMerchantClosure("forced_by_pmfireme_event", force_escrow);
 					break;
 				else
@@ -664,14 +663,6 @@ function QueueGMPageReport(message)
 	SetGlobalProperty("gmpages", gmpages);
 endfunction
 
-function OpenEscrowStorage()
-	var area := FindStorageArea(ESCROW_STORAGE_NAME);
-	if(!area)
-		area := CreateStorageArea(ESCROW_STORAGE_NAME);
-	endif
-	return area;
-endfunction
-
 function AppendEscrowIndex(ownerserial, escrow_name, vendor_name)
 	var owner_name := "Unknown Owner";
 	var owner_obj := SystemFindObjectBySerial(CInt(ownerserial), SYSFIND_SEARCH_OFFLINE_MOBILES);
@@ -682,26 +673,35 @@ function AppendEscrowIndex(ownerserial, escrow_name, vendor_name)
 	var entry_id := ownerserial + "-" + ReadGameClock() + "-" + Random(100000);
 	PMDebug("[PMESCROWDBG] AppendEscrowIndex owner=" + ownerserial + " escrow_name=" + escrow_name + " vendor=" + vendor_name + " entry_id=" + entry_id);
 
-	// Read master serial from merchant object
-	var master := CInt(GetObjProperty(me, "master"));
-	if(!master)
-		PMDebug("[PMESCROWDBG] AppendEscrowIndex aborted: merchant has no master property");
-		return entry_id;
+	// Note: this used to bail out here if the merchant's own "master" property
+	// was unset (masterless merchant), which meant SavePackToEscrow's already-
+	// created escrow root was left permanently unindexed for exactly the
+	// masterless-cleanup path that HandleMasterlessMerchantCleanup now routes
+	// through CashOut(1) to try to prevent asset loss. Indexing must proceed
+	// regardless -- BuildEscrowDatafileNameForSerial(0) still produces a valid,
+	// shared "merchantescrow_0" datafile (keyed per-merchant by me.serial), so
+	// the entry stays findable/loggable instead of orphaned.
+	if(!CInt(GetObjProperty(me, "master")))
+		PMDebug("[PMESCROWDBG] AppendEscrowIndex: merchant has no master property, indexing under owner=" + ownerserial + " anyway");
+		MerchantEscrowLog("[ORPHANED] AppendEscrowIndex: merchant " + me.serial + " has no master property; indexing entry_id=" + entry_id + " under owner=" + ownerserial + " anyway");
 	endif
-	PMDebug("[PMESCROWDBG] AppendEscrowIndex merchant_serial=" + me.serial + " master=" + master);
 
-	// Get owner object to build per-player datafile name
-	if(!owner_obj)
-		owner_obj := SystemFindObjectBySerial(CInt(ownerserial), SYSFIND_SEARCH_OFFLINE_MOBILES);
-		if(!owner_obj)
-			PMDebug("[PMESCROWDBG] AppendEscrowIndex failed to find owner object for serial " + ownerserial);
-			return entry_id;
-			endif
-		endif
-	// Load or create per-player escrow datafile
-	var df_name := ResolveEscrowDatafileNameForSerial(owner_obj, me.serial, 1);
+	// Build the per-owner datafile name. If the owner object still resolves, go
+	// through the legacy-name resolver/migrator as before; if it doesn't (deleted
+	// or otherwise unresolvable character), fall back to building the canonical
+	// name from the raw serial directly. This must NOT bail out here -- doing so
+	// left the escrow root already created by SavePackToEscrow as an unindexed,
+	// unclaimable orphan (the original bug).
+	var df_name;
+	if(owner_obj)
+		df_name := ResolveEscrowDatafileNameForSerial(owner_obj, me.serial, 1);
+	else
+		df_name := BuildEscrowDatafileNameForSerial(ownerserial);
+		MerchantEscrowLog("[ORPHANED] AppendEscrowIndex: owner serial " + ownerserial + " could not be resolved to a character; filing under " + df_name + " anyway (entry_id=" + entry_id + ", vendor=" + vendor_name + ")");
+	endif
 	if(!df_name)
 		PMDebug("[PMESCROWDBG] Failed to build datafile name for owner " + ownerserial);
+		MerchantEscrowLog("[ERROR] AppendEscrowIndex: failed to build datafile name for owner " + ownerserial + ", entry_id=" + entry_id + " never indexed");
 		return entry_id;
 	endif
 
@@ -712,6 +712,7 @@ function AppendEscrowIndex(ownerserial, escrow_name, vendor_name)
 		df := OpenDataFile(df_name);
 		if(!df)
 			PMDebug("[PMESCROWDBG] Failed to reopen datafile " + df_name);
+			MerchantEscrowLog("[ERROR] AppendEscrowIndex: failed to open/create datafile " + df_name + ", entry_id=" + entry_id + " never indexed");
 			return entry_id;
 		endif
 	endif
@@ -725,38 +726,18 @@ function AppendEscrowIndex(ownerserial, escrow_name, vendor_name)
 	endif
 	if(!vendor_elem)
 		PMDebug("[PMESCROWDBG] Failed to create/find element " + vendor_key);
+		MerchantEscrowLog("[ERROR] AppendEscrowIndex: failed to create/find element " + vendor_key + " in " + df_name + ", entry_id=" + entry_id + " never indexed");
 		UnloadDataFile(df_name);
 		return entry_id;
 	endif
 
-	// Get existing entries (stored as format: id|owner|escrow_name|vendor_name|vendor_serial|created|owner_name)
-	var entries_str := vendor_elem.GetProp("entries");
-	var entries := {};
-	PMDebug("[PMESCROWDBG] Existing entries string length=" + CStr(len(entries_str)));
-	if(entries_str)
-		// Parse format: id|owner|escrow_name|vendor_name|vendor_serial|created|owner_name^...
-		var parts := SplitWords(entries_str, "^");
-		PMDebug("[PMESCROWDBG] Parsed existing entries count=" + CStr(len(parts)));
-		foreach part in parts
-			if(part)
-				var fields := SplitWords(part, "|");
-				if(len(fields) >= 7)
-					entries.append({
-						fields[1],
-						CInt(fields[2]),
-						fields[3],
-						fields[4],
-						CInt(fields[5]),
-						CInt(fields[6]),
-						fields[7]
-					});
-				endif
-			endif
-		endforeach
-	endif
-	PMDebug("[PMESCROWDBG] Entries count after parse=" + CStr(len(entries)));
+	// Read-modify-write the entries string. No sleep/wait_for_event happens
+	// anywhere between OpenDataFile and UnloadDataFile in this function, which
+	// keeps this atomic under POL's cooperative script scheduler -- do not add
+	// one here without re-adding real synchronization.
+	var entries := DecodeEscrowEntries(vendor_elem.GetProp("entries"));
+	PMDebug("[PMESCROWDBG] Entries count before append=" + CStr(len(entries)));
 
-	// Append new entry with merchant serial (me.serial)
 	entries.append({
 		entry_id,
 		CInt(ownerserial),
@@ -767,18 +748,9 @@ function AppendEscrowIndex(ownerserial, escrow_name, vendor_name)
 		owner_name
 	});
 
-	// Encode entries back to string
-	var encoded := "";
-	foreach entry in entries
-		if(encoded)
-			encoded := encoded + "^";
-		endif
-		encoded := encoded + entry[1] + "|" + entry[2] + "|" + entry[3] + "|" + entry[4] + "|" + entry[5] + "|" + entry[6] + "|" + entry[7];
-	endforeach
-	PMDebug("[PMESCROWDBG] Encoded entries length=" + CStr(len(encoded)));
-
-	vendor_elem.SetProp("entries", encoded);
+	vendor_elem.SetProp("entries", EncodeEscrowEntries(entries));
 	PMDebug("[PMESCROWDBG] Saved escrow entries under " + vendor_key + " in " + df_name);
+	MerchantEscrowLog("Indexed entry_id=" + entry_id + " owner=" + ownerserial + " (" + owner_name + ") vendor=" + vendor_name + "(" + me.serial + ") escrow_name=" + escrow_name + " df=" + df_name);
 	UnloadDataFile(df_name);
 
 	return entry_id;
@@ -787,6 +759,7 @@ endfunction
 function SavePackToEscrow(payout_pack, ownerserial, vendor_name)
 	var area := OpenEscrowStorage();
 	if(!area)
+		MerchantEscrowLog("[ERROR] SavePackToEscrow: escrow storage area unavailable, dropping payout pack on ground for vendor=" + vendor_name + "(" + me.serial + ") owner=" + ownerserial);
 		MoveObjectToLocation(payout_pack, me.x, me.y, me.z, me.realm, MOVEOBJECT_FORCELOCATION);
 		return 0;
 	endif
@@ -794,6 +767,7 @@ function SavePackToEscrow(payout_pack, ownerserial, vendor_name)
 	var escrow_name := "PMEscrow " + ownerserial + " " + ReadGameClock() + " " + Random(99999);
 	var escrow_root := CreateRootItemInStorageArea(area, escrow_name, UOBJ_BACKPACK);
 	if(!escrow_root)
+		MerchantEscrowLog("[ERROR] SavePackToEscrow: failed to create escrow root " + escrow_name + ", dropping payout pack on ground for vendor=" + vendor_name + "(" + me.serial + ") owner=" + ownerserial);
 		MoveObjectToLocation(payout_pack, me.x, me.y, me.z, me.realm, MOVEOBJECT_FORCELOCATION);
 		return 0;
 	endif
@@ -807,11 +781,13 @@ function SavePackToEscrow(payout_pack, ownerserial, vendor_name)
 	SetObjProperty(escrow_root, "created", ReadGameClock());
 
 	if(!MoveItemToContainer(payout_pack, escrow_root))
+		MerchantEscrowLog("[ERROR] SavePackToEscrow: failed to move payout pack into escrow root " + escrow_name + ", dropping on ground for vendor=" + vendor_name + "(" + me.serial + ") owner=" + ownerserial);
 		DestroyRootItemInStorageArea(area, escrow_name);
 		MoveObjectToLocation(payout_pack, me.x, me.y, me.z, me.realm, MOVEOBJECT_FORCELOCATION);
 		return 0;
 	endif
 
+	MerchantEscrowLog("Saved payout pack to escrow root " + escrow_name + " for vendor=" + vendor_name + "(" + me.serial + ") owner=" + ownerserial);
 	AppendEscrowIndex(ownerserial, escrow_name, vendor_name);
 	return 1;
 endfunction
@@ -933,6 +909,7 @@ function CashOut(force_escrow := 0)
 	if(!owner)
 		Say("I can't find my employer right now.");
 		QueueGMPageReport("CashOut failed: master not found. Vendor=" + me.name + "(" + me.serial + ") MasterSerial=" + ownerserial + " Loc=" + me.x + "," + me.y + "," + me.z + " Realm=" + me.realm);
+		MerchantEscrowLog("[ORPHANED] CashOut: owner serial " + ownerserial + " not found for vendor=" + me.name + "(" + me.serial + "); assets will be escrowed under that serial and a GM page was queued");
 	endif
 
 	var vendor_name := me.name;
@@ -1097,19 +1074,13 @@ exported function ForceCashOut(byref who, force_escrow := 0)
 endfunction
 
 function HandleMasterlessMerchantCleanup()
-	PerformAction(me, ANIM_CAST_DIR);
-	Say("Kal Ort Por");
-	sleep(2);
-	MoveObjectToLocation(me, 5288, 1176, 0, me.realm, MOVEOBJECT_FORCELOCATION);
-	RevokePrivilege(me, "invul");
-	SetObjProperty(me, "guardkill", 1);
-
-	var count := 0;
-	repeat
-		SleepMS(1000);
-		me.kill();
-		count := count + 1;
-	until(!me || count >= 1000);
+	MerchantEscrowLog("[ORPHANED] HandleMasterlessMerchantCleanup: merchant " + me.serial + " (" + me.name + ") has no master property; forcing cash-out to escrow before cleanup");
+	// Delegate to HandleMerchantClosure rather than duplicating its tail --
+	// it already does CashOut + destroys inv_fs/inv_pb/inv_1c + the kill
+	// sequence. Calling CashOut directly here and skipping straight to kill
+	// (the original shape of this function) left those now-emptied storage
+	// containers behind as permanently orphaned empty backpacks.
+	HandleMerchantClosure("masterless_cleanup", 1);
 endfunction
 
 function GetPay()

--- a/pkg/utils/gumps/include/yesNoSizable.inc
+++ b/pkg/utils/gumps/include/yesNoSizable.inc
@@ -121,22 +121,45 @@ endfunction
 * Version 2.0
 * This new gump will actually extend itself based on the length of your prompt text, which means
 *  the text/gump overlap bug is gone.
+*
+* Widened by ZHO to also stretch height, not just width -- the original only
+* grew sideways (fine for a short one-liner) but left a fixed 110-unit-tall
+* box, so anything long enough to wrap past ~3 lines still overflowed the
+* box vertically. Line/char-width estimates below are approximations (POL
+* gumps expose no real font metrics) -- nudge YESNOVAR_* if testing shows
+* text clipping or excess empty space.
 */
 use uo;
 use util;
 
+const YESNOVAR_MAX_WIDTH      := 500; // cap so a very long prompt doesn't run off-screen sideways
+const YESNOVAR_CHARS_PER_LINE_PX := 6;  // rough avg glyph width (px) for the htmlgump font
+const YESNOVAR_LINE_HEIGHT_PX := 18;  // rough line height (px) for the htmlgump font
+
 function YesNoVar(me, prompt, color := "#FFFFFF")
   var lenny := cint(len(prompt) * 2)+160;
   if(lenny < 180) lenny := 180; endif
+  if(lenny > YESNOVAR_MAX_WIDTH) lenny := YESNOVAR_MAX_WIDTH; endif
+
+  var htmlwidth := lenny - 19;
+  var est_chars_per_line := CInt(htmlwidth / YESNOVAR_CHARS_PER_LINE_PX);
+  if(est_chars_per_line < 10) est_chars_per_line := 10; endif
+  var est_lines := CInt((len(prompt) + est_chars_per_line - 1) / est_chars_per_line); // ceil
+
+  var htmlheight := (est_lines * YESNOVAR_LINE_HEIGHT_PX) + 10;
+  if(htmlheight < 59) htmlheight := 59; endif
+
+  var boxheight := htmlheight + 51; // matches the original fixed box's chrome: 45px above the html area, 6px below it, 8px more to the buttons
+
   var layout := array(
      "nodispose",
      "page 0",
-     "resizepic 30 30 5054 "+ lenny +" 110",
-     "gumppictiled 41 41 "+ (lenny - 22) +" 88 2624",
-     "checkertrans 40 40 "+ (lenny - 20) +" 90",
-     "htmlgump 40 45 "+ (lenny - 19) +" 59 0 0 0",
-     "button 50 102 4023 4025 1 0 1",
-     "button "+ (lenny - 20) +" 102 4017 4019 1 0 0"
+     "resizepic 30 30 5054 "+ lenny +" "+ boxheight +"",
+     "gumppictiled 41 41 "+ (lenny - 22) +" "+ (boxheight - 22) +" 2624",
+     "checkertrans 40 40 "+ (lenny - 20) +" "+ (boxheight - 20) +"",
+     "htmlgump 40 45 "+ htmlwidth +" "+ htmlheight +" 0 0 0",
+     "button 50 "+ (boxheight - 8) +" 4023 4025 1 0 1",
+     "button "+ (lenny - 20) +" "+ (boxheight - 8) +" 4017 4019 1 0 0"
   );
   var data := array("<basefont color=\""+ color +"\"><center>"+ prompt +"</center></basefont");
   var res := SendDialogGump( me, layout, data );

--- a/regions/regions.cfg
+++ b/regions/regions.cfg
@@ -235,7 +235,7 @@ Region Occlo Isle
     Range 3332 2352 3815 2931
     Realm britannia
     MIDI 16
-    Type POI
+    Type City
     Area 17545
     EnterText You have entered Occlo Isle.
     LeaveText You have left Occlo Isle.
@@ -1613,7 +1613,7 @@ Region Yew Farmlands
     Range 600 928 707 1255
     Realm britannia
     MIDI 17
-    Type City
+    Type Suburb
     Area 2214
     EnterText You have entered Yew Farmlands.
     LeaveText You have left Yew Farmlands.
@@ -1626,7 +1626,7 @@ Region Yew Farmlands
     Range 500 1052 599 1255
     Realm britannia
     MIDI 17
-    Type City
+    Type Suburb
     Area 1275
     EnterText You have entered Yew Farmlands.
     LeaveText You have left Yew Farmlands.
@@ -1639,7 +1639,7 @@ Region Yew Farmlands
     Range 232 928 499 1255
     Realm britannia
     MIDI 17
-    Type City
+    Type Suburb
     Area 5494
     EnterText You have entered Yew Farmlands.
     LeaveText You have left Yew Farmlands.
@@ -1652,7 +1652,7 @@ Region Yew Farmlands
     Range 412 772 539 927
     Realm britannia
     MIDI 17
-    Type City
+    Type Suburb
     Area 1248
     EnterText You have entered Yew Farmlands.
     LeaveText You have left Yew Farmlands.
@@ -1691,7 +1691,7 @@ Region Vesper Outbuildings
     Range 2716 928 2819 1015
     Realm britannia
     MIDI 22
-    Type City
+    Type Suburb
     Area 572
     EnterText You have entered Vesper Outbuildings.
     LeaveText You have left Vesper Outbuildings.
@@ -1704,7 +1704,7 @@ Region Vesper Outbuildings
     Range 2936 600 3007 655
     Realm britannia
     MIDI 22
-    Type City
+    Type Suburb
     Area 252
     EnterText You have entered Vesper Outbuildings.
     LeaveText You have left Vesper Outbuildings.
@@ -1821,7 +1821,7 @@ Region Minoc Farmlands
     Range 2464 604 2623 687
     Realm britannia
     MIDI 16
-    Type City
+    Type Suburb
     Area 840
     EnterText You have entered Minoc Farmlands.
     LeaveText You have left Minoc Farmlands.
@@ -1834,7 +1834,7 @@ Region Minoc Farmlands
     Range 2540 552 2627 603
     Realm britannia
     MIDI 16
-    Type City
+    Type Suburb
     Area 286
     EnterText You have entered Minoc Farmlands.
     LeaveText You have left Minoc Farmlands.
@@ -1951,7 +1951,7 @@ Region Britain Outer Farmlands
     Range 1084 1540 1287 1903
     Realm britannia
     MIDI 9
-    Type City
+    Type Suburb
     Area 4641
     EnterText You have entered Britain Outer Farmlands.
     LeaveText You have left Britain Outer Farmlands.
@@ -2003,7 +2003,7 @@ Region Skara Brae Farmlands
     Range 696 2056 911 2423
     Realm britannia
     MIDI 20
-    Type City
+    Type Suburb
     Area 4968
     EnterText You have entered Skara Brae Farmlands.
     LeaveText You have left Skara Brae Farmlands.

--- a/scripts/ai/main/killpcsloop.inc
+++ b/scripts/ai/main/killpcsloop.inc
@@ -6,11 +6,17 @@ include "include/areas";
 include "include/attributes";
 include "include/npcboosts";
 
+// wanders counts consecutive main-loop cycles (2s each, see wait_for_event(2)
+// below) with no interrupting event. At NPC_SLEEP_AFTER_WANDERS that's ~5
+// minutes of nothing happening, at which point sleepmode() is tried - it
+// still does its own proximity check before actually going dormant.
+const NPC_SLEEP_AFTER_WANDERS := 150;
+
 //var me := Self();
 
 function main_AI_loop()
 	var ev;
-	var wanders := 60;
+	var wanders := NPC_SLEEP_AFTER_WANDERS;
 	var next_loot := readgameclock() + 20;
 
 	var LOOTSTUFF := imalooter(me.npctemplate);
@@ -66,7 +72,7 @@ function main_AI_loop()
 			wanders := wanders + 1;
 		endif
 
-		if (wanders > 60)
+		if (wanders > NPC_SLEEP_AFTER_WANDERS)
 			wanders :=0;
 			ev := sleepmode();
 		else

--- a/scripts/ai/main/sleepmode.inc
+++ b/scripts/ai/main/sleepmode.inc
@@ -3,9 +3,15 @@ include "include/attributes";
 
 include "include/client";
 
+// Radius (tiles) a PC has to be outside of before this NPC will go dormant,
+// and the radius that wakes it back up again while asleep. Deliberately the
+// same value in both directions - if someone's close enough to prevent
+// sleep, they're close enough to end it.
+const NPC_SLEEP_WAKE_RADIUS := 20;
+
 function sleepmode()
 
-	foreach critter in ListMobilesNearLocation( me.x, me.y, me.z, 20 ,me.realm );
+	foreach critter in ListMobilesNearLocation( me.x, me.y, me.z, NPC_SLEEP_WAKE_RADIUS, me.realm );
 		if (!critter.npctemplate)
 			return 0;
 		endif
@@ -39,10 +45,13 @@ function sleepmode()
 		me.frozen := 0;
 	endif
 	if ( (GetEffectiveSkill(me, 21) > 0 ) and (me.script != "merchant") )
+		// Hiding-skill NPCs conceal themselves while dormant, so they keep a
+		// short wake radius on purpose - the point is not noticing someone
+		// until they're genuinely close, same as a real hidden rogue.
 		me.hidden := 1;
 		EnableEvents(SYSEVENT_ENTEREDAREA, 4);
 	else
-		EnableEvents(SYSEVENT_ENTEREDAREA, 18);
+		EnableEvents(SYSEVENT_ENTEREDAREA, NPC_SLEEP_WAKE_RADIUS);
 	endif
 	
 	EnableEvents(SYSEVENT_ENGAGED);

--- a/scripts/ai/tamed.src
+++ b/scripts/ai/tamed.src
@@ -1,7 +1,6 @@
 use npc;
 use os;
 use uo;
-use basicio;
 
 
 include "include/eventid";
@@ -22,11 +21,6 @@ include "include/areas";
 
 const HALT_THRESHOLD := 10;
 Const MOVING_EFFECT_FIREBALL	:= 0x36D4;
-
-// Follow()'s own Sleepms(25) floor caps normal calls at ~40/sec; this is set
-// well above that so it only fires if something bypasses that floor entirely.
-const FOLLOW_RUNAWAY_THRESHOLD := 100;
-const FOLLOW_RUNAWAY_WARN_COOLDOWN := 60;
 
 var me := Self();
 var masterserial := GetObjProperty( me , "master" );
@@ -64,9 +58,6 @@ var lastspeechkey := "";
 var nextspeechallowed := 0;
 var awaitingtargetselection := 0;
 var ignorespeechuntil := 0;
-var followcalls := 0;
-var followwindowstart := 0;
-var lastfollowwarn := 0;
 
 me.setmaster( master );
 
@@ -1151,18 +1142,6 @@ function Guard()
 endfunction
 
 function Follow()
-
-	var followclock := ReadGameClock();
-	if (followclock != followwindowstart)
-		if ((followcalls > FOLLOW_RUNAWAY_THRESHOLD) and ((followclock - lastfollowwarn) >= FOLLOW_RUNAWAY_WARN_COOLDOWN))
-			var onmulti := GetStandingHeight( me.x, me.y, me.z, me.realm ).multi;
-			Print("[TamedAI runaway-watch] " + me.name + " (" + Hex(me.serial) + ", " + me.npctemplate + ") master=" + master.name + " Follow()calls/sec=" + followcalls + " pos=" + me.x + "," + me.y + " onmulti=" + onmulti + " guarding=" + guarding);
-			lastfollowwarn := followclock;
-		endif
-		followcalls := 0;
-		followwindowstart := followclock;
-	endif
-	followcalls := followcalls + 1;
 
 	// Hard floor on how often Follow() can run, independent of MainAILoop's
 	// waittime (which only has whole-second granularity via wait_for_event).

--- a/scripts/include/checkcity.inc
+++ b/scripts/include/checkcity.inc
@@ -1,62 +1,99 @@
 use os;
 use uo;
+use cfgfile;
+
+///////////////////////////////////////////////////////////////////////////////
+// Shared regions.cfg Type= scanning, used by CheckCity() below and reused by
+// pkg/std/housing/housedeed.src and pkg/opt/alryc/textcmd/test/housezoneaudit.src
+// for their own region-type checks (city/dungeon/shrine/graveyard/suburb/...).
+///////////////////////////////////////////////////////////////////////////////
+
+Function NormalizeRegionType(region_type)
+    case(Lower(CStr(region_type)))
+        "poi":
+            return "poi";
+        "city":
+            return "city";
+        "suburb":
+            return "suburb";
+        "shrine":
+            return "shrine";
+        "dungeon":
+            return "dungeon";
+        "graveyard":
+            return "graveyard";
+        "jail":
+            return "jail";
+        "none":
+            return "none";
+    endcase
+
+    return Lower(CStr(region_type));
+EndFunction
+
+// Returns struct{name, range:={x1,y1,x2,y2}} for the first regions.cfg region
+// of the given Type whose Range overlaps the given box (realm-scoped), or 0
+// if none match / regions.cfg can't be read (fail-open, same as callers'
+// prior behavior when the config was unavailable).
+Function IsBoxOverlappingRegionType(x1, y1, x2, y2, realm, region_type)
+    var regions_cfg := ReadConfigFile("::regions/regions");
+    if(!regions_cfg)
+        return 0;
+    endif
+
+    var wanted_region_type := NormalizeRegionType(region_type);
+    var keys := GetConfigStringKeys(regions_cfg);
+    if(!keys)
+        return 0;
+    endif
+
+    foreach key in keys
+        var region := FindConfigElem(regions_cfg, key);
+        if(!region)
+            continue;
+        endif
+
+        if(NormalizeRegionType(GetConfigString(region, "Type")) != wanted_region_type)
+            continue;
+        endif
+
+        var region_realm := Lower(CStr(GetConfigString(region, "Realm")));
+        if(region_realm and (region_realm != Lower(CStr(realm))))
+            continue;
+        endif
+
+        var range := SplitWords(CStr(GetConfigString(region, "Range")));
+        if(!range or range.size() < 4)
+            continue;
+        endif
+
+        var rx1 := CInt(range[1]);
+        var ry1 := CInt(range[2]);
+        var rx2 := CInt(range[3]);
+        var ry2 := CInt(range[4]);
+
+        if((x1 <= rx2) and (x2 >= rx1) and (y1 <= ry2) and (y2 >= ry1))
+            return struct{ name := key, range := {rx1, ry1, rx2, ry2} };
+        endif
+    endforeach
+
+    return 0;
+EndFunction
+
+// Point-in-region convenience wrapper - a zero-size box degenerates correctly
+// into a point-in-rect test.
+Function IsPointInRegionType(x, y, realm, region_type)
+    return IsBoxOverlappingRegionType(x, y, x, y, realm, region_type);
+EndFunction
+
+///////////////////////////////////////////////////////////////////////////////
+// CheckCity(item) - is this item/mobile standing in a Type=City region?
+///////////////////////////////////////////////////////////////////////////////
 
 Function CheckCity(item)
+    if(IsPointInRegionType(item.x, item.y, item.realm, "city"))
+        return 1;
+    endif
 
-  If ( item.x>=1244 and item.y>=1530 and item.x <= 1704 and item.y <= 1758)
-      Return 1; // Britain
-    
-    Elseif ( item.x>=4379 and item.y>=1045 and item.x <= 4487 and item.y <= 1178)
-      Return 1; // Moonglow
-
-    Elseif ( item.x>=5638 and item.y>=3083 and item.x<=5799 and item.y<=3328)
-      Return 1; // Papua
-    Elseif ( item.x>=5799 and item.y>=3121 and item.x<=5822 and item.y<=3327)
-      Return 1; // Papua
-    Elseif ( item.x>=5137 and item.y>=3948 and item.x<=5196 and item.y<=4082)
-      Return 1; // Delucia
-    Elseif ( item.x>=5196 and item.y>=3923 and item.x<=5322 and item.y<=4085)
-      Return 1; // Delucia
-
-    Elseif ( item.x>=1294 and item.y>=3664 and item.x <= 1506 and item.y <= 3886)
-      Return 1; // Jhelom
-      
-    Elseif ( item.x>=494 and item.y>=926 and item.x <= 600 and item.y <= 1034)
-      Return 1; // Yew
-      
-    Elseif ( item.x>=590 and item.y>=796 and item.x <= 670 and item.y <= 886)
-      Return 1; // Empath Abbey
-      
-    Elseif ( item.x>=2394 and item.y>=370 and item.x <= 2624 and item.y <= 632)
-      Return 1; // Minoc
-
-    Elseif ( item.x>=1794 and item.y>=2638 and item.x <= 2136 and item.y <= 2902)
-      Return 1; // Trinsic
-
-    Elseif ( item.x>=538 and item.y>=2106 and item.x <= 686 and item.y <= 2274)
-      Return 1; // Skara Brae
-
-    Elseif ( item.x>=3646 and item.y>=2040 and item.x <= 3814 and item.y <= 2280)
-      Return 1; // Magincia
-
-    Elseif ( item.x>=3588 and item.y>=2446 and item.x <= 3762 and item.y <= 2690)
-      Return 1; // Occlo
-
-    Elseif ( item.x>=2612 and item.y>=2082 and item.x <= 2772 and item.y <= 2256)
-      Return 1; // Buccaneers Den
-
-    Elseif ( item.x>=3496 and item.y>=1062 and item.x <= 3808 and item.y <= 1400)
-      Return 1; // Nujelm
-
-    Elseif ( item.x>=2794 and item.y>=634 and item.x <= 3026 and item.y <= 1000)
-      Return 1; // Vesper
-
-    Elseif ( item.x>=2206 and item.y>=1116 and item.x <= 2290 and item.y <= 1236)
-      Return 1; // Cove
-
-    Elseif ( item.x>=5120 and item.y>=0 and item.x <= 5374 and item.y <= 254)
-      Return 1; // Wind
-Endif
-
-Return 0;
+    return 0;
 EndFunction

--- a/scripts/include/constants/cmdlevels.inc
+++ b/scripts/include/constants/cmdlevels.inc
@@ -2,13 +2,19 @@
 // CmdLevel.inc
 //
 // Contain the command level names
+//
+// Values must match this shard's actual ladder, defined by the CmdLevel
+// blocks in config/cmds.cfg and confirmed live against the promote/demote
+// tool at scripts/textcmd/test/makestaff.src (which labels level 5
+// "Developer" -- cmds.cfg itself names that same directory "Test"). There
+// is no separate "Shard Mom" tier and no level 6 on this shard -- only 6
+// levels total, numbered 0-5.
 /////////////////////////////////////////////////////////////////////
 
 
 const CMDLEVEL_PLAYER		:= 0;
 const CMDLEVEL_COUNSELOR	:= 1;
-const CMDLEVEL_SHARD_MOM	:= 2;
-const CMDLEVEL_SEER		:= 3;
-const CMDLEVEL_GAME_MASTER	:= 4;
-const CMDLEVEL_ADMINISTRATOR	:= 5;
-const CMDLEVEL_DEVELOPER	:= 6;
+const CMDLEVEL_SEER		:= 2;
+const CMDLEVEL_GAME_MASTER	:= 3;
+const CMDLEVEL_ADMINISTRATOR	:= 4;
+const CMDLEVEL_DEVELOPER	:= 5; // aka "Test" (config/cmds.cfg directory name)

--- a/scripts/textcmd/admin/backfillteleporterserials.src
+++ b/scripts/textcmd/admin/backfillteleporterserials.src
@@ -1,0 +1,100 @@
+// Synopsis: One-time migration - backfill each house's TeleporterSerials list
+/////////////////////////////////////////////////////////////////////////////
+//
+//  ".backfillteleporterserials" - scans every realm for house teleporter
+//  items (ObjType 0xA3CE) and, for each one whose owning house (via its
+//  "teleportserial" cprop) still exists, adds it to that house's
+//  "TeleporterSerials" cprop if it isn't already tracked there.
+//
+//  This is a one-time migration for teleporters placed before house-side
+//  serial tracking existed. It matches by property value across the whole
+//  world instead of a spatial/proximity search, so it correctly finds both
+//  halves of a pair even if they're nowhere near each other - unlike the
+//  house.items-based checks this shard used to rely on.
+//
+//  Teleporters whose "teleportserial" points at a house that no longer
+//  exists are left untouched and only reported - that's a separate cleanup
+//  pass, not this one. Safe to run more than once.
+//
+/////////////////////////////////////////////////////////////////////////////
+
+use uo;
+use os;
+use polsys;
+
+include ":housing:utility";
+
+function GetRealmNameForMigration(mapid)
+	if (mapid == 0)
+		return "britannia";
+	elseif (mapid == 1)
+		return "britannia_alt";
+	elseif (mapid == 2)
+		return "ilshenar";
+	elseif (mapid == 3)
+		return "malas";
+	elseif (mapid == 4)
+		return "tokuno";
+	endif
+
+	return 0;
+endfunction
+
+program backfillteleporterserials( who )
+
+	SendSysMessage(who, "Scanning all realms for house teleporters, please wait...");
+
+	var housesupdated := {};
+	var teletotal := 0;
+	var orphantotal := 0;
+
+	var realmslist := Realms();
+	foreach realm in (realmslist)
+		var realm_name := GetRealmNameForMigration(CInt(realm.mapid));
+		if (!realm_name)
+			continue;
+		endif
+		var realm_width := CInt(realm.width) - 1;
+		var realm_height := CInt(realm.height) - 1;
+
+		var found := ListItemsInBoxOfObjType(0xA3CE, 0, 0, -128, realm_width, realm_height, 127, realm_name);
+		if (!found or !found.size())
+			continue;
+		endif
+
+		foreach tele in (found)
+			teletotal := teletotal + 1;
+
+			var houseserial := GetObjProperty(tele, "teleportserial");
+			if (!houseserial)
+				continue;
+			endif
+
+			var house := SystemFindObjectBySerial(CInt(houseserial));
+			if (!house)
+				orphantotal := orphantotal + 1;
+				continue;
+			endif
+
+			var teleserials := GetObjProperty(house, "TeleporterSerials");
+			if (!teleserials)
+				teleserials := {};
+			endif
+
+			if (!(CInt(tele.serial) in teleserials))
+				teleserials.append(CInt(tele.serial));
+				SetObjProperty(house, "TeleporterSerials", teleserials);
+				if (!(CInt(house.serial) in housesupdated))
+					housesupdated.append(CInt(house.serial));
+				endif
+			endif
+		endforeach
+	endforeach
+
+	SendSysMessage(who, "Done. "+teletotal+" teleporter item(s) scanned across all realms.");
+	SendSysMessage(who, CStr(housesupdated.size())+" house(s) had their TeleporterSerials list backfilled.");
+	if (orphantotal > 0)
+		SendSysMessage(who, CStr(orphantotal)+" teleporter(s) reference a house that no longer exists - left untouched for a separate cleanup pass.");
+	endif
+
+endprogram

--- a/scripts/textcmd/admin/destroymulti.src
+++ b/scripts/textcmd/admin/destroymulti.src
@@ -1,11 +1,17 @@
 // Synopsis: Destroy the multi (house or boat) at or under your position
 use uo;
 
+include ":housing:utility";
+
 program destroy_multi( who )
 	if(!who.multi)
 		var targ := Targetcoordinates( who ).multi;
+		if (targ)
+			CleanupHouseTeleporters(targ);
+		endif
 		DestroyMulti(targ);
 	else
+		CleanupHouseTeleporters(who.multi);
 		DestroyMulti( who.multi );
 	endif
 endprogram

--- a/scripts/textcmd/coun/go.src
+++ b/scripts/textcmd/coun/go.src
@@ -185,14 +185,15 @@ function SelectDestinationGump( who, locs )
   return GFSendGump(who, gump);
 endfunction
 
-// Groups locs by type in priority order (Jail/City/Shrine/Graveyard/Dungeon/
-// POI/None), then appends anything with a custom/unrecognized RegionType
-// label last - same output as before, but a single O(n) pass instead of the
-// old 8-pass approach that re-scanned the growing "ordered" list for every
-// entry (O(n^2)*8). With ~200 go-locations just for Britannia, that old
-// version was heavy enough to occasionally trip the runaway-script watchdog.
+// Groups locs by type in priority order (Jail/City/Suburb/Shrine/Graveyard/
+// Dungeon/POI/None), then appends anything with a custom/unrecognized
+// RegionType label last - same output as before, but a single O(n) pass
+// instead of the old 8-pass approach that re-scanned the growing "ordered"
+// list for every entry (O(n^2)*8). With ~200 go-locations just for
+// Britannia, that old version was heavy enough to occasionally trip the
+// runaway-script watchdog.
 function ReorderLocationsForDisplay( locs )
-  var type_priority := {"Jail", "City", "Shrine", "Graveyard", "Dungeon", "POI", "None"};
+  var type_priority := {"Jail", "City", "Suburb", "Shrine", "Graveyard", "Dungeon", "POI", "None"};
   var known_types := dictionary;
   foreach wanted_type in type_priority
     known_types.Insert(wanted_type, 1);
@@ -418,6 +419,8 @@ function NormalizeRegionType( region_type )
       return "POI";
     "city":
       return "City";
+    "suburb":
+      return "Suburb";
     "shrine":
       return "Shrine";
     "dungeon":

--- a/scripts/textcmd/player/houseescrow.src
+++ b/scripts/textcmd/player/houseescrow.src
@@ -1,0 +1,405 @@
+// Synopsis: Claim house-demolish escrow packages
+// Command: .houseescrow
+
+use uo;
+use storage;
+use datafile;
+use polsys;
+
+include "include/objtype";
+include "include/myutil";
+include "util/bank";
+include ":housing:houseescrow";
+
+function HasHouseKey(byref keys, target_key)
+	foreach k in keys
+		if(CInt(k) == CInt(target_key))
+			return 1;
+		endif
+	endforeach
+	return 0;
+endfunction
+
+function ListHouseEscrowKeys(owner_serial)
+	var keys := {};
+	var df_name := BuildHouseEscrowDatafileNameForSerial(owner_serial);
+	Print("[houseescrow][debug] ListHouseEscrowKeys: owner_serial=" + owner_serial + " -> df_name=" + df_name);
+	if(!df_name)
+		Print("[houseescrow][debug] ListHouseEscrowKeys: ABORTED -- BuildHouseEscrowDatafileNameForSerial returned empty for owner=" + owner_serial);
+		return keys;
+	endif
+
+	var file := OpenDataFile(df_name);
+	if(!file)
+		HouseEscrowLog("ListHouseEscrowKeys: no datafile exists for owner=" + owner_serial + " (df=" + df_name + ") -- nothing has ever been indexed under this serial");
+		Print("[houseescrow][debug] ListHouseEscrowKeys: no datafile " + df_name + " exists at all -- nothing was ever indexed under owner=" + owner_serial);
+		return keys;
+	endif
+
+	foreach house_key in (file.Keys())
+		if(!house_key)
+			continue;
+		endif
+
+		var house_serial := CInt(house_key);
+		if(!house_serial)
+			continue;
+		endif
+
+		if(!HasHouseKey(keys, house_serial))
+			keys.append(house_serial);
+		endif
+	endforeach
+
+	UnloadDataFile(df_name);
+	HouseEscrowLog("ListHouseEscrowKeys: owner=" + owner_serial + " (df=" + df_name + ") house_keys_found=" + len(keys));
+	Print("[houseescrow][debug] ListHouseEscrowKeys: owner=" + owner_serial + " (df=" + df_name + ") house_keys_found=" + len(keys));
+	return keys;
+endfunction
+
+function LoadHouseEscrowEntriesForKey(owner_serial, house_serial)
+	var entries := {};
+	var df_name := BuildHouseEscrowDatafileNameForSerial(owner_serial);
+	if(!df_name)
+		return entries;
+	endif
+
+	var file := OpenDataFile(df_name);
+	if(!file)
+		return entries;
+	endif
+
+	var house_key := CStr(house_serial);
+	var house_elem := file.FindElement(house_key);
+	if(house_elem)
+		entries := DecodeHouseEscrowEntries(house_elem.GetProp("entries"));
+	endif
+
+	UnloadDataFile(df_name);
+	return entries;
+endfunction
+
+function LoadAllHouseEscrowEntries(owner_serial)
+	var all_entries := {};
+	var house_keys := ListHouseEscrowKeys(owner_serial);
+	foreach house_key in house_keys
+		var entries := LoadHouseEscrowEntriesForKey(owner_serial, house_key);
+		foreach entry in entries
+			all_entries.append(entry);
+		endforeach
+	endforeach
+	return all_entries;
+endfunction
+
+program textcmd_houseescrow(who, text)
+	Print("[houseescrow][debug] textcmd_houseescrow: called by " + who.name + "(" + who.serial + ") text='" + text + "' cmdlevel=" + who.cmdlevel);
+	if(text and who.cmdlevel >= 4)
+		var target_serial := CInt(text);
+		if(!target_serial)
+			SendSysMessage(who, "Usage (staff): .houseescrow <owner serial>");
+			return;
+		endif
+		Print("[houseescrow][debug] textcmd_houseescrow: staff override, querying owner_serial=" + target_serial);
+		ShowHouseEscrowGump(who, target_serial, 1, 1);
+		return;
+	endif
+	Print("[houseescrow][debug] textcmd_houseescrow: self-claim, querying owner_serial=" + who.serial + " (" + who.name + ")");
+
+	ShowHouseEscrowGump(who, who.serial, 1, 0);
+endprogram
+
+function ShowHouseEscrowGump(who, owner_serial, page, staff_mode)
+	var all_entries := LoadAllHouseEscrowEntries(owner_serial);
+	HouseEscrowLog("ShowHouseEscrowGump: queried by=" + who.serial + "(" + who.name + ") owner_serial=" + owner_serial + " staff_mode=" + staff_mode + " found_entries=" + len(all_entries));
+
+	if(!len(all_entries))
+		if(staff_mode)
+			SendSysMessage(who, "No house-escrow packages found for serial " + owner_serial + ".");
+		else
+			SendSysMessage(who, "You have no house-escrow packages.");
+		endif
+		return;
+	endif
+
+	const ENTRIES_PER_PAGE := 5;
+	var max_pages := CInt((len(all_entries) + ENTRIES_PER_PAGE - 1) / ENTRIES_PER_PAGE);
+	if(page < 1)
+		page := 1;
+	endif
+	if(page > max_pages)
+		page := max_pages;
+	endif
+
+	var start_idx := (page - 1) * ENTRIES_PER_PAGE + 1;
+	var end_idx := start_idx + ENTRIES_PER_PAGE - 1;
+	if(end_idx > len(all_entries))
+		end_idx := len(all_entries);
+	endif
+
+	var title := staff_mode ? ("House Escrow (staff view, owner serial " + owner_serial + ")") : "House Demolish Escrow";
+	var subtitle := staff_mode ? "Select an entry to reassign to a new owner:" : "Select where to claim each package:";
+
+	var layout := { "page 0", "resizepic 20 20 2620 750 520", "text 30 40 53 0", "text 30 62 53 1", "text 475 40 63 2" };
+	var data := { title, subtitle, "Page " + page + " of " + max_pages };
+
+	if(page > 1)
+		layout.append("button 440 470 5537 5538 1 0 9001");
+		data.append("Prev");
+		layout.append("text 462 468 53 " + (len(data)-1));
+	endif
+
+	if(page < max_pages)
+		layout.append("button 520 470 5540 5541 1 0 9002");
+		data.append("Next");
+		layout.append("text 542 468 53 " + (len(data)-1));
+	endif
+
+	// Button IDs encode a page-relative row number (1..ENTRIES_PER_PAGE), not
+	// the absolute entry index -- an owner with 1000+ escrow entries would
+	// otherwise push an absolute-index-based id into a different button's
+	// range (e.g. idx=1001 colliding with idx=1's bank-button id) and claim
+	// or reassign the wrong entry. The absolute index is reconstructed from
+	// start_idx (still in scope) after SendDialogGump returns.
+	var row_y := 92;
+	for idx := start_idx to end_idx
+		var row_num := idx - start_idx + 1;
+
+		var house_row_label := "House: " + HouseEntryLabel(all_entries[idx]) + " (Serial: " + all_entries[idx][HOUSE_ENTRY_HOUSESERIAL_IDX] + ")";
+		data.append(house_row_label);
+		layout.append("text 30 " + row_y + " 53 " + (len(data)-1));
+		row_y := row_y + 22;
+
+		var owner_row_label := "Owner: " + HouseEntryOwnerName(all_entries[idx]) + " (Serial: " + all_entries[idx][HOUSE_ENTRY_OWNERSERIAL_IDX] + ")";
+		data.append(owner_row_label);
+		layout.append("text 30 " + row_y + " 53 " + (len(data)-1));
+		row_y := row_y + 28;
+
+		if(staff_mode)
+			layout.append("button 150 " + row_y + " 4005 4007 1 0 " + (3000 + row_num));
+			data.append("Reassign to targeted character");
+			layout.append("text 182 " + row_y + " 53 " + (len(data)-1));
+		else
+			layout.append("button 150 " + row_y + " 4005 4007 1 0 " + (2000 + row_num));
+			data.append("To Bank");
+			layout.append("text 182 " + row_y + " 53 " + (len(data)-1));
+
+			layout.append("button 280 " + row_y + " 4005 4007 1 0 " + (1000 + row_num));
+			data.append("To Backpack");
+			layout.append("text 312 " + row_y + " 53 " + (len(data)-1));
+		endif
+
+		row_y := row_y + 28;
+	endfor
+
+	var result := SendDialogGump(who, layout, data);
+	if(!result or !result[0])
+		return;
+	endif
+
+	var btn := CInt(result[0]);
+	if(btn == 9001)
+		ShowHouseEscrowGump(who, owner_serial, page - 1, staff_mode);
+		return;
+	endif
+
+	if(btn == 9002)
+		ShowHouseEscrowGump(who, owner_serial, page + 1, staff_mode);
+		return;
+	endif
+
+	if(staff_mode and btn >= 3000 and btn <= 3999)
+		var reassign_row := btn - 3000;
+		var reassign_idx := start_idx + reassign_row - 1;
+		if(reassign_row >= 1 and reassign_row <= ENTRIES_PER_PAGE and reassign_idx >= 1 and reassign_idx <= len(all_entries))
+			ReassignHouseEscrowEntry(who, owner_serial, all_entries[reassign_idx]);
+			ShowHouseEscrowGump(who, owner_serial, page, staff_mode);
+		endif
+		return;
+	endif
+
+	if(!staff_mode and ((btn >= 1000 and btn <= 1999) or (btn >= 2000 and btn <= 2999)))
+		var to_bank := (btn >= 2000) ? 1 : 0;
+		var claim_row := (btn >= 2000) ? (btn - 2000) : (btn - 1000);
+		var entry_idx := start_idx + claim_row - 1;
+		if(claim_row >= 1 and claim_row <= ENTRIES_PER_PAGE and entry_idx >= 1 and entry_idx <= len(all_entries))
+			ClaimHouseEscrowEntry(who, all_entries[entry_idx], to_bank);
+			ShowHouseEscrowGump(who, owner_serial, page, staff_mode);
+		endif
+	endif
+endfunction
+
+function DestroyHouseEscrowContainerAndContents(byref container)
+	if(!container)
+		return;
+	endif
+
+	var items_to_destroy := {};
+	foreach item in EnumerateItemsInContainer(container)
+		if(item.container == container)
+			items_to_destroy.append(item);
+		endif
+	endforeach
+
+	foreach item in items_to_destroy
+		DestroyItem(item);
+		item := 0;
+	endforeach
+	items_to_destroy := 0;
+
+	DestroyItem(container);
+	container := 0;
+endfunction
+
+function ClaimHouseEscrowEntry(who, entry, to_bank)
+	var area := FindStorageArea(HOUSE_ESCROW_STORAGE_NAME);
+	if(!area)
+		SendSysMessage(who, "House escrow storage is unavailable.");
+		return;
+	endif
+
+	var entry_id := HouseEntryId(entry);
+	var entry_escrow_name := HouseEntryEscrowName(entry);
+
+	var escrow_root := FindRootItemInStorageArea(area, entry_escrow_name);
+	if(!escrow_root)
+		SendSysMessage(who, "That escrow package was not found.");
+		RemoveHouseEscrowEntryById(who.serial, entry_id);
+		return;
+	endif
+
+	var dest;
+	if(to_bank)
+		dest := FindBankBox(who);
+		if(!dest)
+			SendSysMessage(who, "Your bank box is unavailable.");
+			return;
+		endif
+	else
+		dest := who.backpack;
+		if(!dest)
+			SendSysMessage(who, "You have no backpack to receive escrow items.");
+			return;
+		endif
+	endif
+
+	// Snapshot the root's direct children before moving any of them, rather
+	// than moving items while live-iterating the container's own enumerator.
+	var moved := 0;
+	var root_items := ListRootItemsInContainer(escrow_root);
+	foreach item in root_items
+		if(MoveItemToContainer(item, dest))
+			moved := moved + 1;
+		else
+			if(to_bank)
+				SendSysMessage(who, "Bank is full or over limits. Remaining items stayed in escrow.");
+			else
+				SendSysMessage(who, "Backpack is full or overweight. Remaining items stayed in escrow.");
+			endif
+			break;
+		endif
+	endforeach
+
+	var remaining_root_items := 0;
+	foreach rem in EnumerateItemsInContainer(escrow_root)
+		if(rem.container == escrow_root)
+			remaining_root_items := remaining_root_items + 1;
+		endif
+	endforeach
+
+	if(!remaining_root_items)
+		DestroyHouseEscrowContainerAndContents(escrow_root);
+		escrow_root := 0;
+		DestroyRootItemInStorageArea(area, entry_escrow_name);
+		RemoveHouseEscrowEntryById(who.serial, entry_id);
+		HouseEscrowLog("ClaimHouseEscrowEntry: claimant=" + who.serial + " fully claimed and pruned entry_id=" + entry_id + " moved=" + moved);
+		SendSysMessage(who, "Escrow package claimed.");
+	elseif(moved)
+		HouseEscrowLog("ClaimHouseEscrowEntry: claimant=" + who.serial + " partially claimed entry_id=" + entry_id + " moved=" + moved + " remaining=" + remaining_root_items);
+		SendSysMessage(who, "Partial claim completed; remaining items are still in escrow.");
+		escrow_root := 0;
+	else
+		HouseEscrowLog("ClaimHouseEscrowEntry: claimant=" + who.serial + " could not move any items for entry_id=" + entry_id);
+		SendSysMessage(who, "No items could be moved from escrow.");
+		escrow_root := 0;
+	endif
+endfunction
+
+function RemoveHouseEscrowEntryById(owner_serial, entry_id)
+	var df_name := BuildHouseEscrowDatafileNameForSerial(owner_serial);
+	if(!df_name)
+		return;
+	endif
+
+	var file := OpenDataFile(df_name);
+	if(!file)
+		return;
+	endif
+
+	var found := 0;
+	foreach house_key in (file.Keys())
+		var house_elem := file.FindElement(house_key);
+		if(house_elem)
+			var entries := DecodeHouseEscrowEntries(house_elem.GetProp("entries"));
+			var new_entries := {};
+			foreach entry in entries
+				if(HouseEntryId(entry) == entry_id)
+					found := 1;
+				else
+					new_entries.append(entry);
+				endif
+			endforeach
+
+			if(found)
+				if(len(new_entries) > 0)
+					house_elem.SetProp("entries", EncodeHouseEscrowEntries(new_entries));
+				else
+					file.DeleteElement(house_key);
+				endif
+				break;
+			endif
+		endif
+	endforeach
+
+	UnloadDataFile(df_name);
+	if(found)
+		HouseEscrowLog("RemoveHouseEscrowEntryById: owner=" + owner_serial + " removed entry_id=" + entry_id + " from df=" + df_name);
+	endif
+endfunction
+
+// Staff-only: re-key an orphaned (or otherwise misfiled) house escrow entry
+// to a living, targeted character -- same shape as the precedented merchant
+// escrow re-keying in pkg/systems/playervendor/commands/test/pmtakeover.src.
+function ReassignHouseEscrowEntry(who, old_owner_serial, entry)
+	SendSysMessage(who, "Target the character to reassign this house escrow to.");
+	var reassign_target := Target(who);
+	if(!reassign_target or !reassign_target.isa(POLCLASS_MOBILE))
+		SendSysMessage(who, "Invalid target. Cancelled.");
+		return;
+	endif
+
+	var entry_id := HouseEntryId(entry);
+	var entry_escrow_name := HouseEntryEscrowName(entry);
+	var house_serial := HouseEntryHouseSerial(entry);
+	var house_label := HouseEntryLabel(entry);
+
+	var area := FindStorageArea(HOUSE_ESCROW_STORAGE_NAME);
+	if(!area)
+		SendSysMessage(who, "House escrow storage is unavailable.");
+		return;
+	endif
+
+	var escrow_root := FindRootItemInStorageArea(area, entry_escrow_name);
+	if(!escrow_root)
+		SendSysMessage(who, "That escrow package was not found.");
+		RemoveHouseEscrowEntryById(old_owner_serial, entry_id);
+		return;
+	endif
+
+	SetObjProperty(escrow_root, "ownerserial", CInt(reassign_target.serial));
+
+	RemoveHouseEscrowEntryById(old_owner_serial, entry_id);
+	AppendHouseEscrowIndex(reassign_target.serial, house_serial, entry_escrow_name, house_label, reassign_target.name);
+
+	HouseEscrowLog("ReassignHouseEscrowEntry: staff=" + who.serial + " reassigned entry_id=" + entry_id + " (house=" + house_serial + ") from owner=" + old_owner_serial + " to owner=" + reassign_target.serial + " (" + reassign_target.name + ")");
+	SendSysMessage(who, "Reassigned to " + reassign_target.name + ". They can now claim it with .houseescrow.");
+endfunction

--- a/scripts/textcmd/seer/findboat.src
+++ b/scripts/textcmd/seer/findboat.src
@@ -7,8 +7,6 @@
 use uo;
 use os;
 
- include "include/account";
-
 program textcmd_WhereBoat( mobile )
    
 	SendSysMessage( mobile, "Select a player." );

--- a/scripts/textcmd/test/editcharacter.src
+++ b/scripts/textcmd/test/editcharacter.src
@@ -78,7 +78,7 @@ program editcharacter( who )
 		graphic := GenderToGraphic( gender );
 	endif
 
-	var color := ClampInt( CInt( GFExtractData(result, ENTRY_COLOR) ), 0, 10000 );
+	var color := ClampInt( CInt( GFExtractData(result, ENTRY_COLOR) ), 0, 65535 );
 	var strength := ClampInt( CInt( GFExtractData(result, ENTRY_STR) ), 10, 300 );
 	var dexterity := ClampInt( CInt( GFExtractData(result, ENTRY_DEX) ), 10, 300 );
 	var intelligence := ClampInt( CInt( GFExtractData(result, ENTRY_INT) ), 10, 300 );


### PR DESCRIPTION
# Developer Changelog - v1.1.1
**Range:** `f52370c` (origin/Patch-1.1.0) -> `7107d6d` (HEAD)  
**Branch:** Patch-1.1.1  
**Date:** 2026-08-07 -> 2026-08-08  
**Commits in range:** 2 (excluding the boundary merge commit, which carries no new 1.1.1 content)  
**Files changed (committed):** 48 (+3201 / -567)

---

## Table of Contents

1. [Scope Summary](#1-scope-summary)
2. [Commit Timeline](#2-commit-timeline)
3. [Stability - DataFile Handle Leak Fixes (Email + Area Policy)](#3-stability---datafile-handle-leak-fixes-email--area-policy)
4. [New Staff Tools - Load/Stress-Testing and Leak Diagnostics](#4-new-staff-tools---loadstress-testing-and-leak-diagnostics)
5. [CheckCity() Rewrite - Realm-Scoped, regions.cfg-Driven City Detection](#5-checkcity-rewrite---realm-scoped-regionscfg-driven-city-detection)
6. [New "Suburb" Region Type - Farmland/Outbuilding Reclassification](#6-new-suburb-region-type---farmlandoutbuilding-reclassification)
7. [House Placement - MultiID Resolution Fix and Region-Check Refactor](#7-house-placement---multiid-resolution-fix-and-region-check-refactor)
8. [House Placement - Per-Account House Limit (New, Cap 5)](#8-house-placement---per-account-house-limit-new-cap-5)
9. [NPC AI - Sleep-Mode Timing and Wake-Radius Tuning](#9-npc-ai---sleep-mode-timing-and-wake-radius-tuning)
10. [New House Escrow System - Staff Demolish-and-Escrow, Player Claim Command](#10-new-house-escrow-system---staff-demolish-and-escrow-player-claim-command)
11. [Player-Vendor Escrow - Shared Module Refactor and Orphaned-Merchant Fixes](#11-player-vendor-escrow---shared-module-refactor-and-orphaned-merchant-fixes)
12. [New Admin Command - Teleporter Serial Backfill Migration](#12-new-admin-command---teleporter-serial-backfill-migration)
13. [Tamed Pets - Follow() Runaway-Watch Diagnostics Removed](#13-tamed-pets---follow-runaway-watch-diagnostics-removed)
14. [CmdLevel Constants - Renumbered to Match the Actual Ladder](#14-cmdlevel-constants---renumbered-to-match-the-actual-ladder)
15. [Misc Small Fixes](#15-misc-small-fixes)
16. [Exhaustive File-by-File Change List](#16-exhaustive-file-by-file-change-list)
17. [Risk and Regression Notes](#17-risk-and-regression-notes)

---

## 1. Scope Summary

Patch 1.1.1 is a large patch built from two commits. `6817955` ("Bunch of fixes to try and stop the shard crashing", 2026-08-07) is a stability pass: it plugs a class of DataFile handle leaks across the email and area-policy systems, adds five new staff-only load/stress-testing and leak-diagnostic tools, rewrites `CheckCity()` to be realm-scoped and driven by `regions.cfg` instead of a hardcoded, incomplete box list, splits farmland/outbuilding regions into a new "Suburb" type so they stop being treated as city, fixes a `GetMultiDimensions()` misuse in house placement that could let houses go undetected inside city/dungeon/shrine/graveyard regions, adds a new per-account house limit (5), and retunes NPC sleep-mode timing. `7107d6d` ("Patch 1.1.1 housing and teleporters fix / housing escrow / taming animals follow speeds", 2026-08-08) is a feature commit: it adds an entirely new staff "Demolish and Escrow" house teardown plus a player-facing `.houseescrow` claim command, refactors the pre-existing player-vendor escrow system into a shared module (fixing two paths that could orphan a merchant's inventory), rewrites house teleporter tracking to use an explicit serial list instead of an unreliable `house.items`-membership check, adds a one-time admin migration command to backfill that new teleporter list for already-placed houses, removes the 1.1.0-era `Follow()` runaway-diagnostic instrumentation (the underlying rate cap itself is untouched), and renumbers the `CMDLEVEL_*` named constants to match this shard's actual 6-level ladder (a phantom "Shard Mom" level and an off-by-one had existed in the constants file, though not in the engine-assigned levels themselves).

---

## 2. Commit Timeline

| Hash | Date | Message |
|---|---|---|
| `f52370c` | 2026-08-07 | Merge pull request #316 from Andries1985/Patch-1.1.0 (boundary - no new 1.1.1 content) |
| `6817955` | 2026-08-07 | Bunch of fixes to try and stop the shard crashing |
| `7107d6d` | 2026-08-08 | Patch 1.1.1 housing and teleporters fix / housing escrow / taming animals follow speeds |

---

## 3. Stability - DataFile Handle Leak Fixes (Email + Area Policy)

### Files Changed

| File | Change |
|---|---|
| `pkg/systems/email/chardelete.src` | `OnDelete()` - `UnloadDataFile()` on every exit path |
| `pkg/systems/email/commands/gm/inspectmail.src` | `ReadMail()` - `UnloadDataFile()` before all 5 return points |
| `pkg/systems/email/email.src` | `GetMail()` - `UnloadDataFile()` before both return points |
| `pkg/systems/email/logon.src` | `Logon()` - `UnloadDataFile()` before both return points |
| `pkg/systems/email/reconnect.src` | `Reconnect()` - same pattern as `logon.src` |
| `pkg/systems/email/webmail/webmail.src` | `GetInbox()` - `UnloadDataFile()` before final return |
| `pkg/opt/sysbook/start.src` | adds `UnloadDataFile("staticbooks")` at the end |
| `pkg/opt/areas/include/areapolicy.inc` | `GetPolicyMask()`, `SetPolicyMask()`, `PruneStaleRealmPolicies()` - `UnloadDataFile()` added on every exit path |

### Overview

Every function above opened a DataFile handle (`"Emails"`, `"AddressBooks"`, `"BlockLists"`, `"staticbooks"`, or a realm's area-policy datafile) and returned without calling `UnloadDataFile()` on at least one exit path - almost always an early-return/error branch, since the "happy path" return in most of these already unloaded correctly. Each open handle that's never unloaded holds a live OS file handle for the life of the process. Given how frequently `logon.src`/`reconnect.src` run (every character login/reconnect) and how often area-policy lookups happen (per [[project-known-engine-constraints]]-adjacent AI/movement code calling into `ResolvePolicyAtLocation()`), this is a plausible contributor to gradual handle exhaustion and an eventual crash under sustained uptime - the stated motivation for this commit.

### Notable Functional Changes

- No behavioral/logic change on any success path - every fix is purely adding a missing `UnloadDataFile()` call before a `return` that previously skipped it.
- `areapolicy.inc`'s `SetPolicyMask()` and `PruneStaleRealmPolicies()` each had multiple distinct early-return branches (`DFFindElement` failure, `GetRealmAreaLines` failure, `keys` failure) that independently needed the fix, not just one.

### Expected Impact

No player-visible change. Reduces (and per the new `dfleaktest`/`emailstressworker`/`areastressworker` diagnostics in section 4, is intended to be verifiable as having reduced) open-handle growth over long uptime, which is one plausible contributor to the crashes this commit is titled after.

---

## 4. New Staff Tools - Load/Stress-Testing and Leak Diagnostics

### Files Changed

| File | Change |
|---|---|
| `pkg/opt/alryc/textcmd/test/dfleaktest.src` | New - `.dfleaktest` |
| `pkg/opt/alryc/textcmd/test/aimovementsim.src` | New - `.aimovementsim` |
| `pkg/opt/alryc/textcmd/test/shardstress.src` | New - `.shardstress` |
| `pkg/opt/alryc/stresstest/areastressworker.src` | New - spawned worker, not a direct command |
| `pkg/opt/alryc/stresstest/emailstressworker.src` | New - spawned worker, not a direct command |
| `pkg/opt/alryc/textcmd/test/housezoneaudit.src` | New - `.housezoneaudit` (see section 7) |
| `config/command_synopses.cfg` | Regenerated for `aimovementsim`, `dfleaktest`, `housezoneaudit`, `shardstress` |

### Overview

Five new Developer-only (CmdLevel 5) diagnostic tools, built specifically to reproduce and verify the fixes in this patch under sustained/concurrent load rather than a single serial test loop, since the live crash reports this patch responds to were plausibly load-dependent.

### Notable Functional Changes

- `dfleaktest`: runs 3000 iterations of open/lookup/unload against both the Britannia area-policy datafile and the `"Emails"` datafile (6000 total open/unload cycles), yielding every 100 iterations. Operator watches `pol.exe`'s Handles count in Task Manager before/after - flat count confirms the section 3 fix holds.
- `aimovementsim`: 20,000 calls to `ResolvePolicyAtLocation()` at random coordinates, batched 50 at a time with a 300ms pause between batches (~120s total), forcibly invalidating the policy-mask cache every 200 calls so it keeps hitting the real datafile-backed lookup instead of a warm cache.
- `shardstress`: spawns 20 `areastressworker` instances and 10 `emailstressworker` instances, each running for 15 minutes, to simulate sustained mixed player/AI load.
- `areastressworker` (spawned, not a command): loops for a given duration, invalidating the realm's policy-mask cache every 15 calls and calling `ResolvePolicyAtLocation()` at random coordinates - reproduces many concurrent instances independently warming/missing their own cache, closer to live conditions than one serial loop.
- `emailstressworker` (spawned, not a command): loops for a given duration doing open/lookup/unload cycles against the `"Emails"` datafile, simulating repeated login/reconnect churn.

### Expected Impact

Staff/developer-facing only. No player-visible change. Gives the team a repeatable way to load-test the area-policy cache and email-datafile paths and watch for handle growth going forward.

---

## 5. CheckCity() Rewrite - Realm-Scoped, regions.cfg-Driven City Detection

### Files Changed

| File | Change |
|---|---|
| `scripts/include/checkcity.inc` | `CheckCity()` rewritten; new shared helpers `NormalizeRegionType()`, `IsBoxOverlappingRegionType()`, `IsPointInRegionType()` |

### Overview

`CheckCity(item)` was previously a long `If/Elseif` chain of ~18 hardcoded x/y bounding boxes (Britain, Moonglow, Papua, Delucia, Jhelom, Yew, Empath Abbey, Minoc, Trinsic, Skara Brae, Magincia, Occlo, Buccaneers Den, Nujelm, Vesper, Cove, Wind) with no realm parameter at all, so it could false-positive across realms/facets sharing the same coordinates, and it never covered every city-type region actually defined in `regions.cfg` (Occlo Isle, for instance, matched nothing under the old hardcoded list, and was itself misclassified as `Type POI` rather than `Type City` in `regions.cfg` prior to section 6's fix).

### Notable Functional Changes

- `CheckCity(item)` is now a two-line wrapper around `IsPointInRegionType(item.x, item.y, item.realm, "city")`.
- New `IsBoxOverlappingRegionType(x1, y1, x2, y2, realm, region_type)`: reads `regions/regions.cfg`, filters by normalized region `Type` and (case-insensitively, only when the region specifies one) `Realm`, and returns the first region whose `Range` overlaps the given box, or `0` (fail-open, matching the old behavior when config was unavailable) if none match.
- New `IsPointInRegionType(x, y, realm, region_type)`: convenience wrapper calling the above with a degenerate zero-size box.
- New `NormalizeRegionType(region_type)`: lowercases/canonicalizes a region-type string against the known set `poi`, `city`, `suburb`, `dungeon`, `graveyard`, `jail`, `none` (adds `"suburb"`, see section 6).
- These three helpers are shared with `pkg/std/housing/housedeed.src` (section 7) and the new `pkg/opt/alryc/textcmd/test/housezoneaudit.src` (section 7), replacing three independent, duplicated implementations of essentially the same regions.cfg scan.

### Expected Impact

`CheckCity()` is now realm-scoped and matches every `Type=City` region actually defined in `regions.cfg`, not a hardcoded and incomplete subset. Every downstream consumer of `CheckCity()` (`pkg/std/fishing/fishingnet.src` - nets restricted outside cities; `pkg/opt/botanik/maketree.src` - trees blocked in cities; `pkg/std/alchemy/exploder.src` and `pkg/opt/GMItems/cains_exploder.src` - exploding-potion power reduced in cities; `scripts/control/spawnbookcase.src` - bookcase decay only in cities; `scripts/control/lockchests.src` and `pkg/std/provocation/provocation.src`'s `CheckCity()` calls are dead/commented-out code, unaffected) now evaluates against the corrected, realm-aware region data. Combined with section 6's reclassification, this changes which specific locations count as "city" for all of the above.

---

## 6. New "Suburb" Region Type - Farmland/Outbuilding Reclassification

### Files Changed

| File | Change |
|---|---|
| `regions/regions.cfg` | Occlo Isle `POI` -> `City`; 5 farmland/outbuilding region groups `City` -> `Suburb` |
| `pkg/opt/areas/areas.cfg` | Matching `cat=city` -> `cat=suburb` for the same 10 area entries |
| `config/golocs_by_id.cfg` | Matching `Type City` -> `Type Suburb` for the same GoLoc entries |
| `pkg/opt/areas/textcmd/admin/areas.src` | `CATEGORY_ORDER` gains `"suburb"` after `"city"` |
| `scripts/textcmd/coun/go.src` | `type_priority` gains `"Suburb"`; `NormalizeRegionType()` gains a `"suburb"` case |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | Same `type_priority`/normalize additions as `go.src` |

### Overview

`regions.cfg` reclassifies five previously `Type City` region groups - Yew Farmlands (4 ranges), Vesper Outbuildings (2 ranges), Minoc Farmlands (2 ranges), Britain Outer Farmlands, and Skara Brae Farmlands - to a new `Type Suburb`, and separately reclassifies Occlo Isle from `Type POI` to `Type City`. `pkg/opt/areas/areas.cfg` and `config/golocs_by_id.cfg` carry matching reclassifications for the same named areas/GoLocs. `areas.src`'s policy-resolution category order, and both `go.src`'s and `restartspawnpointarea.src`'s location-listing display order, are all updated to insert `"Suburb"`/`"suburb"` immediately after `"City"`/`"city"` so the new type sorts and resolves consistently with the others.

### Notable Functional Changes

- `areas.src`'s `CATEGORY_ORDER` ordering is load-bearing: `ResolveAreaKeyAtLocation()`/`ResolveAreaMatchAtLocation()` in `areapolicy.inc` walk this list in order and the first bounding-box match wins, so this insertion changes which policy applies at any coordinates where a city and a suburb region overlap.
- `go.src` and `restartspawnpointarea.src` each gain a `"Suburb"` display case in their respective location-normalization functions so suburb regions show a proper label instead of falling through to a generic/blank one.

### Expected Impact

Farmland and outbuilding zones around Yew, Vesper, Minoc, Britain, and Skara Brae are no longer treated as "city" by anything gated on `CheckCity()` or the `city` area category (section 5) - e.g. fishing nets, tree planting, exploding-potion power, and bookcase decay now behave as if those zones are wilderness, not town. Occlo Isle is now correctly recognized as a city region everywhere it wasn't before. The new "Suburb" type also now appears as its own category in `.go` location listings and the spawnpoint-area restart tool's location listings.

---

## 7. House Placement - MultiID Resolution Fix and Region-Check Refactor

### Files Changed

| File | Change |
|---|---|
| `pkg/std/housing/housedeed.src` | `GetHouseFootprintBounds()`, new `ResolveHouseMultiId()`, `IsHousePlacementBlockedByRegionType()` refactored, debug logging added |
| `pkg/opt/alryc/textcmd/test/housezoneaudit.src` | New - `.housezoneaudit` |
| `pkg/opt/townstones/textcmd/admin/createtownstone.src` | `GetRegionRange()` - `GetConfigStringArray` -> `SplitWords(CStr(GetConfigString(...)))` |
| `pkg/opt/townstones/textcmd/admin/townbankstatus.src` | Same one-line change as above |

### Overview

`GetHouseFootprintBounds(housetype, x, y)` called `GetMultiDimensions(housetype)` directly using the house item's objtype. `GetMultiDimensions()` actually needs the raw multi ID, not the item objtype - `itemdesc.cfg` maps every `"House <objtype>"` block to a separate, much smaller `MultiID` (e.g. House `0xA3EF` -> MultiID `0x3F`), and while `CreateMultiAtLocation()`/`TargetMultiPlacement()` already translate this internally, `GetMultiDimensions()` did not. This means footprint-bounds-dependent region checks (`IsHousePlacementBlockedByRegionType`, i.e. the city/dungeon/shrine/graveyard placement guard) could silently receive wrong or failed dimensions for any house whose objtype differs from its raw multi ID, potentially letting a house be placed inside a restricted region undetected.

### Notable Functional Changes

- New `ResolveHouseMultiId(housetype)`: looks up `:housing:itemdesc.cfg`'s `"House <housetype>"` block and returns its `MultiID`, falling back to the unresolved `housetype` if no block/field is found (with debug logging on each fallback).
- `GetHouseFootprintBounds()` now calls `GetMultiDimensions(ResolveHouseMultiId(housetype))` instead of `GetMultiDimensions(housetype)` directly.
- `IsHousePlacementBlockedByRegionType()` no longer inlines its own `regions.cfg` scan - it now calls the shared `IsBoxOverlappingRegionType()` from `checkcity.inc` (section 5).
- `NormalizeRegionType()` moved out of this file entirely into `checkcity.inc`.
- Debug `Print()` logging (prefixed `[housedeed][debug]`/`[houselimit][debug]`) added at several points in `Buildhouse()` and `IsHousePlacementBlockedByRegionType()` - console-only, staff-visible.
- New `.housezoneaudit` command (Developer, CmdLevel 5): scans every realm for placed houses (`ListMultisInBox` + `POLCLASS_HOUSE` filter), recomputes each house's footprint using the same `ResolveHouseMultiId()`/`GetHouseFootprintBounds()` logic as `housedeed.src` (deliberately duplicated to mirror placement-time checks exactly), and reports any house whose footprint overlaps a city/dungeon/shrine/graveyard region - i.e. an audit for houses that were placed illegally before this fix, or that became illegal after a region redefinition. Also includes a one-shot diagnostic trace (`RunRegionDiagnostics()`) built around a specific reported case (towers inside a "Lost Lands" dungeon region).
- `createtownstone.src` and `townbankstatus.src`'s `GetRegionRange()` both switch from `GetConfigStringArray(elem, "Range")` to `SplitWords(CStr(GetConfigString(elem, "Range")))` for parsing the same `Range` config line - consistent with the parsing approach used in the new `checkcity.inc` helpers, though no comment in the diff states a concrete bug this fixes in these two files specifically.

### Expected Impact

House placement's city/dungeon/shrine/graveyard region guard now correctly evaluates footprint bounds for every house type, including the ones whose item objtype differs from their raw multi ID (previously silently broken for those types). `.housezoneaudit` gives staff a way to find and clean up any already-placed houses that slipped through before this fix.

---

## 8. House Placement - Per-Account House Limit (New, Cap 5)

### Files Changed

| File | Change |
|---|---|
| `pkg/std/housing/utility.inc` | New `MAX_HOUSES_PER_ACCOUNT`, `GetAccountHouseCount()`, `IsAccountAtHouseLimit()` |
| `pkg/std/housing/housedeed.src` | `Buildhouse()` - new limit check |
| `pkg/std/housing/changeowner.src` | `ChangeHouseOwner()` - new limit check, plus a separate `owneracct`/`"Houses"` cprop sync bugfix |
| `pkg/std/housing/sign.src` | `ChangeHouseOwner()` - new limit check |
| `pkg/opt/statichousing/ssign.src` | `use_sign()` purchase flow and its own `ChangeHouseOwner()` - new limit check |

### Overview

New feature: an account may not own more than `MAX_HOUSES_PER_ACCOUNT` (5) houses at once. Not described in the commit as a crash fix - it's a scoped feature addition bundled into the same commit.

### Notable Functional Changes

- `GetAccountHouseCount(who)`: resolves the account via `FindAccount(who.acctname)` and sums the `"Houses"` obj-property array's size across all 5 of the account's character slots (`account.GetCharacter(1)` through `(5)`, including offline characters) - a live sum each call, not a maintained counter.
- `IsAccountAtHouseLimit(who)`: exempts staff (`who.cmdlevel >= 4`, matching `Buildhouse()`'s existing city/dungeon/shrine/graveyard staff-exemption threshold), otherwise denies if `GetAccountHouseCount(who) >= 5`.
- Wired into every house-acquisition path found in this range: new-deed placement (`housedeed.src`), ownership transfer via `changeowner.src` and `sign.src`'s in-game ownership-change flow, and static-housing sign purchase (`ssign.src`) - each blocks with "You already own the maximum of 5 houses on this account." before the acquisition completes.
- Separately, `changeowner.src`'s `ChangeHouseOwner()` had a pre-existing bug fixed in the same edit: it set `ownerserial` but never `owneracct`, and never called `AddHouseToCharacter()`/`RemoveHouseFromCharacter()` to keep the `"Houses"` cprop in sync on either the old or new owner - meaning a house transferred via this specific path previously went stale in both parties' house lists (and would have thrown off `GetAccountHouseCount()` for anyone who received a house this way). `sign.src`'s own `ChangeHouseOwner()` already did this correctly and was not affected by the bug.

### Expected Impact

An account cannot acquire a 6th house through deed placement, in-game ownership transfer, or static-housing purchase - existing accounts already over the cap are not retroactively affected (no house is removed), only further acquisition is blocked. Staff (Administrator and above) are exempt. The `changeowner.src` cprop-sync fix means houses transferred through that specific code path now correctly show up in the new owner's (and disappear from the old owner's) house list and account house count going forward.

---

## 9. NPC AI - Sleep-Mode Timing and Wake-Radius Tuning

### Files Changed

| File | Change |
|---|---|
| `scripts/ai/main/killpcsloop.inc` | New `NPC_SLEEP_AFTER_WANDERS := 150` (was a bare `60`) |
| `scripts/ai/main/sleepmode.inc` | New `NPC_SLEEP_WAKE_RADIUS := 20`; wake-on-entered-area radius unified to match |

### Overview

`killpcsloop.inc`'s main AI loop counted consecutive idle cycles (`wanders`, ~2s each via `wait_for_event(2)`) before attempting to put an NPC into sleep mode, previously triggering at 60 (~2 minutes). `sleepmode.inc` had two related but mismatched radius values: a proximity check before actually going dormant (20) and the radius used to re-enable `SYSEVENT_ENTEREDAREA` to wake the NPC back up (18).

### Notable Functional Changes

- `NPC_SLEEP_AFTER_WANDERS` raised from 60 to 150 - NPCs now need ~5 minutes of inactivity (up from ~2 minutes) before `sleepmode()` is even attempted. `sleepmode()` still does its own proximity check before actually going dormant.
- `NPC_SLEEP_WAKE_RADIUS` (20) now used for both the pre-sleep proximity check and the `EnableEvents(SYSEVENT_ENTEREDAREA, ...)` wake trigger (previously 18 for the latter) - both directions are now the same value: "if someone's close enough to prevent sleep, they're close enough to end it."
- The separate hiding-skill branch (stealthy/rogue-type NPCs, `GetEffectiveSkill(me, 21) > 0`) keeps its own short wake radius of 4, unchanged.

### Expected Impact

NPCs stay active longer before going dormant (5 minutes of no player interaction instead of 2), and the radius that wakes a dormant NPC back up is now consistent with the radius that would have kept it awake in the first place, removing a small dead zone (18-20 tiles) where an NPC could go to sleep with a player just barely outside the old wake trigger.

---

## 10. New House Escrow System - Staff Demolish-and-Escrow, Player Claim Command

### Files Changed

| File | Change |
|---|---|
| `pkg/std/housing/houseescrow.inc` | New (1206 lines) - core escrow logic |
| `scripts/textcmd/player/houseescrow.src` | New (405 lines) - `.houseescrow` player/staff command |
| `pkg/std/housing/sign.src` | New gump case 17 "Demolish and Escrow (For Staff Only)"; teleporter-placement rewrite (see also section 12); decay-timestamp field un-commented |
| `pkg/std/housing/signcontrol.src` | Dead decay-check block un-commented and fixed; `CleanupHouseTeleporters()` added to `Demolish()` |
| `pkg/std/housing/setup.inc` | New `HOUSE_DECAY_PERIOD` constant (placeholder, `DECAY` flag itself still 0) |
| `pkg/std/housing/utility.inc` | New `IsLocationInThisHouse()`, `CleanupHouseTeleporters()`, owner-last-login helpers, `ResolveHouseTypeDisplayName()` |
| `pkg/utils/gumps/include/yesNoSizable.inc` | `YesNoVar()` rewritten to also scale gump height to wrapped line count |
| `config/command_synopses.cfg` | New `.houseescrow` entry |
| `config/fileaccess.cfg` | New `.log` file-access grants for the `housing` and `playervendor` packages |

### Overview

A new staff-only "Demolish and Escrow" house teardown, explicitly modeled on but deliberately not sharing code with the pre-existing player-vendor escrow system (section 11) - a comment in `houseescrow.inc` states this is so the two systems "can't drift into each other." When staff use the new sign-gump option, the house's entire contents (secure containers, redeedable furniture groups, Omega Cache deposits, trash-can tokens, any player-merchant NPCs standing inside, and the resulting house deed itself) are swept into per-owner escrow storage instead of being destroyed, and any player it belonged to (or a staff-reassigned recipient) can later reclaim it with the new `.houseescrow` player command.

### Notable Functional Changes

- New sign gump option, case 17, gated `who.cmdlevel < CMDLEVEL_DEVELOPER` -> `"Staff only."` (i.e. requires the top cmdlevel, 5). Blocks first if any nearby item still has `outside == house.serial` set (owner must redeed outdoor furniture first). Two `YesNoVar` confirmations (a second, sterner one if the house has a `"GuildHouse"` flag). Writes an audit line to console (`[houseescrow][audit] ...`) before proceeding.
- The sign gump itself was widened (300 -> 360 height) to add an info section: Risk of Escrow (Yes/No, via `IsOwnerAccountAtRisk()`), Owner Last Seen (via `ResolveHouseOwnerLastLogin()`), House Type (via `ResolveHouseTypeDisplayName()`), and teleporter count (placed/total) - all informational display only in this patch, nothing auto-triggers escrow off the "at risk" flag.
- `DemolishAndEscrowHouse(who, house, sign)`: sets `SCRIPTOPT_NO_RUNAWAY` up front (large houses can trip the 500,000-instruction runaway-script threshold; mitigated with periodic `SleepMS(1)` yields). Resolves the owner (falling back through `owneracct`/sign's `lastownername`, logging `[ORPHANED]` and queuing a GM page via the same shared `gmpages` queue the player-vendor escrow system uses, if resolution fails entirely); creates the house's redeed deed via the same ~40-entry objtype->deed case table `sign.src`'s existing self-service demolish already used (extended with two new entries, `0xA3F1`/`0xA3F2`); destroys structural components; calls the new `CleanupHouseTeleporters()` (section 12); snapshots and classifies every item (secure containers, Omega Cache token, trash cans, redeed-group furniture, generic items) into escrow packs; drains the house's Omega Cache datafile wholesale; force-fires any player-merchant NPCs inside via a `pm_force_fire` event (routed into the *separate* player-vendor escrow system, not this one); removes the house from the owner's character record and destroys the multi; escrows the house deed itself as its own labeled pack.
- Escrow storage: a DataFile per owner (`:housing:houseescrow_<ownerserial>`, package-prefixed deliberately - a bare filespec resolves relative to the calling script's own package, so without the prefix `houseescrow.inc` and `houseescrow.src` would silently address two different datafiles despite an identical bare name), plus a `"House Demolish Escrow"` StorageArea holding the actual item packs (root backpacks tagged with `ownerserial`/`house_serial`/`house_label`/`created` cprops). Index entries are batch-appended (`AppendHouseEscrowIndexBatch`) for O(N) rather than O(N²) behavior - the comment cites a real house with 346 packs.
- `.houseescrow` (`scripts/textcmd/player/houseescrow.src`, Player level, CmdLevel 0): with no argument, shows the caller's own paginated escrow gump (5 entries/page) with "To Bank"/"To Backpack" claim buttons per entry. With a numeric argument and `cmdlevel >= 4`, shows a staff view of another character's escrow entries with a "Reassign to targeted character" button per row instead. Claiming (`ClaimHouseEscrowEntry`) snapshots root children before moving (not live iteration), reports if the bank/backpack destination is full, and prunes the datafile entry once fully drained (partial claims leave the remainder in escrow). Gump button IDs are page-relative row numbers reconstructed to an absolute entry index after the gump returns - explicitly to avoid an ID-collision bug that would otherwise occur past 1000 entries (same fix pattern as section 11's player-vendor escrow gump).
- `signcontrol.src`'s previously dead, commented-out house-decay check (`/* FIXME: ... decay is a string! */`) is un-commented and fixed with a `CInt()` cast; `sign.src` now actively refreshes the `"decay"` obj-property timestamp on every owner/cowner/staff sign click. Both remain dormant in practice since the `DECAY` feature flag itself is still `0`.
- `yesNoSizable.inc`'s `YesNoVar()` now estimates wrapped line count from prompt length and scales gump height accordingly (previously fixed-height, horizontal-only scaling) - needed for the new, longer house-demolish confirmation text.
- New `.log` file-access grants (`housing`, `playervendor` packages, `.log` extension) support new `HouseEscrowLog()`/`MerchantEscrowLog()` functions (persistent audit logs to `::log/houseescrow.log` and `::log/merchantescrow.log`, independent of the existing console-only debug print flags).

### Expected Impact

Staff now have a way to tear down and fully preserve a house's contents instead of the previous full-destroy behavior. Affected players (or a staff-designated recipient) can retrieve everything via `.houseescrow`. No existing house-management flow (self-service demolish, redeed, sign gump for owners/cowners) changes behavior beyond the teleporter-tracking rewrite covered in section 12.

---

## 11. Player-Vendor Escrow - Shared Module Refactor and Orphaned-Merchant Fixes

### Files Changed

| File | Change |
|---|---|
| `pkg/systems/playervendor/include/escrow.inc` | Becomes the shared/canonical escrow module |
| `pkg/systems/playervendor/commands/player/escrow.src` | Local duplicate code removed; pagination ID-collision fix |
| `pkg/systems/playervendor/commands/test/pmescrowtest.src` | Local duplicate code removed |
| `pkg/systems/playervendor/playermerchant.src` | Orphaned-merchant fixes; payout pack capacity raised; staff force-fire permission |

### Overview

This pre-existing escrow system (for cashed-out/closed player vendors) had its entry-encoding, storage-opening, and accessor logic duplicated independently across `escrow.src`, `pmescrowtest.src`, and `playermerchant.src`. This commit centralizes all of it into `escrow.inc` and, while doing so, fixes two paths that could leave a merchant's payout permanently orphaned (unclaimable).

### Notable Functional Changes

- `escrow.inc` gains: `MerchantEscrowLog()` (persistent log, independent of existing debug-print flags), `OpenEscrowStorage()`, `EscrowEscapeField`/`EscrowUnescapeField`, `EncodeEscrowEntryFields`/`EncodeEscrowEntries`/`DecodeEscrowEntries`, and accessor functions (`EntryId`, `EntryOwnerSerial`, `EntryEscrowName`, `EntryVendorName`, `EntryVendorSerial`, `EntryCreated`, `EntryOwnerName`) that check a struct-style field first before falling back to the legacy positional-array index.
- New `BuildEscrowDatafileNameForSerial(owner_serial)`, with the existing `BuildEscrowDatafileName(player_obj)` refactored to delegate to it - fixes the datafile name from a bare `PLAYERVENDOR_ESCROW_DF_PREFIX + serial` (no package prefix, previously "worked by accident" because every caller happened to already live inside `pkg/systems/playervendor`) to the package-scoped `":playervendor:..."` form, same class of fix as the house-escrow naming in section 10 but flagged here as latent (no confirmed live failure) rather than confirmed-active.
- `escrow.src`: pagination button IDs changed from absolute entry index to page-relative row number, reconstructed to an absolute index via `start_idx` after the gump returns, with added bounds checks - without this, a player with 1000+ escrow entries could push an absolute-index button ID into another button's numeric range and claim the wrong entry. `ClaimEscrowEntry` now snapshots via `ListRootItemsInContainer` instead of live-iterating while moving, and both it and `RemoveEscrowEntryById` gain `MerchantEscrowLog()` calls at each branch.
- `pmescrowtest.src`: pure deduplication (local `ENTRY_*_IDX` constants, accessor functions, `OpenEscrowStorage()`, and inline parse/encode logic all removed in favor of the shared module). One unstated side effect: this test tool's vendor-name fallback default changes from its own local `"[TEST] Player Merchant"` to the shared module's `"Player Merchant"`, since its local override was deleted along with the rest of the duplicate code.
- `playermerchant.src`: `PAYOUT_PACK_MAX_ROOT_ITEMS` 100 -> 225, `PAYOUT_PACK_MAX_WEIGHT` 40000 -> 60000 (matches the new house-escrow pack limits in section 10). The forced-fire event handler now also accepts `ev.source.cmdlevel >= 4` in addition to the merchant's actual master - required so `houseescrow.inc`'s `FireHouseMerchants()` can force-fire a merchant it doesn't own during a house demolish. `AppendEscrowIndex()` previously bailed out early without ever indexing the entry if the merchant had no `master` set (masterless), leaving the already-created escrow root permanently orphaned/unclaimable - it now proceeds regardless, logging `[ORPHANED]` and falling back to a raw-serial datafile name if the owner can't otherwise be resolved. Separately, `HandleMasterlessMerchantCleanup()` previously ran its own standalone teleport-and-kill sequence that never called `CashOut()` at all, destroying a masterless merchant's inventory/gold along with the NPC - it now delegates to `HandleMerchantClosure("masterless_cleanup", 1)`, which does call `CashOut()` before destroying the merchant's storage containers and running the kill sequence.

### Expected Impact

No change to normal vendor cash-out flow for merchants with a live master. Masterless merchants (owner deleted/unresolvable) are no longer silently destroyed with their inventory intact but unclaimable - their payout is now escrowed and locatable (flagged `[ORPHANED]` in the log) instead. The pagination fix prevents a wrong-entry claim for any player who accumulates 1000+ escrow entries. Payout packs can now hold more before a new pack is spun up.

---

## 12. New Admin Command - Teleporter Serial Backfill Migration

### Files Changed

| File | Change |
|---|---|
| `scripts/textcmd/admin/backfillteleporterserials.src` | New (100 lines) - `.backfillteleporterserials` |
| `pkg/std/housing/sign.src` | `AddTeleporter()` rewritten to use `TeleporterSerials` cprop instead of `house.items` membership |
| `pkg/std/housing/utility.inc` | New `CleanupHouseTeleporters()`, `IsLocationInThisHouse()` |
| `scripts/textcmd/admin/destroymulti.src` | Now calls `CleanupHouseTeleporters()` before destroying a house |

### Overview

House teleporter placement/removal previously validated against `house.items` membership - placement checked whether the newly created teleporter showed up in `house.items`, and removal counted matching-`teleNum` items directly within `house.items` (capped at 2 via a hardcoded counter). This commit introduces an explicit `TeleporterSerials` cprop list on each house as the source of truth, plus a one-time migration command to populate that list for teleporters placed before this change existed.

### Notable Functional Changes

- `sign.src`'s `AddTeleporter(who, house, num)`: placement now validates via the new `IsLocationInThisHouse(house, x, y, z, realm)` (an explicit spatial check against the house's own footprint via `ListMultisInBox`, replacing the old items-membership check) and, on success, appends the new teleporter's serial to `TeleporterSerials`. Removal now iterates the `TeleporterSerials` list (falling back to scanning `house.items` for untracked `0xA3CE` teleporters to backfill the list first if it's empty/missing), destroys matches, and writes back the remainder. Error message text changed from "That is not inside the building." to "You can only place teleporters inside this house." in both spots.
- New `CleanupHouseTeleporters(house)`: destroys every teleporter tracked in `TeleporterSerials`, plus sweeps `house.items` for any untracked pre-migration teleporters pointing at this house, then clears the cprop. Wired into `DemolishAndEscrowHouse()` (section 10), `sign.src`'s existing case-14 self-service demolish, `signcontrol.src`'s `Demolish()`, and now `scripts/textcmd/admin/destroymulti.src` as well.
- `.backfillteleporterserials` (Administrator, CmdLevel 4, idempotent - "safe to run more than once"): scans every realm world-wide by objtype (`0xA3CE`) rather than by proximity, specifically because a proximity/spatial search could miss a teleporter's paired partner if it's placed far away; resolves each teleporter's owning house via its `teleportserial` cprop and backfills that house's `TeleporterSerials` list. Orphaned teleporters (owning house no longer exists) are counted and reported but left untouched - explicitly deferred to "a separate cleanup pass."

### Expected Impact

Teleporter placement/removal is now driven by an explicit, house-scoped serial list instead of an unreliable items-membership check, and every path that destroys a house (demolish, redeed, escrow, admin destroymulti) now reliably cleans up its teleporters instead of potentially leaving them behind. Houses with teleporters placed before this patch need `.backfillteleporterserials` run once (already scheduled as part of this deployment) so their existing teleporters are tracked correctly going forward.

---

## 13. Tamed Pets - Follow() Runaway-Watch Diagnostics Removed

### Files Changed

| File | Change |
|---|---|
| `scripts/ai/tamed.src` | Removes 1.1.0's runaway-watch diagnostic block from `Follow()` |

### Overview

Patch 1.1.0 added a hard `Sleepms(25)` rate floor to `Follow()` (capping calls to ~40/sec) plus a console-only runaway-watch diagnostic that counted calls-per-second and printed a warning if a pet exceeded a threshold. This patch removes only the diagnostic instrumentation.

### Notable Functional Changes

- Removed: `FOLLOW_RUNAWAY_THRESHOLD`, `FOLLOW_RUNAWAY_WARN_COOLDOWN` constants; `followcalls`, `followwindowstart`, `lastfollowwarn` module-level vars; the per-call counting/windowing block and its `"[TamedAI runaway-watch] ..."` console print; the now-unused `use basicio;` import.
- **Not removed / unchanged:** the actual `Sleepms(25)` rate floor at the top of `Follow()` remains in place, applying before any early-return branch exactly as it did at the end of 1.1.0.

### Expected Impact

No gameplay/behavior change - pet follow speed and rate-limiting are identical to 1.1.0. This is a cleanup of console-only diagnostic logging that had served its purpose (confirming the 1.1.0 floor works) and is no longer needed.

---

## 14. CmdLevel Constants - Renumbered to Match the Actual Ladder

### Files Changed

| File | Change |
|---|---|
| `scripts/include/constants/cmdlevels.inc` | Removes phantom `CMDLEVEL_SHARD_MOM`; renumbers everything above Counselor |

### Overview

`config/cmds.cfg` defines exactly 6 `CmdLevel` blocks in order: Player, Coun, Seer, GM, Admin, Test. `cmdlevels.inc`'s named constants had a phantom `CMDLEVEL_SHARD_MOM := 2` that doesn't correspond to any real level, which pushed every constant above Counselor one level too high (`CMDLEVEL_SEER` was `3` instead of `2`, up through `CMDLEVEL_DEVELOPER` being `6` instead of the real top level, `5`).

### Notable Functional Changes

- `CMDLEVEL_SHARD_MOM` removed entirely. `CMDLEVEL_SEER` 3->2, `CMDLEVEL_GAME_MASTER` 4->3, `CMDLEVEL_ADMINISTRATOR` 5->4, `CMDLEVEL_DEVELOPER` 6->5.
- Only two symbol-name consumers of these constants exist repo-wide: `pkg/opt/spawnpoint/spawnpoint.src`'s case statement (pre-existing), and this patch's own new `who.cmdlevel < CMDLEVEL_DEVELOPER` check in `sign.src`'s case-17 escrow gump gate (section 10) - both reference by name and are correct as of this commit's renumbering.
- Not touched by this change: the large number of pre-existing raw numeric `who.cmdlevel >= 4` / `>= 5` comparisons found elsewhere in the codebase (e.g. `sign.src`'s existing owner/cowner checks). Those were already keyed to the engine's real, unaffected level numbering (`config/cmds.cfg` itself never changed), so their meaning is unchanged by this commit - only code that referenced the old, incorrect `CMDLEVEL_*` *names* was ever wrong.

### Expected Impact

No behavior change for the two confirmed symbol-name consumers (they now correctly reference the shard's real "Administrator"/"Developer" levels). No repo-wide audit of every raw-numeric cmdlevel check was performed as part of this commit - only the two confirmed name-based consumers were verified.

---

## 15. Misc Small Fixes

### Files Changed

| File | Change |
|---|---|
| `scripts/textcmd/seer/findboat.src` | Removes unused `include "include/account";` |
| `config/animxlate.cfg` | One new `Graphic 0x175` entry under `MobileType Monster` |
| `scripts/textcmd/test/editcharacter.src` | Color/hue clamp ceiling raised |

### Notable Functional Changes

- `findboat.src`: no functional code touched, only an unused include removed. No comment in the diff states why.
- `animxlate.cfg`: registers one additional monster graphic ID (`0x175`) for animation translation, alongside the pre-existing `0x176` entry. No further context in the diff about which creature this is for.
- `editcharacter.src`: `ClampInt(CInt(GFExtractData(result, ENTRY_COLOR)), 0, 10000)` -> `ClampInt(..., 0, 65535)` - the `.editcharacter` staff tool's hue/color clamp ceiling raised from 10000 to the full 16-bit hue range, so valid hues above 10000 are no longer incorrectly clamped down.

### Expected Impact

Staff-tool-only changes plus one unexplained dead-code removal; no player-facing effect.

---

## 16. Exhaustive File-by-File Change List

| File | Section | Summary |
|---|---|---|
| `config/animxlate.cfg` | 15 | One new monster graphic entry |
| `config/command_synopses.cfg` | 4, 10, 12 | Regenerated for new commands |
| `config/fileaccess.cfg` | 10 | New `.log` grants for housing/playervendor |
| `config/golocs_by_id.cfg` | 6 | City -> Suburb reclassification |
| `pkg/opt/alryc/stresstest/areastressworker.src` | 4 | New - spawned load worker |
| `pkg/opt/alryc/stresstest/emailstressworker.src` | 4 | New - spawned load worker |
| `pkg/opt/alryc/textcmd/test/aimovementsim.src` | 4 | New - `.aimovementsim` |
| `pkg/opt/alryc/textcmd/test/dfleaktest.src` | 4 | New - `.dfleaktest` |
| `pkg/opt/alryc/textcmd/test/housezoneaudit.src` | 7 | New - `.housezoneaudit` |
| `pkg/opt/alryc/textcmd/test/shardstress.src` | 4 | New - `.shardstress` |
| `pkg/opt/areas/areas.cfg` | 6 | City -> Suburb reclassification |
| `pkg/opt/areas/include/areapolicy.inc` | 3 | `UnloadDataFile()` leak fixes |
| `pkg/opt/areas/textcmd/admin/areas.src` | 6 | `CATEGORY_ORDER` gains "suburb" |
| `pkg/opt/spawnpoint/textcmd/admin/restartspawnpointarea.src` | 6 | Display ordering gains "Suburb" |
| `pkg/opt/statichousing/ssign.src` | 8 | House-limit check added |
| `pkg/opt/sysbook/start.src` | 3 | `UnloadDataFile()` leak fix |
| `pkg/opt/townstones/textcmd/admin/createtownstone.src` | 7 | `GetConfigStringArray` -> `SplitWords`/`GetConfigString` |
| `pkg/opt/townstones/textcmd/admin/townbankstatus.src` | 7 | Same as above |
| `pkg/std/housing/changeowner.src` | 8 | House-limit check + `owneracct`/cprop-sync bugfix |
| `pkg/std/housing/houseescrow.inc` | 10 | New - core house-escrow logic |
| `pkg/std/housing/housedeed.src` | 7, 8 | MultiID resolution fix, region-check refactor, house-limit check |
| `pkg/std/housing/setup.inc` | 10 | New `HOUSE_DECAY_PERIOD` constant (dormant) |
| `pkg/std/housing/sign.src` | 10, 12 | New escrow gump case, teleporter rewrite, decay timestamp refresh |
| `pkg/std/housing/signcontrol.src` | 10, 12 | Decay-check fix, `CleanupHouseTeleporters()` added |
| `pkg/std/housing/utility.inc` | 8, 10, 12 | House-limit helpers, escrow helpers, teleporter cleanup, owner-risk helpers |
| `pkg/systems/email/chardelete.src` | 3 | `UnloadDataFile()` leak fix |
| `pkg/systems/email/commands/gm/inspectmail.src` | 3 | `UnloadDataFile()` leak fix |
| `pkg/systems/email/email.src` | 3 | `UnloadDataFile()` leak fix |
| `pkg/systems/email/logon.src` | 3 | `UnloadDataFile()` leak fix |
| `pkg/systems/email/reconnect.src` | 3 | `UnloadDataFile()` leak fix |
| `pkg/systems/email/webmail/webmail.src` | 3 | `UnloadDataFile()` leak fix |
| `pkg/systems/playervendor/commands/player/escrow.src` | 11 | Dedup + pagination ID-collision fix |
| `pkg/systems/playervendor/commands/test/pmescrowtest.src` | 11 | Dedup |
| `pkg/systems/playervendor/include/escrow.inc` | 11 | Becomes shared escrow module |
| `pkg/systems/playervendor/playermerchant.src` | 11 | Orphaned-merchant fixes, pack capacity, staff force-fire |
| `pkg/utils/gumps/include/yesNoSizable.inc` | 10 | `YesNoVar()` vertical scaling |
| `regions/regions.cfg` | 6 | City/Suburb reclassification, Occlo Isle -> City |
| `scripts/ai/main/killpcsloop.inc` | 9 | Sleep-after-wanders threshold 60 -> 150 |
| `scripts/ai/main/sleepmode.inc` | 9 | Wake radius unified to 20 |
| `scripts/ai/tamed.src` | 13 | Runaway-watch diagnostics removed |
| `scripts/include/checkcity.inc` | 5 | `CheckCity()` rewrite, new shared region helpers |
| `scripts/include/constants/cmdlevels.inc` | 14 | Renumbered to match actual ladder |
| `scripts/textcmd/admin/backfillteleporterserials.src` | 12 | New - `.backfillteleporterserials` |
| `scripts/textcmd/admin/destroymulti.src` | 12 | `CleanupHouseTeleporters()` added |
| `scripts/textcmd/coun/go.src` | 6 | Display ordering gains "Suburb" |
| `scripts/textcmd/player/houseescrow.src` | 10 | New - `.houseescrow` |
| `scripts/textcmd/seer/findboat.src` | 15 | Unused include removed |
| `scripts/textcmd/test/editcharacter.src` | 15 | Hue clamp ceiling raised |
| `patchnotes/developer-changelog-v1.1.1.md` | - | This file |
| `patchnotes/patch-v1.1.1.md` | - | Player-facing notes |
| `patchnotes/launchernotes.md` | - | Replaced with this release's player-facing content |

---

## 17. Risk and Regression Notes

- **`CheckCity()`/region reclassification (sections 5-6):** any location logic gated on `CheckCity()` or the `city` area category now behaves differently for the five reclassified farmland/outbuilding zones (no longer "city") and Occlo Isle (now "city"). Confirmed active consumers: fishing nets, tree planting, exploding-potion power, bookcase decay. `lockchests.src` and `provocation.src`'s `CheckCity()` calls are dead/commented-out code and unaffected either way.
- **House placement MultiID fix (section 7):** `.housezoneaudit` should be run post-deploy to identify any already-placed houses that slipped into a restricted region under the old, broken `GetMultiDimensions()` call - this fix only prevents *new* violations, it does not retroactively move or flag existing ones automatically.
- **Per-account house limit (section 8):** only blocks new acquisition; accounts already over the 5-house cap are unaffected until they try to acquire another house. Worth confirming intended cap value (5) matches policy before this reaches players, since it's not adjustable without a code change (no config entry, just the `MAX_HOUSES_PER_ACCOUNT` constant).
- **Teleporter serial backfill (section 12):** `.backfillteleporterserials` needs to be run once, post-deploy, before the new `TeleporterSerials`-based removal logic in `sign.src` can be trusted for houses with pre-existing teleporters (the removal path does have a same-call fallback scan for untracked teleporters, but the backfill command is the deliberate one-time fix for the general case). Orphaned teleporters (house already destroyed) are reported but not cleaned up by this command - flagged as a separate follow-up.
- **Escrow storage growth (section 10):** house-escrow and player-vendor-escrow entries are only removed from their index once fully claimed - abandoned/orphaned entries (masterless merchants, unresolvable house owners) persist indefinitely in storage unless staff intervene via the reassign flow. No automatic expiry exists yet.
- **`pmescrowtest.src` vendor-name default (section 11):** this test tool's fallback vendor-name text silently changed from `"[TEST] Player Merchant"` to `"Player Merchant"` as an unstated side effect of removing its local duplicate code - purely a test-tool display string, but worth knowing if `.pmescrowtest` output is compared against old screenshots/docs.
- **CmdLevel renumbering (section 14):** only two symbol-name consumers were confirmed and verified correct; no repo-wide audit of raw-numeric `cmdlevel` comparisons was performed as part of this commit (none should be affected in principle, since `config/cmds.cfg`'s actual numbering never changed, but this wasn't exhaustively checked file-by-file).
- **`findboat.src` include removal (section 15):** no stated reason in the diff; if `.findboat` (Seer level) breaks in a way tied to account-related functionality, this removed include is the first thing to check.
