### PR TITLE
Healing and Chrdeath update

### DIFF
--- a/pkg/std/healing/healing.src
+++ b/pkg/std/healing/healing.src
@@ -224,6 +224,7 @@ function TryToCure( character , patient , bandages )
 
 	if( patient.dead )
 		SendSysMessage( character , "Your patient is dead." );
+		return;
 	endif
 
 	if( CheckSkill( character , SKILLID_HEALING , diff , points ) )
@@ -295,6 +296,7 @@ function TryToHeal( character , patient , bandages )
 
 	if( patient.dead )
 		SendSysMessage( character , "Your patient is dead." );
+		return;
 	endif
 
 	var diff 	:= GetMaxHP(patient) - GetHP(patient); //patient.maxhp - patient.hp;

--- a/scripts/misc/chrdeath.src
+++ b/scripts/misc/chrdeath.src
@@ -144,7 +144,7 @@ program chrdeath(corpse,ghost)
 		if (oktodestroy)
 			DestroyItem(corpse);
 		else
-			SendSysMessage(ghost,"There are still items left on your corpse - please page staff.");
+			SendSysMessage(ghost,"Your backpack is too full to hold everything - some items are still on your corpse. They won't be lost; loot them now or they'll drop to the ground when the corpse decays.");
 		endif
 		return;
 	endif
@@ -205,7 +205,7 @@ program chrdeath(corpse,ghost)
 		if (oktodestroy)
 			DestroyItem(corpse);
 		else
-			SendSysMessage(ghost,"There are still items left on your corpse - please page staff.");
+			SendSysMessage(ghost,"Your backpack is too full to hold everything - some items are still on your corpse. They won't be lost; loot them now or they'll drop to the ground when the corpse decays.");
 		endif
 		SetSafeAreaProperties(ghost);
 		MoveObjectToLocation( ghost, 5503, 1665, 22, "britannia", MOVEOBJECT_FORCELOCATION );
@@ -297,7 +297,7 @@ program chrdeath(corpse,ghost)
 		if (oktodestroy2)
 			DestroyItem(corpse);
 		else
-			SendSysMessage(ghost,"There are still items left on your corpse - please page staff.");
+			SendSysMessage(ghost,"Your backpack is too full to hold everything - some items are still on your corpse. They won't be lost; loot them now or they'll drop to the ground when the corpse decays.");
 		endif
 		if(len(ghost.reportables)>0)
 			SendReportGump(ghost);


### PR DESCRIPTION
# Developer Changelog - v1.1.2
**Range:** `7107d6d` (HEAD of v1.1.1) -> `9e06736` (HEAD)  
**Branch:** Patch-1.1.2  
**Date:** 2026-08-08 -> 2026-08-19  
**Commits in range:** 14 non-boundary commits (`29962db`, `4ce28ea`, `25b0b3b`, `37cf238`, `bc79410`, `8bb55cb`, `a18c2e7`, `43261fe`, `88720ac`, `1ae01df`, `e6a6be9`, `e3980f7`, `5aa5f81`, `9e06736`); 2 merge commits (`8386eef`, `316c467`) carry no new content; `9e36189`, `f6c4bd5`, `9c354ed` are this release's own prior patchnotes commits, boundary/superseded by this update  
**Files changed (committed):** 41 (+896 / -155), plus this release's own 3 `patchnotes/` files

---

## Table of Contents

1. [Scope Summary](#1-scope-summary)
2. [Commit Timeline](#2-commit-timeline)
3. [Vendor Training - Magic Resistance Now Teachable](#3-vendor-training---magic-resistance-now-teachable)
4. [Stability - Defensive Nil/Error Guards From Live Log Review](#4-stability---defensive-nilerror-guards-from-live-log-review)
5. [FileAccess - AllowRemote Enabled for Housing/PlayerVendor Escrow Logs](#5-fileaccess---allowremote-enabled-for-housingplayervendor-escrow-logs)
6. [Command-Level Corrections and Script Housekeeping](#6-command-level-corrections-and-script-housekeeping)
7. [New Staff Tool - .memdump Command and Standalone Memory-Usage Log Analyzers](#7-new-staff-tool---memdump-command-and-standalone-memory-usage-log-analyzers)
8. [Command Fix - .ph Now Reports Personal Powerhour Status](#8-command-fix---ph-now-reports-personal-powerhour-status)
9. [New GM Tool - .resetph Command](#9-new-gm-tool---resetph-command)
10. [New Item - Eon-Prism](#10-new-item---eon-prism)
11. [Housing Sign - Owner Name Resolved Live Instead of Cached](#11-housing-sign---owner-name-resolved-live-instead-of-cached)
12. [Performance and Cleanup - Area-Policy Cache Simplified; NPC AI Setup Scripts Decoupled From the Spawnpoint Package](#12-performance-and-cleanup---area-policy-cache-simplified-npc-ai-setup-scripts-decoupled-from-the-spawnpoint-package)
13. [Stability - NPC Corpse Decay No Longer Risks Erroring on an Already-Despawned Corpse](#13-stability---npc-corpse-decay-no-longer-risks-erroring-on-an-already-despawned-corpse)
14. [Bug Fix - Bandage Healing on a Patient Who Dies Mid-Treatment (Life Crystal Interaction)](#14-bug-fix---bandage-healing-on-a-patient-who-dies-mid-treatment-life-crystal-interaction)
15. [Exhaustive File-by-File Change List](#15-exhaustive-file-by-file-change-list)
16. [Risk and Regression Notes](#16-risk-and-regression-notes)

---

## 1. Scope Summary

Patch 1.1.2 grew across two work sessions (2026-08-08 to 2026-08-11, then 2026-08-12, then a single follow-up fix on 2026-08-19). The first session's five commits are covered in sections 3-9 as previously documented. `9c354ed` (2026-08-11) added the Eon-Prism item (section 10) and its own `.resetph` counterpart (section 9). Since then: `a18c2e7` ("sign name update") fixes a stale house-sign owner-name display (section 11). `43261fe` ("Quick Eon Fix") and `88720ac` ("Eon Prism Update"), both same-day follow-ups to the Eon-Prism item, are folded into section 10 - the eligibility guard was already captured there by the previous update, this update corrects the item's graphic/color description, which `88720ac` changed after that text was written. `1ae01df` ("memdump update") extends `.memdump` with a third diagnostic dump targeted at AI script memory (folded into section 7). `e6a6be9` ("Area policy memory update") removes a redundant per-script in-RAM cache layer from the area-policy system and decouples six NPC AI setup scripts from the `spawnpoint` package, pulling in only the one shared function they actually use (section 12). `e3980f7` ("Corpse Decay Fix") and `5aa5f81` ("corpsedecay fix") are a same-topic pair - the first attempt at making NPC corpse decay resilient to the corpse already being gone used a stale-reference check that doesn't actually detect a destroyed object, the second replaces it with a proper serial lookup and also patches the same gap in the top-level dispatcher (section 13). `9e06736` ("Healing and Chrdeath update") fixes a player-reported bug: bandage-healing a patient who dies mid-treatment (most visibly, a player protected by a Dundee Life Crystal) could still apply `HealDamage`/`CheckSkill` to them after they'd already died, racing the crystal's own auto-resurrect sequence on the same mobile; it also clarifies the sysmessage shown when a resurrected player's backpack can't hold everything recovered from their corpse (section 14).

---

## 2. Commit Timeline

| Hash | Date | Message |
|---|---|---|
| `7107d6d` | 2026-08-08 | (v1.1.1 HEAD - range start) |
| `8386eef` | 2026-08-08 | Merge pull request #317 from Andries1985/Patch-1.1.1 (boundary - no new content) |
| `316c467` | 2026-08-08 | Merge pull request #318 from Andries1985/Test-Shard (boundary - brings in already-released Patch-1.1.0 merge commits, no new content) |
| `29962db` | 2026-08-08 | Patchnotes for Patch 1.1.1 (adds 1.1.1's docs; also bundles the FileAccess `AllowRemote` fix, section 5) |
| `4ce28ea` | 2026-08-08 | Minor fixes from the logs |
| `25b0b3b` | 2026-08-08 | Fixes for commands |
| `37cf238` | 2026-08-10 | Memory Dump Checks |
| `bc79410` | 2026-08-10 | Magic resistence training fix |
| `9e36189` | 2026-08-10 | Patch Notes (boundary - superseded by this update) |
| `8bb55cb` | 2026-08-11 | ph command fix |
| `f6c4bd5` | 2026-08-11 | Patchnotes update (boundary - superseded by this update) |
| `9c354ed` | 2026-08-11 | resetph command eon-prism artifact patchnotes update (adds sections 9-10; boundary, superseded by this update) |
| `a18c2e7` | 2026-08-11 | sign name update |
| `43261fe` | 2026-08-11 | Quick Eon Fix (folded into section 10) |
| `88720ac` | 2026-08-11 | Eon Prism Update (folded into section 10) |
| `1ae01df` | 2026-08-12 | memdump update (folded into section 7) |
| `e6a6be9` | 2026-08-12 | Area policy memory update |
| `e3980f7` | 2026-08-12 | Corpse Decay Fix (folded into section 13) |
| `5aa5f81` | 2026-08-12 | corpsedecay fix (folded into section 13) |
| `9e06736` | 2026-08-19 | Healing and Chrdeath update |

---

## 3. Vendor Training - Magic Resistance Now Teachable

### Files Changed

| File | Change |
|---|---|
| `config/npcdesc.cfg` | Adds `MagicResistance 100` to the `mage`, `alchemist`, and `scribe` NPC templates |

### Overview

A player reported that "vendor train" never offered Magic Resistance from any vendor - not mage, not scribe, not alchemist. `MerchantTrain()` in `scripts/ai/merchant.src` only lists a skill as trainable if the NPC's own base skill value for it (`GetBaseSkillBaseValue(me, i)`) is non-zero, which in turn only exists if the NPC's template defines that skill line at spawn. A repo-wide search of every `MagicResistance` line in `npcdesc.cfg` found it only on six combat-monster templates (`scourgegladiator`, `scourgecommander`, `titanwarmaster`, `plague`, `pestilence`, `scourgebattlemaster`) - none of which use `script merchant`. No vendor template anywhere in the file had it.

### Notable Functional Changes

- `mage` template: adds `MagicResistance 100` alongside its existing `evaluatingintelligence`, `magery`, `SpiritSpeak`, `meditation` lines (100 matches the value already used for those).
- `alchemist` template: adds `MagicResistance 100` alongside `alchemy`, `evaluatingintelligence`.
- `scribe` template: adds `MagicResistance 100` alongside `itemid`, `evaluatingintelligence`, `inscription`, `spiritspeak`, `meditation`.

### Expected Impact

Newly spawned Mage, Alchemist, and Scribe vendors now offer Magic Resistance training (up to 33.3 skill, per the `NPC_level/3` cap in `MerchantTrain()`) via "vendor train". Vendors already spawned before this patch keep their existing base skills until they respawn or the server reloads `npcdesc.cfg` and re-templates them - not retroactively updated in place.

---

## 4. Stability - Defensive Nil/Error Guards From Live Log Review

### Files Changed

| File | Change |
|---|---|
| `pkg/items/armor/include/armorZones.inc` | `CS_GetLayersInArmorZone()`, `CS_GetEquipmentInArmorZone()`, `CS_GetEffectiveArmor()` - guard against missing zone/item config entries |
| `pkg/opt/powerscrolls/textcmd/player/showcaps.src` | `skillwindow()` - guard against an empty `classe` before the `GetObjProperty()` lookup |
| `pkg/opt/spawnpoint/checkpoint.src` | `ValidatePointSpawns()` - treat an `error`-valued spawned-objects property the same as missing |
| `pkg/opt/vanityshop/mountstone.src` | `MountStone()`, `CreateMount()`, `StoreMount()` - guard `error`-valued `Owner`/`DMountSerial`/`DMountStoneSerial` properties and missing owner/mount objects |
| `pkg/opt/versebook/Bardic_Boulders.src` | `HitWithBoulder()` - guard against `CreateItemAtLocation()` returning nothing |
| `pkg/std/boat/boat.src` | `DoEncounter()` - bail out if `boat` or `boat.realm` is unset |
| `pkg/std/boat/plankutil.inc` | `IsPlankOccupied()` - bail out if `plank` or `plank.realm` is unset |
| `pkg/std/boat/plankwalk.src` | `plankwalk()` - pass `who.realm`/`plank.realm` explicitly to `MoveObjectToLocation()`/`ListMobilesNearLocation()` instead of relying on defaults |
| `pkg/std/traps/traps.src` | `open_trapped_item()` - skip the crafter lookup when `trapcrafter` is the literal string `"Spawnpoint"` |
| `scripts/ai/chaosmultikillpcs.src` | `MakeLord()`, `SplitLord()` - pass `"britannia"` explicitly to two `MoveObjectToLocation()` calls that previously omitted the realm argument |
| `scripts/control/firecontrol.src` | `field_control()` - break out of the damage loop if `item.realm` becomes unset |
| `scripts/misc/death.src` | `npcdeath()`, `RegisterNPC()` - guard `error`-valued `master`/`KilledBySerial` properties and missing master objects |

### Overview

Eleven files, one fix pattern: each was throwing (or silently misbehaving) on a code path that assumed an obj-property lookup, a config-file lookup, or a freshly-created/located object reference would always succeed. The commit message ties this directly to specific errors seen in the live server logs rather than a general audit - `death.src`'s `RegisterNPC()`/heart-creation path and `traps.src`'s spawnpoint-chest trap message were the most concretely motivated (see inline comment added in `traps.src`), the rest are the same class of defensive fix applied to nearby call sites that shared the same risk.

### Notable Functional Changes

- `armorZones.inc`: all three functions now check their `zone_cfg`/`itemdesc_cfg` lookup against `error` before using it, returning an empty array/`0` instead of erroring when an item or zone isn't in config.
- `showcaps.src`: `level` now defaults to `0` and the `GetObjProperty()` call is skipped entirely when `classe` is falsy, instead of calling `GetObjProperty(who, classe)` with an empty key.
- `checkpoint.src`: `serials` is now reset to `{}` when the stored property is either missing *or* `error`-valued (previously only checked falsy).
- `mountstone.src`: `Owner`, `DMountSerial`, and `DMountStoneSerial` obj-properties are each normalized to `0` if `error`-valued before use; `StoreMount()` now returns early if the resolved mount or original-stone item can't be found, instead of dereferencing a nil object.
- `Bardic_Boulders.src`: the entire boulder-placement/cleanup block is now skipped if `CreateItemAtLocation()` returns nothing, instead of immediately reading `.z` off it.
- `boat.src` / `plankutil.inc`: both bail out early if the boat/plank reference or its `.realm` is unset, before calling `ListMobilesNearLocation*()`/`GetMapInfo()`.
- `plankwalk.src`: two `MoveObjectToLocation()`/`ListMobilesNearLocation()` calls that previously omitted the realm argument (defaulting to the current/default realm) now pass `who.realm`/`plank.realm` explicitly, matching the third call in the same function that already did.
- `traps.src`: spawnpoint-placed trapped chests store the literal string `"Spawnpoint"` in the `trapped_by` obj-property (see `checkpoint.src`'s `PROPID_CHEST_TRAPPED_BY`) rather than a crafter serial. `open_trapped_item()` previously tried to `SystemFindObjectBySerial()` that string as if it were a serial; it's now explicitly excluded from the crafter-lookup/notify branch, with a comment explaining why.
- `chaosmultikillpcs.src`: `MoveObjectToLocation(mergewith, 5376, 1081, 0, 0)` and the equivalent call for `me` in `SplitLord()` previously passed `0` where a realm string is expected; both now pass `"britannia"` explicitly.
- `firecontrol.src`: `field_control()`'s damage-tick loop now breaks if `item.realm` becomes unset mid-loop (e.g. the field item was destroyed/moved off-realm), instead of calling `ListMobilesNearLocation()` with a stale/invalid realm every tick until `item.x` itself goes falsy.
- `death.src`: `npcdeath()` now resolves `mastersrl` and `masterobj` once up front, normalizing an `error`-valued `master` property to `0` and skipping the "Heart of the Beast" backpack placement/sysmessage and the disintegration message entirely if no master object can be resolved (previously called `.backpack` and `SendSysMessage()` directly on whatever `SystemFindObjectBySerial()` returned, including a nil result). The `IsInSafeArea(corpse)` item-recovery branch is now also gated on `masterobj` being resolved. `RegisterNPC()` similarly normalizes an `error`-valued `KilledBySerial` to `0` before checking it.

### Expected Impact

No new features and no intended change to normal-case behavior - every fix is guarding a path that would previously error out (visible as a server-log error, and in several cases as a script simply failing partway through, e.g. a tamed-pet death not producing a Heart, or a boat encounter/plank check throwing instead of running) when it hit one of these edge cases. Should reduce the frequency of the specific errors these were pulled from in the logs.

---

## 5. FileAccess - AllowRemote Enabled for Housing/PlayerVendor Escrow Logs

### Files Changed

| File | Change |
|---|---|
| `config/fileaccess.cfg` | Adds `AllowRemote 1` to the `housing` and `playervendor` package `.log` FileAccess blocks |

### Overview

1.1.1 added `HouseEscrowLog()` and `MerchantEscrowLog()` (sections 10-11 of the v1.1.1 changelog), which write to package-prefixed paths (`::log/houseescrow.log`, `::log/merchantescrow.log`) outside each package's own directory tree. Per `fileaccess.cfg`'s documented semantics, a package-prefixed/remote file path only resolves if the granting `FileAccess` block has `AllowRemote 1` set - the `.log` grants added alongside those two functions in 1.1.1 did not set it. This fix was bundled into the same commit as the 1.1.1 patch-notes files (`29962db`), after the 1.1.1 changelog's own commit range had already closed, so it's documented here instead.

### Notable Functional Changes

- Both the `housing` and `playervendor` `.log`-extension `FileAccess` blocks in `config/fileaccess.cfg` gain `AllowRemote 1`.

### Expected Impact

`HouseEscrowLog()` and `MerchantEscrowLog()` calls can now actually write to their target log files under `::log/`. Staff-facing only - no player-visible change, but the house-escrow and player-vendor-escrow audit logs referenced in 1.1.1's documentation should now actually be populated going forward (any 1.1.1-era calls between that release and this fix landing may not have written successfully).

---

## 6. Command-Level Corrections and Script Housekeeping

### Files Changed

| File | Change |
|---|---|
| `config/command_synopses.cfg` | `backfillteleporterserials`, `migrateclassfirsts` - `Level Administrator`/`CmdLevel 4` -> `Level Developer`/`CmdLevel 5` |
| `scripts/textcmd/admin/backfillteleporterserials.src` -> `scripts/textcmd/test/backfillteleporterserials.src` | Renamed, no content change |
| `scripts/textcmd/admin/migrateclassfirsts.src` -> `scripts/textcmd/test/migrateclassfirsts.src` | Renamed, no content change |
| `pkg/opt/classfirsts/pkg.cfg` | Comment updated to reference the new `test/migrateclassfirsts.src` path |
| `pkg/std/housing/houseescrow.inc` | Removes leftover `[houseescrow][debug]`/`[houseescrow][ERROR]` `Print()` calls (12 call sites) |
| `pkg/std/housing/sign.src` | Removes the `[houseescrow][audit]` `Print()` call before `DemolishAndEscrowHouse()` |
| `scripts/textcmd/player/houseescrow.src` | Removes 4 `[houseescrow][debug]` `Print()` calls |

### Overview

Two related cleanups bundled into one commit: (1) the two one-time migration commands added in 1.1.1 (`.backfillteleporterserials`, `.migrateclassfirsts`) were registered at `Administrator`/`CmdLevel 4` and living in the `admin` command folder despite being one-shot, rarely-rerun migration tools rather than routine admin commands - both are now `Developer`/`CmdLevel 5` and moved into `test`; and (2) the console-only `Print()` debug logging added throughout 1.1.1's new house-escrow system is removed now that `HouseEscrowLog()` (section 5) is confirmed to actually persist to its log file, leaving the persistent log as the sole record instead of duplicating everything to console.

### Notable Functional Changes

- `command_synopses.cfg` regenerated (`pythonscripts/_gen_command_synopses_cfg.py`) to reflect the two commands' new level/folder.
- File renames are pure moves (`git show` reports 100% similarity, no content diff) - existing references were already package-relative and don't need updating beyond `pkg.cfg`'s comment.
- `houseescrow.inc`/`sign.src`/`houseescrow.src`: every removed `Print()` call had a corresponding `HouseEscrowLog()` call carrying the same (or more detailed) information already in place - none of the removed lines were the only record of that event.

### Expected Impact

Both migration commands now require the shard's top staff level instead of Administrator, matching how they're actually used (one-time, developer-run). No player-visible change. House-escrow operations stop double-logging to console; the persistent `::log/houseescrow.log` (now reliably written per section 5) remains the record of truth.

---

## 7. New Staff Tool - .memdump Command and Standalone Memory-Usage Log Analyzers

### Files Changed

| File | Change |
|---|---|
| `pkg/opt/alryc/textcmd/test/memdump.src` | New (`37cf238`) - `.memdump`; extended (`1ae01df`) with a third diagnostic dump |
| `config/command_synopses.cfg` | New `memdump` entry (Developer, CmdLevel 5); synopsis text updated by `1ae01df` |
| `pythonscripts/analyze_memory_usage.py` | New (286 lines) - standalone log parser/report tool |
| `pythonscripts/Analyze-MemoryUsage.ps1` | New (199 lines) - PowerShell equivalent of the above |

### Overview

A new staff diagnostic command plus two standalone (run outside the game server) scripts for investigating script memory usage, in support of ongoing shard-stability work. `1ae01df` (2026-08-12, "memdump update") extends the command a day later with a fourth `POLCore().internal()` call targeted specifically at the `killpcs` AI script's memory footprint, following up on the same investigation.

### Notable Functional Changes

- `.memdump` (Developer, CmdLevel 5): calls `POLCore().internal(2)` and `POLCore().internal(5)` - engine-internal diagnostic dumps (script memory usage, among other things) written to the server directory, per the command's own sysmessage/console output. No parameters.
- `1ae01df` adds a third call, `POLCore().internal(6, "scripts/ai/killpcs.ecl")` - a per-script-file memory dump scoped to the compiled `killpcs.ecl`, run alongside the existing `internal(2)`/`internal(5)` calls. Three more `internal(6, ...)` calls for `spellkillpcs.ecl`, `barker.ecl`, and `animal.ecl` are added as commented-out lines (`MEMDUMP_SPELLKILLPCS_SCRIPT`, `MEMDUMP_BARKER_SCRIPT`, `MEMDUMP_ANIMAL_SCRIPT` constants defined but unused) for a developer to uncomment as needed rather than dumping all four every run.
- Command synopsis updated from "Trigger POLCore() internal diagnostic dumps 2 and 5 (script memory usage, etc.)" to "...2, 5, and 6 (killpcs/spellkillpcs/barker/animal AI memory)".
- `analyze_memory_usage.py` / `Analyze-MemoryUsage.ps1`: both parse `memoryusagescripts.log` (the file `.memdump`'s `internal(2)`/`internal(5)` calls produce) into per-script memory entries and per-snapshot totals, and report top-N consumers; the Python version also supports CSV export. Not part of the EScript codebase - run directly via `python`/`pwsh` against a log file pulled from the server. Not updated for the new `internal(6)` output format in this range.

### Expected Impact

Staff/developer-facing only. No player-visible change. Gives the team a repeatable way to trigger and then analyze script memory-usage snapshots when investigating memory-related stability issues, now with a targeted option for the four heaviest/longest-running AI scripts rather than only the shard-wide dumps.

---

## 8. Command Fix - .ph Now Reports Personal Powerhour Status

### Files Changed

| File | Change |
|---|---|
| `pkg/opt/powerhour/textcmd/player/ph.src` | Rewritten - adds personal-powerhour reporting; server-wide reporting unchanged in substance |

### Overview

`.ph` previously only reported server-wide powerhour status (active type, or countdown to the next chance at one); it had no visibility into a player's own personal powerhour (`.setph`), even though `.setph` itself already reported remaining time when a personal PH was active. Ported from the equivalent fix already shipped on ZH3.0. `checkPH()` now also reads the same `pph_use_time`/`pph_use_weekday`/`#PPHH`/`#PPHC`/`#PPHS` obj-properties `setph.src` uses, and mirrors `setph.src`'s eligibility check (`weekday_now < use_weekday || time_now > use_time_nextweek`) to report either the active personal PH's remaining time or the countdown until the player is next eligible to start one via `.setph`.

### Notable Functional Changes

- Adds `use math;` for `Floor()`, used in the weekday/reset-time math (previously only `use uo;`).
- New personal-status block, printed before the (retained) server-wide block: if any of `#PPHH`/`#PPHC`/`#PPHS` is set, reports which personal PH is active and its remaining minutes (same `(use_time + hour - time_now) / minute` calculation `setph.src` uses). Otherwise, reports the player has no personal PH active, then either "you can start one now" or a days/hours/minutes countdown to the next eligible day, computed by finding the next weekday-0 (Sunday) boundary on/after `use_time` - the same reset point implied by `setph.src`'s eligibility check.
- Server-wide messages reworded for clarity now that personal-PH messages exist alongside them ("Hunting powerhour is currently active!" -> "A server-wide Hunting powerhour is currently active!", and adds an explicit "No server-wide powerhour is currently active." message in the else branch instead of only printing the countdown).
- `POLCORE().systime` is now read once into `time_now` up front and reused for both the personal and server-wide countdown math, instead of being read a second time (as `curTime`) partway through the program.

### Expected Impact

Player-facing: `.ph` now tells you your own personal powerhour's remaining time (if active) or when you're next eligible to start one via `.setph`, in addition to the server-wide status it already reported. No change to `.setph` itself or to how either type of powerhour is granted/expires.

---

## 9. New Developer Tool - .resetph Command

### Files Changed

| File | Change |
|---|---|
| `pkg/opt/powerhour/textcmd/test/resetph.src` | New - `.resetph` |
| `config/command_synopses.cfg` | New `resetph` entry (Developer, CmdLevel 5), regenerated via `pythonscripts/_gen_command_synopses_cfg.py` |

### Overview

Investigating the report that prompted section 8 surfaced a related stuck-state bug: `setph.src` sets the obj-property `#SettingPH` to `1` while a personal powerhour gump is open, and only clears it once `activateph()` finishes its full one-hour `Sleep(3600)` and reaches its cleanup at the end of that function (or on the player's next logon/reconnect, both of which already erase it). If that backgrounded script instance dies before then - a server restart while a player's personal PH is active being the most likely case - `#SettingPH` is orphaned at `1` indefinitely, and every subsequent `.setph` hits the "You have the gump window open already!" branch with no way out for the player. `.resetph`, a targeted staff command, was ported from the equivalent tool already shipped on ZH3.0 (`pkg/opt/powerhour/textcmd/test/resetph.src` there) to give staff a way to clear a player out of this state on request.

### Notable Functional Changes

- `.resetph` (Developer, CmdLevel 5): targets a mobile, erases `pph_use_time`, `pph_use_weekday`, `#PPHH`, `#PPHC`, `#PPHS`, and `#SettingPH` from it, and reports the reset to the caller. Refuses to run on NPCs.
- Placed under `pkg/opt/powerhour/textcmd/test/`, matching the level/folder ZH3.0's own `resetph.src` uses there (Developer-level, `textcmd/test/`).
- Adapted from the ZH3.0 source rather than copied verbatim: adds the `#SettingPH` erase (not present on ZH3.0, whose `setph.src` doesn't use that property at all - see below), drops `SetObjProperty(mobile, "usedpph", 0)` (a ZH3.0-only property this repo's powerhour system never reads or writes), and uses this repo's `mobile.isa(POLCLASS_NPC)` NPC-check idiom instead of ZH3.0's `mobile == POLCLASS_NPC` object/constant equality comparison.

### Expected Impact

Staff-facing only. Gives Developer-level staff a one-command fix for a player stuck unable to `.setph` after a personal powerhour's backing script is lost (server restart mid-PH being the main trigger), instead of requiring a manual obj-property edit. No change to normal `.setph`/`.ph` behavior.

---

## 10. New Item - Eon-Prism (Artifact System)

### Files Changed

| File | Change |
|---|---|
| `pkg/opt/ArtifactSystem/eonprism.src` | New (`9c354ed`) - `eonprism` double-click handler; extended (`43261fe`) with an eligibility guard |
| `pkg/opt/ArtifactSystem/itemdesc.cfg` | New (`9c354ed`) - `item 0x792F` (`eonprism`); graphic/color changed (`88720ac`) |
| `pkg/opt/ArtifactSystem/artifactbox.src` | Added `UOBJ_EON_PRISM` (`0x792F`) to the decay-on-pull objtype check alongside the champion relics/world gem (`43261fe`) |

### Overview

A player-facing self-service version of `.resetph` (section 9): an item that lets a player clear their own stuck/used-up personal-powerhour properties without needing staff. Built as an Artifact System item (`pkg/opt/ArtifactSystem/` - see `pkg/opt/ArtifactSystem/artifact-system-summary.txt`) rather than a plain consumable, matching `championrelic.src`/`worldgem.src`'s pattern: `CProp Artifact i1` means the item recycles back into the global artifact pool via `maindestroy.src` instead of being permanently deleted when "used up," so it can circulate through `.makeartifact`/`.openartifact`/artifactbox pulls like the system's other rare rewards. `43261fe` ("Quick Eon Fix"), landing the same day, added the missing eligibility guard and the artifact-box decay hook described below. `88720ac` ("Eon Prism Update"), also the same day, swapped the item's graphic and gave it a color.

### Notable Functional Changes

- `item 0x792F` ("Eon-Prism", internal name `eonprism`): objtype picked from the documented-unused `0x792F-0x798F` gap in `objtypes.txt`, immediately after the `sysbook` package's `0x7910-0x792E` block - no collisions with any other `itemdesc.cfg` in the repo. Graphic is `0x1f1c` ("magical crystal", per `config/tiles.cfg` - a colorable tile), with `color 1182` applied; the item originally shipped (`9c354ed`) using the stock UO "runed prism" tile (`0x2f57`), replaced by `88720ac` the same day.
- On use: refuses (with a sysmessage, releasing the item instead of consuming it) if the player has an active personal powerhour (`#PPHH`/`#PPHC`/`#PPHS`) - so the item can't silently cut a live personal powerhour short (the same hazard noted for `.resetph` in section 16's risk notes) - or if a server-wide powerhour is currently active (`GetGlobalProperty("PHH"/"PHC"/"PHS")`), so it can't be used to stack a fresh personal powerhour on top of/immediately after a global one - or if the player is already eligible to start a fresh personal powerhour right now (mirrors the `weekday_now < use_weekday || time_now > use_time_nextweek` eligibility check in `textcmd/player/setph.src`/`textcmd/player/ph.src`), so it can't be wasted resetting a cooldown that isn't actually blocking them. This eligibility guard (`use math;`, `PH_DAY`/`PH_WEEK` constants, and the check itself) was added by `43261fe`, the same day the item first shipped without it.
- Otherwise erases `pph_use_time`, `pph_use_weekday`, `#PPHH`, `#PPHC`, `#PPHS`, and `#SettingPH` (same property set `.resetph` clears), then `PrintTextAbove()`s a random line from a 5-entry flavor-text array via `.randomentry()` (public overhead text, like `scripts/textcmd/coun/sayabove.src` - not a sysmessage, so nearby players see it too) and plays `SFX_SPELL_RESURRECTION` (the same sound `Resurrect()`/`highpriest.src` use), then `ReleaseItem()`/`DestroyItem()`s itself - matching `championrelic.src`/`worldgem.src`'s exact release-then-destroy order, needed because `maindestroy.src` intercepts the destroy for `Artifact`-flagged items and reroutes them into the global pool rather than freeing them; skipping the explicit `ReleaseItem()` would leave the recycled item stuck reserved (undoubleclickable) once it lands back in the artifact box.
- Not yet added to the live artifact pool via `.makeartifact`/`.openartifact`, and not on any loot table/vendor - this patch only adds the item and its objtype; getting copies into circulation is a separate staff step.
- Decays like the other artifact-box pulls: `dblclick_artifactbox()` in `artifactbox.src` matches `UOBJ_EON_PRISM` (`0x792F`) in its objtype check (added by `43261fe` - the item shipped a few hours without this hook), so pulling one from the box sets `item.decayat` and `#ArtifactExpireAt` to `RELIC_DECAY_SECONDS` (1209600s / 2 weeks) out, and stamps a `RelicUID`. If it sits unused (not double-clicked) past that window, the engine's native `decayat` and/or the `artifact_daily_sweeper.src`/`artifact_startup_sweeper.src` sweep (`SweepExpiredArtifacts()` in `artifact.inc`) will `DestroyItem()` it, which `maindestroy.src` reroutes back into the artifact box (`toArtifactBox()`, which also clears the expiry/`RelicUID` so it decays fresh on its next pull) rather than deleting it outright - same lifecycle as `championrelic.src`/`worldgem.src`.

### Expected Impact

Player-facing: gives players a way to self-recover from a stuck personal-powerhour state (or reset their weekly eligibility) without staff intervention, once copies exist in the artifact pool. No effect until staff adds it via `.makeartifact`/`.openartifact`.

---

## 11. Housing Sign - Owner Name Resolved Live Instead of Cached

### Files Changed

| File | Change |
|---|---|
| `pkg/std/housing/sign.src` | `textcmd_sign()` - resolves the house owner's current name via `SystemFindObjectBySerial()` instead of only reading the cached `lastownername` obj-property |

### Overview

The house sign gump shows the owner's name in slot `data[6]`. When the person opening the sign *is* the owner, it reads `who.name` live and refreshes the `lastownername` cache. When someone else opens it, it previously always read the cached `lastownername` property - which is only ever refreshed by that first branch, i.e. only when the owner personally opens their own sign. If the owner's name changes in the meantime (e.g. a town citizenship name change) and the owner doesn't reopen their own sign, every other player sees the stale cached name indefinitely.

### Notable Functional Changes

- Non-owner sign views now first try `SystemFindObjectBySerial(CInt(oserial), SYSFIND_SEARCH_OFFLINE_MOBILES)` to resolve the actual owner mobile (online or offline) and read `.name` from it live, updating `lastownername` at the same time.
- Falls back to the existing cached `lastownername` only if that lookup fails (e.g. the owner character has been deleted) - same behavior as before in that specific case.

### Expected Impact

Player-facing: a house sign now shows its owner's current name to any viewer, not just to the owner. Fixes signs showing an out-of-date name after an owner's name changes, without waiting for the owner to open their own sign first.

---

## 12. Performance and Cleanup - Area-Policy Cache Simplified; NPC AI Setup Scripts Decoupled From the Spawnpoint Package

### Files Changed

| File | Change |
|---|---|
| `pkg/opt/areas/include/areapolicy.inc` | Removes the per-program in-RAM cache layer from `GetParsedRealmAreaLines()`/`InvalidateParsedAreaLinesCache()`/`GetCachedRealmMaskDict()`/`StoreCachedPolicyMask()`/`InvalidatePolicyMaskCache()`, keeping only the shared `GlobalProperty` cache |
| `scripts/ai/setup/dressCustom.inc` | New - `DressNPCCustom()`, extracted verbatim from `pkg/opt/spawnpoint/include/customnpc.inc` |
| `scripts/ai/setup/animalsetup.inc` | Swaps `include ":spawnpoint:customnpc"` (commented out, left in place) for `include "ai/setup/dressCustom"` |
| `scripts/ai/setup/archersetup.inc` | Same swap as above |
| `scripts/ai/setup/criersetup.inc` | Same swap as above |
| `scripts/ai/setup/sheepsetup.inc` | Same swap as above |
| `scripts/ai/setup/spellsetup.inc` | Same swap as above |
| `scripts/ai/setup/killpcssetup.inc` | Same swap, plus adds `use util;` and `include "include/randname"` |
| `pkg/opt/shrink/Use_Shrink.src` | Same swap as above |

### Overview

Two changes bundled into one commit, both aimed at the memory footprint of long-lived NPC AI scripts (the same theme `.memdump`, section 7, was built to investigate). First: `GetParsedRealmAreaLines()`/`GetCachedRealmMaskDict()` previously cached parsed area-policy lines and masks in *two* layers - a per-program (per running script instance) in-RAM dictionary, plus a shared `GlobalProperty`. With potentially hundreds of concurrent NPC AI scripts each calling into area-policy checks on their own AI tick, each one held its own full copy of the parsed-lines/mask dictionary for the lifetime of that script instance; the shared `GlobalProperty` layer alone already avoids the expensive cold-parse cost for every caller, so the per-program layer was pure duplicated memory with no remaining performance benefit. Second: six NPC AI setup include files (`animalsetup.inc`, `archersetup.inc`, `criersetup.inc`, `killpcssetup.inc`, `sheepsetup.inc`, `spellsetup.inc`) plus `Use_Shrink.src` were only including the `spawnpoint` package's `customnpc.inc` (which also pulls in `include/attributes`, `include/client`, `include/constants/gumpids`, and `:gumps:old-gumps`) to reach one shared function, `DressNPCCustom()`. That function is extracted verbatim into a new, dependency-free `scripts/ai/setup/dressCustom.inc`, and all seven call sites now include that instead - the old `:spawnpoint:customnpc` include is commented out (not deleted) at each site rather than removed outright.

### Notable Functional Changes

- `areapolicy.inc`: `_parsed_area_lines_cache` and `_policy_mask_cache` (both per-program `dictionary` variables) are removed entirely. `GetParsedRealmAreaLines()` now always reads through to the `GlobalProperty` cache (still fingerprinted against the config's current line count, still invalidated by `InvalidateParsedAreaLinesCache()`/config edits) instead of checking a local dictionary first. `GetCachedRealmMaskDict()`/`StoreCachedPolicyMask()`/`InvalidatePolicyMaskCache()` lose their equivalent per-program dictionary reads/writes the same way. Behavior is unchanged from the caller's perspective - same fingerprint-invalidation rules - just one fewer cache layer, and every call now pays one `GetGlobalProperty()` read instead of a free dictionary hit on a warm per-program cache.
- `dressCustom.inc`'s `DressNPCCustom(me)` is byte-identical to the function of the same name still present (unremoved) in `pkg/opt/spawnpoint/include/customnpc.inc` - reads the NPC's `SpawnPoint` obj-property, finds that spawnpoint object, and for each item stored on it creates a copy (via `CreateItemCopyAtLocation`) that's either equipped on the NPC or moved into its backpack (if flagged `packitem`).
- `killpcssetup.inc` additionally gains `include "include/randname"` (the file calls `RandomName()`/`randomname()` at lines 69/72 for random NPC naming) and `use util;` (no `util`-module call is exercised in this file's own body in this range - added alongside the dependency cleanup, not yet put to use here).

### Expected Impact

No player-visible change intended. Reduces per-script memory usage for every running NPC AI script that touches area-policy checks (replacing a per-instance dictionary with a single shared property-store read) and narrows seven NPC setup scripts' dependency footprint from the entire `spawnpoint` package down to one shared function. Worth confirming in-game that newly spawned animals/archers/criers/sheep/spellcasters/killpcs NPCs (and shrunk-then-respawned NPCs via `.shrink`) still dress correctly from their spawnpoint's stored custom-NPC items, since this is the first time `DressNPCCustom()` has been called from a copy of itself rather than the original `spawnpoint` package function.

---

## 13. Stability - NPC Corpse Decay No Longer Risks Erroring on an Already-Despawned Corpse

### Files Changed

| File | Change |
|---|---|
| `scripts/control/corpsedecay.src` | `corpse_decay()`, `ProcessNpcCorpseDecaying()` - existence checks changed from truthiness on a stale object reference to `SystemFindObjectBySerial(corpse.serial)` |

### Overview

Two same-day commits on the same fix. `ProcessNpcCorpseDecaying()` previously did one flat `Sleep(Cint(DECAY_TIME_NPC_CORPSE*60))` (30 minutes) and then unconditionally `DestroyItem(corpse)` - if the corpse had already been removed in the meantime (the added comment in the second commit calls out `restartspawnpointarea` despawning it as the likely case), this called `DestroyItem()` on a corpse that no longer exists. `e3980f7` ("Corpse Decay Fix") first attempt: replaced the flat sleep with a loop that checks `if(!corpse) return;` every 30 seconds instead. That check doesn't actually do what it looks like it does - `corpse` is a local object-reference variable, and in this engine a stale reference to an already-destroyed object still reads as truthy, so the check never actually caught the despawned-corpse case it was written for; it also left the top-level `corpse_decay()` dispatcher's own initial `Sleep(5)` unguarded, and still ended with the same unconditional-looking `if(corpse) DestroyItem(corpse)` pattern. `5aa5f81` ("corpsedecay fix"), the same day, replaces every one of those truthiness checks with `SystemFindObjectBySerial(corpse.serial)` - an actual existence lookup - and adds the same check to `corpse_decay()` itself, right after its initial `Sleep(5)`, before it even decides whether to run the NPC or human decay path.

### Notable Functional Changes

- `corpse_decay(corpse)`: after `Sleep(5)`, now returns immediately if `SystemFindObjectBySerial(corpse.serial)` finds nothing, before dispatching to `ProcessNpcCorpseDecaying()`/`ProcessHumanCorpseDecaying()`.
- `ProcessNpcCorpseDecaying(corpse)`: rewritten to sleep in `CORPSE_CHECK_INTERVAL` (30s) chunks via a `time_left` countdown, checking `SystemFindObjectBySerial(corpse.serial)` at the top of every chunk and returning early if it's gone; the last chunk is capped to whatever's left of `time_left` (`this_sleep`) so total elapsed time lands exactly on `DECAY_TIME_NPC_CORPSE*60` instead of potentially overshooting by up to 29 seconds, as the first version's fixed-increment loop could. The final `DestroyItem(corpse)` is now also gated on the same serial lookup.
- `ProcessHumanCorpseDecaying()` (player corpses) is untouched by either commit - it already used `GetObjProperty(corpse, "NoDecay")` checks rather than a `corpse`-truthiness check, so wasn't affected by this bug.

### Expected Impact

No player-visible change intended - player corpse decay is unaffected. NPC corpse decay should no longer log an error (or otherwise misbehave) when the corpse it's tracking was already destroyed by something else (a spawnpoint area restart being the identified case) before its 30-minute timer elapsed.

---

## 14. Bug Fix - Bandage Healing on a Patient Who Dies Mid-Treatment (Life Crystal Interaction)

### Files Changed

| File | Change |
|---|---|
| `pkg/std/healing/healing.src` | `TryToHeal()`, `TryToCure()` - `return` immediately if the patient died during the bandage delay, instead of falling through |
| `scripts/misc/chrdeath.src` | All three corpse-item-recovery blocks (`pvpdeath`, `bmdeath`, `freedeath` branches) - clearer sysmessage when the resurrected character's backpack can't hold everything pulled off their corpse |

### Overview

Player report: a character protected by a Dundee Life Crystal (`pkg/std/dundee/lifecrystal.src`, which sets the `#freedeath` obj-property so the next death is auto-pardoned) who was being bandage-healed at the time they died would sometimes not end up properly resurrected. Both `TryToHeal()` and `TryToCure()` in `healing.src` check `patient.dead` after their multi-second bandage delay (`Sleep(delay)`) and, if true, sent "Your patient is dead." - but neither function actually `return`ed after that message, so execution fell through into `CheckSkill()`/`HealDamage()`/`CurePoison()` against the now-dead patient regardless. `DELAY_TO_HEAL` is a fixed 5 seconds; the Life Crystal's own auto-resurrect in `chrdeath.src`'s `freedeath` branch fires only ~2 seconds after death and, in that window, runs `ResurrectMobile()`, resets HP/mana/stamina, sets the character hidden, and moves every item off the corpse back into the character's backpack. A bandage-heal in progress on a Life-Crystal-protected character who dies mid-treatment lands its post-`Sleep()` code squarely inside or right after that auto-resurrect sequence, and - lacking the `return` - kept writing to the same mobile (`HealDamage`/`CheckSkill`) concurrently with it. Separately, the same corpse-item-recovery loop (used by all three `chrdeath.src` death branches, not just `freedeath`) only retries a failed `MoveItemToContainer()` once before giving up and leaving that item on the corpse with a "please page staff" sysmessage - which happens whenever the resurrected character's backpack doesn't have room for everything recovered (e.g. it was already close to full at the time of death), not because of anything staff need to intervene on.

### Notable Functional Changes

- `healing.src` `TryToCure()`: adds `return;` immediately after the `SendSysMessage(character, "Your patient is dead.")` line, before the `CheckSkill()`/`CurePoison()` call that previously still ran.
- `healing.src` `TryToHeal()`: same fix - adds `return;` after the equivalent "Your patient is dead." message, before the `diff`/`CheckSkill()`/`HealDamage()` block that previously still ran (and previously could apply healing/skillgain against a dead or already-resurrected mobile).
- `chrdeath.src`: the sysmessage shown when a leftover corpse item can't be moved to the character's backpack (all three occurrences, identical string, in the `pvpdeath`, `bmdeath`, and `freedeath` branches) changes from `"There are still items left on your corpse - please page staff."` to `"Your backpack is too full to hold everything - some items are still on your corpse. They won't be lost; loot them now or they'll drop to the ground when the corpse decays."` - no logic change, message only. Confirmed against `scripts/control/corpsedecay.src`'s `ProcessHumanCorpseDecaying()`: any item still on a player corpse at decay time is moved to the ground (`MoveObjectToLocation(..., MOVEOBJECT_FORCELOCATION)`) before the empty corpse is destroyed, so a leftover item was never actually lost - just confusingly reported.

### Expected Impact

Player-facing: bandaging someone who dies mid-treatment (most visibly, someone protected by a Life Crystal at the moment they'd otherwise die) no longer risks the bandage script continuing to act on them after death, which is the suspected cause of the reported "didn't get resurrected properly" symptom. A resurrected character whose backpack can't hold everything recovered from their corpse now gets an accurate explanation instead of a "page staff" message that doesn't apply to this case - nothing about what actually gets recovered, held back, or later dropped to the ground changes.

---

## 15. Exhaustive File-by-File Change List

| File | Section | Summary |
|---|---|---|
| `config/command_synopses.cfg` | 6, 7, 9 | Migration commands re-leveled; new `memdump` entry (later updated); new `resetph` entry |
| `config/fileaccess.cfg` | 5 | `AllowRemote 1` added for housing/playervendor `.log` |
| `config/npcdesc.cfg` | 3 | `MagicResistance 100` added to mage/alchemist/scribe |
| `pkg/items/armor/include/armorZones.inc` | 4 | Nil-guards for zone/item config lookups |
| `pkg/opt/alryc/textcmd/test/memdump.src` | 7 | New - `.memdump`; extended with `internal(6)` killpcs dump |
| `pkg/opt/areas/include/areapolicy.inc` | 12 | Per-program cache layer removed; shared `GlobalProperty` cache only |
| `pkg/opt/ArtifactSystem/artifactbox.src` | 10 | `UOBJ_EON_PRISM` added to the decay-on-pull objtype check |
| `pkg/opt/ArtifactSystem/eonprism.src` | 10 | New - `eonprism` double-click handler; eligibility guard added |
| `pkg/opt/ArtifactSystem/itemdesc.cfg` | 10 | New - `item 0x792F` (`eonprism`); graphic/color updated |
| `pkg/opt/classfirsts/pkg.cfg` | 6 | Comment path update |
| `pkg/opt/powerhour/textcmd/player/ph.src` | 8 | Adds personal-powerhour status reporting |
| `pkg/opt/powerhour/textcmd/test/resetph.src` | 9 | New - `.resetph` |
| `pkg/opt/powerscrolls/textcmd/player/showcaps.src` | 4 | Nil-guard for empty `classe` |
| `pkg/opt/shrink/Use_Shrink.src` | 12 | Swapped `:spawnpoint:customnpc` include for `ai/setup/dressCustom` |
| `pkg/opt/spawnpoint/checkpoint.src` | 4 | `error`-value guard for spawned-objects property |
| `pkg/opt/vanityshop/mountstone.src` | 4 | `error`-value/nil guards, owner/mount lookups |
| `pkg/opt/versebook/Bardic_Boulders.src` | 4 | Nil-guard for `CreateItemAtLocation()` result |
| `pkg/std/boat/boat.src` | 4 | Realm-unset guard in `DoEncounter()` |
| `pkg/std/boat/plankutil.inc` | 4 | Realm-unset guard in `IsPlankOccupied()` |
| `pkg/std/boat/plankwalk.src` | 4 | Explicit realm args to movement/lookup calls |
| `pkg/std/healing/healing.src` | 14 | `TryToHeal()`/`TryToCure()` now `return` when the patient died mid-treatment |
| `pkg/std/housing/houseescrow.inc` | 6 | Debug `Print()` calls removed |
| `pkg/std/housing/sign.src` | 6, 11 | Debug `Print()` call removed; owner name now resolved live for non-owner viewers |
| `pkg/std/traps/traps.src` | 4 | `"Spawnpoint"` trapcrafter guard |
| `pythonscripts/Analyze-MemoryUsage.ps1` | 7 | New - standalone log analyzer (PowerShell) |
| `pythonscripts/analyze_memory_usage.py` | 7 | New - standalone log analyzer (Python) |
| `scripts/ai/chaosmultikillpcs.src` | 4 | Explicit realm arg on two `MoveObjectToLocation()` calls |
| `scripts/ai/setup/animalsetup.inc` | 12 | Swapped `:spawnpoint:customnpc` include for `ai/setup/dressCustom` |
| `scripts/ai/setup/archersetup.inc` | 12 | Same swap |
| `scripts/ai/setup/criersetup.inc` | 12 | Same swap |
| `scripts/ai/setup/dressCustom.inc` | 12 | New - `DressNPCCustom()`, extracted from the spawnpoint package |
| `scripts/ai/setup/killpcssetup.inc` | 12 | Same swap, plus `use util;`/`include "include/randname"` |
| `scripts/ai/setup/sheepsetup.inc` | 12 | Same swap |
| `scripts/ai/setup/spellsetup.inc` | 12 | Same swap |
| `scripts/control/corpsedecay.src` | 13 | NPC corpse existence checked via `SystemFindObjectBySerial()` instead of stale-reference truthiness |
| `scripts/control/firecontrol.src` | 4 | Realm-unset guard in damage-tick loop |
| `scripts/misc/chrdeath.src` | 14 | Clearer full-backpack sysmessage on resurrection (all three death branches) |
| `scripts/misc/death.src` | 4 | `error`-value/nil guards for master/killer lookups |
| `scripts/textcmd/player/houseescrow.src` | 6 | Debug `Print()` calls removed |
| `scripts/textcmd/test/backfillteleporterserials.src` | 6 | Moved from `admin/`, re-leveled |
| `scripts/textcmd/test/migrateclassfirsts.src` | 6 | Moved from `admin/`, re-leveled |
| `patchnotes/developer-changelog-v1.1.2.md` | - | This file |
| `patchnotes/patch-v1.1.2.md` | - | Player-facing notes |
| `patchnotes/launchernotes.md` | - | Replaced with this release's player-facing content |

---

## 16. Risk and Regression Notes

- **Bandage-heal dead-patient `return` (section 14):** low-risk, additive guard - the only behavior removed is the (already-broken) fall-through that tried to heal/skill-check a dead patient. Worth confirming in-game that a bandage-heal targeting someone who dies mid-treatment now cleanly stops instead of throwing a "your patient is dead" message and then silently no-opping into `CheckSkill`, and that a Life-Crystal-protected character being bandaged at the moment of death now reliably ends up alive, visible-state-consistent, and back in control after the crystal's auto-resurrect completes - the exact race this fix targets was inferred from reading both scripts together, not reproduced against a live server.
- **Full-backpack corpse message (section 14):** message-only change, no logic touched. The underlying "one retry, then give up and leave it on the corpse" behavior for a `MoveItemToContainer()` failure is unchanged - still worth a follow-up look at whether that recovery loop should retry harder or check capacity up front, independent of this message fix.
- **Area-policy cache simplification (section 12):** removing the per-program dictionary layer trades a small amount of per-call latency (one `GetGlobalProperty()` read instead of a warm in-memory dictionary hit) for lower per-script memory use; should be behaviorally invisible, but worth a load-check on shards with very high concurrent NPC counts if `sysload` from area-policy checks was ever meaningfully above baseline.
- **NPC setup script decoupling from `spawnpoint` (section 12):** the old `:spawnpoint:customnpc` includes were commented out, not deleted, at all seven call sites, so reverting is a one-line change per file if `dressCustom.inc`'s extracted copy of `DressNPCCustom()` ever drifts from the original. Confirm in-game that animals/archers/criers/sheep/spellcasters/killpcs NPCs with a `customnpc` spawnpoint, and NPCs spawned via `.shrink`, still dress correctly.
- **NPC corpse decay existence checks (section 13):** behavioral fix, not just cleanup - `ProcessNpcCorpseDecaying()`'s decay timing (30 minutes, checked in 30-second chunks) is otherwise unchanged; only the "is the corpse still there" check is now accurate. Player corpse decay (`ProcessHumanCorpseDecaying()`) was not touched by either commit in this range.
- **Eon-Prism (section 10):** guarded against use during an active personal powerhour, but otherwise unconditional and irreversible like `.resetph` - a player who uses it while ineligible anyway (e.g. just to reset the weekly countdown) gets no confirmation prompt. As an `Artifact`-flagged item it recycles into the global artifact pool on "destroy" rather than being deleted, so the `ReleaseItem()` call before `DestroyItem()` is load-bearing - worth confirming in-game that a used prism actually turns up recoverable in the artifact box rather than stuck reserved, before relying on it in production. Not yet added to the live pool via `.makeartifact`, so has zero live impact until staff does that. The graphic/color swap (`88720ac`) is cosmetic only.
- **`.resetph` (section 9):** unconditionally erases the targeted player's `pph_use_time`/`pph_use_weekday`/`#PPHH`/`#PPHC`/`#PPHS`/`#SettingPH` - if used on a player with a legitimately active personal powerhour rather than a stuck one, it ends that powerhour early without the normal "has ended" sysmessage `activateph()` sends. GM-level tool, used on request; no automatic trigger.
- **`.ph` personal-powerhour reporting (section 8):** read-only reporting change - it does not touch how personal or server-wide powerhours are granted, tracked, or expired (still entirely owned by `setph.src`/`activateph()`). Worth spot-checking the eligibility-countdown branch against a live `#PPHH`/`#PPHC`/`#PPHS` obj-property state once, since the reset-time math (next Sunday on/after `use_time`) is inferred from `setph.src`'s existing condition rather than a separate stored "next eligible" timestamp.
- **Magic Resistance vendor training (section 3):** only affects vendors spawned/re-templated after this patch deploys - existing live Mage/Alchemist/Scribe vendors keep their current base skills until they respawn or the server reloads and re-applies `npcdesc.cfg`.
- **`plankwalk.src` explicit realm arguments (section 4):** previously-implicit realm defaults are now explicit `who.realm`/`plank.realm` - should be behaviorally identical for any plank/player pair that was already on the same realm (the normal case), but worth watching for cross-realm boat/plank edge cases specifically, since that's the scenario this class of fix targets.
- **House-escrow log de-duplication (section 6):** console `Print()` output for house-escrow operations is gone; `::log/houseescrow.log` and `::log/merchantescrow.log` (via `HouseEscrowLog()`/`MerchantEscrowLog()`) are now the only record, and depend on the `AllowRemote 1` fix in section 5 actually being in effect - confirm those log files are being written to post-deploy before relying on them for any incident investigation.
- **`.memdump` (section 7):** triggers engine-internal diagnostic dumps on demand; no rate-limiting or size cap on the resulting `memoryusagescripts.log`/per-script dump files is implemented in this patch - fine for occasional developer use, worth keeping in mind if it's ever scripted/automated.
